### PR TITLE
Adding support for subnet_id in AWS script & config

### DIFF
--- a/aws/AwsDockerOMLRun.py
+++ b/aws/AwsDockerOMLRun.py
@@ -24,6 +24,10 @@ class AwsDockerOMLRun:
 
         self.setup = config["setup"]
         self.token = config["token"]
+        if config["subnet_id"] == "":
+          self.subnet_id = None
+        else:
+          self.subnet_id = config["subnet_id"]
 
         if region_name is None:
             if "region_name" in config.keys() and len(config["region_name"]) > 0:
@@ -31,6 +35,7 @@ class AwsDockerOMLRun:
             else:
                 self.region_name = boto3.session.Session().region_name
         self.ec2_resource = boto3.resource("ec2", region_name=region_name)
+
 
         with open("resources/ami.json") as file:
                 amis = json.load(file)
@@ -55,6 +60,7 @@ class AwsDockerOMLRun:
             MinCount=1,
             MaxCount=1,
             InstanceType=self.aws_instance_type,
+            SubnetId=self.subnet_id,
             UserData=setup)[0]
 
     def terminateInstance(self):

--- a/config.json
+++ b/config.json
@@ -4,5 +4,6 @@
   "overhead_time":600,
   "query_frequency":10,
   "max_parallel_jobs":5,
-  "region_name":"eu-west-1"
+  "region_name":"us-east-1",
+  "subnet_id":""
 }


### PR DESCRIPTION
If you want to use a VPC/subnet, then you can now specify the subnet id in the config file.  Defaults to None / no subset.