### PR TITLE
updated scipy version constrant in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ numpy>=1.15,<2.0
 pandas>=0.23,<1.0
 psutil>=5.4,<6.0
 ruamel.yaml>=0.15,<1.0
-scipy>=1.1,<2.0
+scipy>=1.1,<1.3
 scikit-learn>=0.19,<0.20
 openml==0.7.0


### PR DESCRIPTION
Updated constraint to avoid error with arff library. Scipy 1.3 was not using the liac-arff library as required by the code.