### PR TITLE
Improvement: remove relative paths to resource files

### DIFF
--- a/automl/resources.py
+++ b/automl/resources.py
@@ -37,7 +37,8 @@ class Resources:
         self._common_dirs = dict(
             input=normalize_path(config.input_dir),
             output=normalize_path(config.output_dir),
-            user=normalize_path(config.user_dir)
+            user=normalize_path(config.user_dir),
+            root=normalize_path(config.root_dir),
         )
         self.config = Resources._normalize(config, replace=self._common_dirs)
         log.debug("Using config:\n%s", self.config)

--- a/examples/custom/config.yaml
+++ b/examples/custom/config.yaml
@@ -5,13 +5,13 @@ project_repository: https://github.com/openml/automlbenchmark
 
 frameworks:
   definition_file:
-    - resources/frameworks.yaml
+    - '{root}/resources/frameworks.yaml'
     - '{user}/frameworks.yaml'
 
 benchmarks:
   definition_dir:
     - '{user}'
-    - resources/benchmarks
+    - '{root}/resources/benchmarks'
   defaults:
     cores: 2
 

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -8,6 +8,7 @@ user_dir: ~/.config/automlbenchmark   # where to override settings with a custom
 input_dir: ~/.openml/cache            # where the datasets are loaded by default.
 output_dir: results                   # where logs and results are saved by default.
 
+root_dir:   # app root dir: set by caller (runbenchamrk.py)
 script:     # calling script: set by caller (runbenchmark.py)
 run_mode:   # target run mode (local, docker, aws): set by caller (runbenchmark.py)
 sid:        # session id: set by caller (runbenchmark.py)
@@ -23,11 +24,11 @@ seed: auto  # default global seed (used if not set in task definition), can be o
             # any int32 to pass a fixed seed to the jobs.
 
 frameworks:
-  definition_file: resources/frameworks.yaml
+  definition_file: '{root}/resources/frameworks.yaml'
   root_module: frameworks
 
 benchmarks:
-  definition_dir: resources/benchmarks
+  definition_dir: '{root}/resources/benchmarks'
   os_mem_size_mb: 2048        # the default amount of memory left to the OS when task assigned memory is computed automatically.
   os_vol_size_mb: 2048        # the default amount of volume left to the OS when task volume memory is verified.
   overhead_time_seconds: 3600   # amount of additional time allowed for the job to complete before sending an interruption signal

--- a/runbenchmark.py
+++ b/runbenchmark.py
@@ -53,6 +53,7 @@ parser.add_argument('-X', '--extra', default=[], action='append', help=argparse.
 # parser.add_argument('-r', '--region', metavar='aws_region', default=None,
 #                     help="The region on which to run the benchmark when using AWS.")
 
+root_dir = os.path.dirname(__file__)
 args = parser.parse_args()
 script_name = os.path.splitext(os.path.basename(__file__))[0]
 extras = {t[0]: t[1] if len(t) > 1 else True for t in [x.split('=', 1) for x in args.extra]}
@@ -74,7 +75,7 @@ automl.logger.setup(log_file=os.path.join(log_dir, '{script}_{now}.log'.format(s
 log.info("Running `%s` on `%s` benchmarks in `%s` mode.", args.framework, args.benchmark, args.mode)
 log.debug("Script args: %s.", args)
 
-config = config_load("resources/config.yaml")
+config = config_load(os.path.join(root_dir, "resources", "config.yaml"))
 # allowing config override from user_dir: useful to define custom benchmarks and frameworks for example.
 config_user = config_load(os.path.join(args.userdir if args.userdir is not None else config.user_dir, "config.yaml"))
 # config listing properties set by command line
@@ -83,8 +84,9 @@ config_args = ns.parse(
     input_dir=args.indir,
     output_dir=args.outdir,
     user_dir=args.userdir,
-    run_mode=args.mode,
+    root_dir=root_dir,
     script=os.path.basename(__file__),
+    run_mode=args.mode,
     sid=sid,
 ) + ns.parse(extras)
 if args.mode != 'local':


### PR DESCRIPTION
### Rationale
Removing relative paths in the `config.yaml` makes default paths behave similarly to custom `{user}` paths.
Main benefit is that the `runbenchmark.py` script can be now executed from anywhere (not required to have `cwd` in the main app folder.