### PR TITLE
Test benchmark on AWS: removing hardcoded ec2_instance_type

### DIFF
--- a/resources/benchmarks/test.yaml
+++ b/resources/benchmarks/test.yaml
@@ -29,7 +29,6 @@
   folds: 2
   cores: 2
   max_runtime_seconds: 60
-  ec2_instance_type: t3.small
 
 - name: iris
   openml_task_id: 59


### PR DESCRIPTION
test on AWS is using hardcoded ec2 T3 series (available only in VPC)