### PR TITLE
Fixing path issue when running on aws from subfolder

### DIFF
--- a/automl/aws.py
+++ b/automl/aws.py
@@ -523,11 +523,14 @@ class AWSBenchmark(Benchmark):
 
     def _upload_resources(self):
         def dest_path(res_path):
+            in_app_dir = res_path.startswith(rconfig().root_dir)
+            if in_app_dir:
+                return None
             in_input_dir = res_path.startswith(rconfig().input_dir)
             in_user_dir = res_path.startswith(rconfig().user_dir)
-            name = os.path.relpath(res_path, start=rconfig().input_dir) if in_input_dir \
-                else os.path.relpath(res_path, start=rconfig().user_dir) if in_user_dir \
-                else os.path.basename(res_path)
+            name = (os.path.relpath(res_path, start=rconfig().input_dir) if in_input_dir
+                    else os.path.relpath(res_path, start=rconfig().user_dir) if in_user_dir
+                    else os.path.basename(res_path))
             return self._s3_input(name) if in_input_dir else self._s3_user(name)
 
         upload_paths = [self.benchmark_path] + rconfig().aws.resource_files
@@ -536,6 +539,9 @@ class AWSBenchmark(Benchmark):
         uploaded_resources = []
         for res in upload_files:
             upload_path = dest_path(res)
+            if upload_path is None:
+                log.debug("Skipping upload of `%s` to s3 bucket.", res)
+                continue
             log.info("Uploading `%s` to `%s` on s3 bucket %s.", res, upload_path, self.bucket.name)
             self.bucket.upload_file(res, upload_path)
             uploaded_resources.append(upload_path)

--- a/automl/aws.py
+++ b/automl/aws.py
@@ -208,7 +208,7 @@ class AWSBenchmark(Benchmark):
                 instance_def,
                 script_params="{framework} {benchmark} {task_param} {folds_param} -Xseed={seed}".format(
                     framework=self.framework_name,
-                    benchmark="{}/{}.yaml".format(resources_root, self.benchmark_name),
+                    benchmark=self.benchmark_name if self.benchmark_path.startswith(rconfig().root_dir) else "{}/{}.yaml".format(resources_root, self.benchmark_name),
                     task_param='' if len(task_names) == 0 else ' '.join(['-t']+task_names),
                     folds_param='' if len(folds) == 0 else ' '.join(['-f']+folds),
                     seed=rget().seed(int(folds[0])) if len(folds) == 1 else rconfig().seed,

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -131,6 +131,7 @@ aws:
                         #  this folder being itself synchronized on each ec2 instance and used as user directory.
                         # The possibility of adding resource_files is especially necessary to run custom frameworks.
   resource_ignore:      # files ignored when listing `resource_files`, especially if those contain directories
+    - '*/lib/*'
     - '*/venv/*'
     - '*/__pycache__/*'
     - '*/.marker_*'

--- a/runbenchmark.py
+++ b/runbenchmark.py
@@ -59,8 +59,12 @@ script_name = os.path.splitext(os.path.basename(__file__))[0]
 extras = {t[0]: t[1] if len(t) > 1 else True for t in [x.split('=', 1) for x in args.extra]}
 
 now_str = datetime_iso(date_sep='', time_sep='')
-sid = args.session if args.session is not None \
-    else "{}_{}".format('_'.join([extras.get('run_mode', args.mode), args.framework, args.benchmark]).lower(), now_str)
+sid = (args.session if args.session is not None
+       else "{}_{}".format('_'.join([extras.get('run_mode', args.mode),
+                                     args.framework,
+                                     os.path.splitext(os.path.basename(args.benchmark))[0]])
+                              .lower(),
+                           now_str))
 log_dir = automl.resources.output_dirs(args.outdir or os.getcwd(),
                                        session=sid if args.outdir else None,
                                        subdirs='logs',


### PR DESCRIPTION
When running app from a different folder than the application root directory, the benchmark parameter is incorrect when running on AWS: this is annoying when extending the benchmark with private frameworks (which are usually placed outside the `automlbenchmark` app).

