### PR TITLE
Live display for some subprocesses when using `run_cmd`

### DIFF
--- a/automl/benchmark.py
+++ b/automl/benchmark.py
@@ -89,7 +89,7 @@ class Benchmark:
         log.info("Setting up framework {}.".format(self.framework_name))
         self.framework_module.setup(self.framework_def.setup_args)
         if self.framework_def.setup_cmd is not None:
-            run_cmd(self.framework_def.setup_cmd)
+            run_cmd(self.framework_def.setup_cmd, _live_output_=True)
         invalidate_caches()
         log.info("Setup of framework {} completed successfully.".format(self.framework_name))
 

--- a/automl/docker.py
+++ b/automl/docker.py
@@ -176,7 +176,7 @@ class DockerBenchmark(Benchmark):
             options="" if cache else "--no-cache",
             container=self._docker_image_name,
             script=self._docker_script
-        ))
+        ), _live_output_=True)
         log.info("Successfully built docker image %s.", self._docker_image_name)
 
     def _upload_docker_image(self):

--- a/automl/logger.py
+++ b/automl/logger.py
@@ -94,8 +94,9 @@ def setup(log_file=None, root_file=None, root_level=logging.WARNING, app_level=N
             buf = buffer[buf_type]
             if buf is None:
                 buf = buffer[buf_type] = io.StringIO()
-            buf.write(sep.join(map(str, [self, *args])))  # end added by logger
-            if end == nl:
+            line = sep.join(map(str, [self, *args]))
+            buf.write(line)  # "end" newline always added by logger
+            if end == nl or line.endswith(nl):  # flush buffer for every line
                 with buf:
                     level = logging.ERROR if buf_type == 'err' else logging.INFO
                     print_logger.log(level, buf.getvalue())

--- a/automl/logger.py
+++ b/automl/logger.py
@@ -85,16 +85,16 @@ def setup(log_file=None, root_file=None, root_level=logging.WARNING, app_level=N
 
         ori_print = builtins.print
 
-        def new_print(self, *args, sep=' ', end=nl, file=None):
+        def new_print(*args, sep=' ', end=nl, file=None):
             if file not in [None, sys.stdout, sys.stderr]:
-                return ori_print(self, *args, sep=sep, end=end, file=file)
+                return ori_print(*args, sep=sep, end=end, file=file)
 
             nonlocal buffer
             buf_type = 'err' if file is sys.stderr else 'out'
             buf = buffer[buf_type]
             if buf is None:
                 buf = buffer[buf_type] = io.StringIO()
-            line = sep.join(map(str, [self, *args]))
+            line = sep.join(map(str, [*args]))
             buf.write(line)  # "end" newline always added by logger
             if end == nl or line.endswith(nl):  # flush buffer for every line
                 with buf:

--- a/automl/utils.py
+++ b/automl/utils.py
@@ -672,7 +672,8 @@ def run_cmd(cmd, *args, **kwargs):
                 print(re.sub(r'\n$', '', line, count=1))
             elif mode == 'block':
                 print(line, end='')
-        print('\n')  # ensure that the log buffer is flushed at the end
+        print()  # ensure that the log buffer is flushed at the end
+        return None, ''.join(map(str, iter(process.stderr.readline, ''))) if process.stderr else None
 
     try:
         completed = run_subprocess(str_cmd if params.shell else full_cmd,

--- a/automl/utils.py
+++ b/automl/utils.py
@@ -18,6 +18,7 @@ import multiprocessing as mp
 import os
 import pprint
 import queue
+import re
 import shutil
 import signal
 import stat
@@ -587,6 +588,50 @@ class TmpDir:
         # pass
 
 
+""" PROCESS """
+
+
+def run_subprocess(*popenargs, input=None, timeout=None, check=False, communicate_fn=None, **kwargs):
+    """
+    a clone of :function:`subprocess.run` which allows custom handling of communication
+    :param popenargs:
+    :param input:
+    :param timeout:
+    :param check:
+    :param communicate_fn:
+    :param kwargs:
+    :return:
+    """
+    if input is not None:
+        if 'stdin' in kwargs:
+            raise ValueError('stdin and input arguments may not both be used.')
+        kwargs['stdin'] = subprocess.PIPE
+
+    def communicate(process, input=None, timeout=None):
+        if communicate_fn:
+            out, err = communicate_fn(process, input=input, timeout=timeout)
+            process.wait()  # safety, in case not done by communicate_fn
+            return out, err
+        else:
+            return process.communicate(input=input, timeout=timeout)
+
+    with subprocess.Popen(*popenargs, **kwargs) as process:
+        try:
+            stdout, stderr = communicate(process, input, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            stdout, stderr = communicate(process)
+            raise subprocess.TimeoutExpired(process.args, timeout, output=stdout, stderr=stderr)
+        except:
+            process.kill()
+            process.wait()
+            raise
+        retcode = process.poll()
+        if check and retcode:
+            raise subprocess.CalledProcessError(retcode, process.args, output=stdout, stderr=stderr)
+    return subprocess.CompletedProcess(process.args, retcode, stdout, stderr)
+
+
 def as_cmd_args(*args, **kwargs):
     return list(filter(None,
                        []
@@ -600,9 +645,11 @@ def run_cmd(cmd, *args, **kwargs):
         input_str=None,
         capture_output=True,
         capture_error=True,
+        live_output=False,  # one of (True, 'line', 'block', False)
         output_level=logging.DEBUG,
         error_level=logging.ERROR,
-        shell=True
+        shell=True,
+        timeout=None,
     )
     for k, v in params:
         kk = '_'+k+'_'
@@ -614,14 +661,29 @@ def run_cmd(cmd, *args, **kwargs):
     str_cmd = ' '.join(full_cmd)
     log.info("Running cmd `%s`", str_cmd)
     log.debug("Running cmd `%s` with input: %s", str_cmd, params.input_str)
+
+    def live_output(process, **ignored):
+        mode = params.live_output
+        if mode is True:
+            mode = 'line'
+
+        for line in iter(process.stdout.readline, ''):
+            if mode == 'line':
+                print(re.sub(r'\n$', '', line, count=1))
+            elif mode == 'block':
+                print(line, end='')
+        print('\n')  # ensure that the log buffer is flushed at the end
+
     try:
-        completed = subprocess.run(str_cmd if params.shell else full_cmd,
+        completed = run_subprocess(str_cmd if params.shell else full_cmd,
                                    input=params.input_str,
+                                   timeout=params.timeout,
+                                   check=True,
+                                   communicate_fn=live_output if params.live_output and params.capture_output else None,
                                    # stdin=subprocess.PIPE if input is not None else None,
                                    stdout=subprocess.PIPE if params.capture_output else None,
                                    stderr=subprocess.PIPE if params.capture_error else None,
                                    shell=params.shell,
-                                   check=True,
                                    universal_newlines=True)
         if completed.stdout:
             log.log(params.output_level, completed.stdout)
@@ -644,9 +706,6 @@ def call_script_in_same_dir(caller_file, script_file, *args, **kwargs):
     mod = os.stat(script).st_mode
     os.chmod(script, mod | stat.S_IEXEC)
     return run_cmd(script, *args, **kwargs)
-
-
-""" PROCESS """
 
 
 def get_thread(tid=None):

--- a/frameworks/AutoWEKA/exec.py
+++ b/frameworks/AutoWEKA/exec.py
@@ -62,7 +62,7 @@ def run(dataset: Dataset, config: TaskConfig):
     )
     cmd = cmd_root + ' '.join(["-{} {}".format(k, v) for k, v in cmd_params.items()])
     with Timer() as training:
-        run_cmd(cmd)
+        run_cmd(cmd, _live_output_=True)
 
     # if target values are not sorted alphabetically in the ARFF file, then class probabilities are returned in the original order
     # interestingly, other frameworks seem to always sort the target values first

--- a/frameworks/ranger/exec.py
+++ b/frameworks/ranger/exec.py
@@ -23,6 +23,6 @@ def run(dataset: Dataset, config: TaskConfig):
         test=dataset.test.path,
         output=config.output_predictions_file,
         cores=config.cores
-    ))
+    ), _live_output_=True)
 
     log.info("Predictions saved to %s", config.output_predictions_file)


### PR DESCRIPTION
adding live console display for long-running commands when using `run_cmd`.
The main utility is when building docker images as we're blind otherwise and can't see issues that may block docker.