### PR TITLE
Improve and standardize usage of virtual environments in the app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,11 +16,17 @@ results
 # editors/IDEs
 .idea
 *.iml
-*.swp
+**/*.swp
 **/*.ipynb
 
 # tmp files
 **/*.log
 **/*.csv
 **/*.arff
+
+# binary files
+**/*.zip
+**/*.tgz
+**/*.gz
+**/*.bz2
 **/*.png

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,12 @@ _site/
 *.log
 *.csv
 *.arff
+
+# binary files
+*.zip
+*.tgz
+*.gz
+*.bz2
 *.png
 
 #whitelist

--- a/amlb/aws.py
+++ b/amlb/aws.py
@@ -829,8 +829,8 @@ runcmd:
   - mkdir -p /s3bucket/input
   - mkdir -p /s3bucket/output
   - mkdir -p /s3bucket/user
-  - mkdir /repo
-  - cd /repo
+  - mkdir ~/repo
+  - cd ~/repo
   - git clone --depth 1 --single-branch --branch {branch} {repo} .
   - python3 -m venv venv
   - alias PIP='~/repo/venv/bin/pip3'

--- a/amlb/aws.py
+++ b/amlb/aws.py
@@ -829,13 +829,13 @@ runcmd:
   - mkdir -p /s3bucket/input
   - mkdir -p /s3bucket/output
   - mkdir -p /s3bucket/user
-  - mkdir ~/repo
-  - cd ~/repo
+  - mkdir /repo
+  - cd /repo
   - git clone --depth 1 --single-branch --branch {branch} {repo} .
   - python3 -m venv venv
-  - alias PIP='~/repo/venv/bin/pip3'
-  - alias PY='~/repo/venv/bin/python3 -W ignore'
-  - alias PIP_REQ='xargs -L 1 ~/repo/venv/bin/pip3 install --no-cache-dir'
+  - alias PIP='/repo/venv/bin/pip3'
+  - alias PY='/repo/venv/bin/python3 -W ignore'
+  - alias PIP_REQ='xargs -L 1 /repo/venv/bin/pip3 install --no-cache-dir'
 #  - PIP install -U pip=={pip_version}
   - PIP install -U pip
   - PIP_REQ < requirements.txt
@@ -899,13 +899,13 @@ pip3 install -U awscli
 mkdir -p /s3bucket/input
 mkdir -p /s3bucket/output
 mkdir -p /s3bucket/user
-mkdir ~/repo
-cd ~/repo
+mkdir /repo
+cd /repo
 git clone --depth 1 --single-branch --branch {branch} {repo} .
 
 python3 -m venv venv
-alias PIP='~/repo/venv/bin/pip3'
-alias PY='~/repo/venv/bin/python3 -W ignore'
+alias PIP='/repo/venv/bin/pip3'
+alias PY='/repo/venv/bin/python3 -W ignore'
 #PIP install -U pip=={pip_version}
 PIP install -U pip
 xargs -L 1 PIP install --no-cache-dir < requirements.txt

--- a/amlb/aws.py
+++ b/amlb/aws.py
@@ -826,17 +826,18 @@ runcmd:
   - systemctl disable apt-daily.service
   - systemctl daemon-reload
   - pip3 install -U awscli
-  - python3 -m venv /venvs/bench
-  - alias PIP='/venvs/bench/bin/pip3'
-  - alias PY='/venvs/bench/bin/python3 -W ignore'
-  - alias PIP_REQ='xargs -L 1 /venvs/bench/bin/pip3 install --no-cache-dir'
   - mkdir -p /s3bucket/input
   - mkdir -p /s3bucket/output
   - mkdir -p /s3bucket/user
   - mkdir /repo
   - cd /repo
   - git clone --depth 1 --single-branch --branch {branch} {repo} .
-  - PIP install -U pip=={pip_version}
+  - python3 -m venv venv
+  - alias PIP='~/repo/venv/bin/pip3'
+  - alias PY='~/repo/venv/bin/python3 -W ignore'
+  - alias PIP_REQ='xargs -L 1 ~/repo/venv/bin/pip3 install --no-cache-dir'
+#  - PIP install -U pip=={pip_version}
+  - PIP install -U pip
   - PIP_REQ < requirements.txt
 #  - until aws s3 ls '{s3_base_url}'; do echo "waiting for credentials"; sleep 10; done
   - aws s3 cp '{s3_input}' /s3bucket/input --recursive
@@ -894,9 +895,6 @@ apt-get -y install python3 python3-pip python3-venv
 #apt-get -y install docker.io
 
 pip3 install -U awscli
-python3 -m venv /venvs/bench
-alias PIP='/venvs/bench/bin/pip3'
-alias PY='/venvs/bench/bin/python3 -W ignore'
 
 mkdir -p /s3bucket/input
 mkdir -p /s3bucket/output
@@ -905,9 +903,12 @@ mkdir ~/repo
 cd ~/repo
 git clone --depth 1 --single-branch --branch {branch} {repo} .
 
-PIP install -U pip=={pip_version}
+python3 -m venv venv
+alias PIP='~/repo/venv/bin/pip3'
+alias PY='~/repo/venv/bin/python3 -W ignore'
+#PIP install -U pip=={pip_version}
+PIP install -U pip
 xargs -L 1 PIP install --no-cache-dir < requirements.txt
-PIP install -U awscli
 
 aws s3 cp '{s3_input}' /s3bucket/input --recursive
 aws s3 cp '{s3_user}' /s3bucket/user --recursive

--- a/amlb/docker.py
+++ b/amlb/docker.py
@@ -219,10 +219,7 @@ RUN apt-get -y install curl wget unzip git
 RUN apt-get -y install python3 python3-pip python3-venv
 RUN pip3 install -U pip
 
-# We create a virtual environment so that AutoML systems may use their preferred versions of 
-# packages that we need to data pre- and postprocessing without breaking it.
-ENV PIP /venvs/bench/bin/pip3
-ENV PY /venvs/bench/bin/python3 -W ignore
+# aliases for the python system
 ENV SPIP pip3
 ENV SPY python3
 
@@ -233,10 +230,16 @@ ENV PYTHONIOENCODING utf-8
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
-RUN $SPY -m venv /venvs/bench
-RUN $PIP install -U pip=={pip_version}
-
 WORKDIR /bench
+
+# We create a virtual environment so that AutoML systems may use their preferred versions of 
+# packages that we need to data pre- and postprocessing without breaking it.
+RUN $SPY -m venv venv
+ENV PIP /bench/venv/bin/pip3
+ENV PY /bench/venv/bin/python3 -W ignore
+#RUN $PIP install -U pip=={pip_version}
+RUN $PIP install -U pip
+
 VOLUME /input
 VOLUME /output
 VOLUME /custom

--- a/amlb/resources.py
+++ b/amlb/resources.py
@@ -224,8 +224,8 @@ class Resources:
             if isinstance(framework.setup_cmd, str):
                 framework.setup_cmd = [framework.setup_cmd]
             framework.setup_cmd = [cmd.format(**self._common_dirs,
-                                              **dict(pip="PIP",
-                                                     py="PY"))
+                                              **dict(pip="{pip}",
+                                                     py="{py}"))
                                    for cmd in framework.setup_cmd]
 
         if framework['params'] is None:

--- a/frameworks/H2OAutoML/exec.py
+++ b/frameworks/H2OAutoML/exec.py
@@ -105,7 +105,7 @@ def save_artifacts(automl, dataset, config):
             all_models_se = next((mid for mid in lb['model_id'] if mid.startswith("StackedEnsemble_AllModels")),
                                  None)
             mformat = 'mojo' if 'mojos' in artifacts else 'json'
-            if all_models_se:
+            if all_models_se and mformat == 'mojo':
                 save_model(all_models_se, dest_dir=models_dir, mformat=mformat)
             else:
                 for mid in lb['model_id']:

--- a/frameworks/shared/setup.sh
+++ b/frameworks/shared/setup.sh
@@ -2,6 +2,8 @@
 #shopt -s expand_aliases
 
 MODULE_ROOT="$1"
+APP_ROOT=$(dirname $(dirname $(dirname "$0")))
+#APP_ROOT="$(pwd)"
 
 SUDO() {
   if [[ $EUID == 0 ]]; then
@@ -14,8 +16,8 @@ SUDO() {
 
 if [[ -n "$MODULE_ROOT" ]]; then
     PY_VENV="$MODULE_ROOT/venv"
-elif [[ -d "/venvs/bench" ]]; then
-    PY_VENV="/venvs/bench"
+elif [[ -d "$APP_ROOT/venv" ]]; then
+    PY_VENV="$APP_ROOT/venv"
 fi
 
 if [[ -n "$PY_VENV" ]]; then


### PR DESCRIPTION
- frameworks can create a virtualenv `venv` under their package folder.
- automlbenchmark app creates a virtualenv `venv` under its folder (esp. in docker, aws).
This allows auto-detection of python/pip executables in a hierarchical way depending on which command is being executed.