### PR TITLE
Moving sklearn to v0.6.0

### DIFF
--- a/frameworks/autosklearn/__init__.py
+++ b/frameworks/autosklearn/__init__.py
@@ -1,23 +1,36 @@
-from amlb.utils import call_in_subprocess, call_script_in_same_dir, dir_of
+from amlb.benchmark import TaskConfig
+from amlb.data import Dataset
+from amlb.resources import config as rconfig
+from amlb.utils import call_script_in_same_dir, dir_of
 
 
 def setup(*args, **kwargs):
-    call_script_in_same_dir(__file__, "setup.sh", *args, **kwargs)
+    call_script_in_same_dir(__file__, "setup.sh", rconfig().root_dir, *args, **kwargs)
 
 
-def run(*args, **kwargs):
-    def exec_run(*args, **kwargs):
-        # ensure import is done here to be able to modify the environment variables in the target script
-        from .exec import run
-        return run(*args, **kwargs)
+def run(dataset: Dataset, config: TaskConfig):
+    from frameworks.shared.caller import run_in_venv
 
-    return call_in_subprocess(exec_run, *args, **kwargs)
+    data = dict(
+        train=dict(
+            X_enc=dataset.train.X_enc,
+            y_enc=dataset.train.y_enc
+        ),
+        test=dict(
+            X_enc=dataset.test.X_enc,
+            y_enc=dataset.test.y_enc
+        ),
+        predictors_type=['Categorical' if p.is_categorical() else 'Numerical' for p in dataset.predictors]
+    )
+
+    return run_in_venv(__file__, "exec.py",
+                       input_data=data, dataset=dataset, config=config)
 
 
 def docker_commands(*args, **kwargs):
     return """
-RUN {here}/setup.sh
-""".format(here=dir_of(__file__, True))
+RUN {here}/setup.sh {amlb_dir}
+""".format(here=dir_of(__file__, True), amlb_dir=rconfig().root_dir)
 
 
 __all__ = (setup, run, docker_commands)

--- a/frameworks/autosklearn/requirements.txt
+++ b/frameworks/autosklearn/requirements.txt
@@ -2,11 +2,10 @@ setuptools
 nose
 Cython
 
-numpy==1.15
+numpy>=1.9.0
 scipy>=0.14.1
 
-scikit-learn>=0.19,<0.20
-xgboost==0.80
+scikit-learn>=0.21.0,<0.22
 
 lockfile
 joblib
@@ -17,6 +16,7 @@ pandas
 
 ConfigSpace>=0.4.0,<0.5
 pynisher>=0.4.2
-pyrfr>=0.7,<0.8
+pyrfr>=0.7,<0.9
+smac==0.8
 
-auto-sklearn==0.5.1
+auto-sklearn==0.6.0

--- a/frameworks/autosklearn/setup.sh
+++ b/frameworks/autosklearn/setup.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 HERE=$(dirname "$0")
+#AMLB_DIR="$1"
 . $HERE/../shared/setup.sh
 if [[ -x "$(command -v apt-get)" ]]; then
     SUDO apt-get install -y build-essential swig
 fi
+# by passing the module directory to `setup.sh`, it tells it to automatically create a virtual env under the current module.
+# this virtual env is then used to run the exec.py only, and can be configured here using `PIP` and `PY` commands.
+. $HERE/../shared/setup.sh $HERE
 PIP install --no-cache-dir -r $HERE/requirements.txt
-

--- a/frameworks/shared/callee.py
+++ b/frameworks/shared/callee.py
@@ -134,3 +134,14 @@ def call_run(run_fn):
 
     print(config.result_token)
     print(json.dumps(res, separators=(',', ':')))
+
+
+def touch(path, as_dir=False):
+    path = os.path.realpath(os.path.expanduser(path))
+    if not os.path.exists(path):
+        dirname, basename = (path, '') if as_dir else os.path.split(path)
+        if not os.path.exists(dirname):
+            os.makedirs(dirname, exist_ok=True)
+        if basename:
+            open(path, 'a').close()
+    os.utime(path, times=None)

--- a/resources/frameworks.yaml
+++ b/resources/frameworks.yaml
@@ -47,7 +47,7 @@ TunedRandomForest:
 
 ### AutoML frameworks
 autosklearn:
-  version: '0.5.1'
+  version: '0.6.0'
   project: https://automl.github.io/auto-sklearn/stable/
 
 AutoWEKA:


### PR DESCRIPTION
This pull request is related to #84 

It moves autosklearn version to v0.6.0.

I also took advantage and move autosklearn to the venv feature, following the recommendation given in above issue.

It is important to note that I had to add some procs to frameworks/shared/callee.py that might benefit other frameworks, yet added some custom memory management inside auto-sklearn (that required psutil).


This has been tested in autosklearn -m local and -m docker. I also ran RandomForest to make sure nothing is broken.
