### PR TITLE
Force /bench workdir in singularity

### DIFF
--- a/amlb/singularity.py
+++ b/amlb/singularity.py
@@ -90,7 +90,7 @@ class SingularityBenchmark(ContainerBenchmark):
         script_extra_params = ""
         inst_name = self.sid
         cmd = (
-            "singularity run {options} "
+            "singularity run --pwd /bench {options} "
             "-B {input}:/input -B {output}:/output -B {custom}:/custom "
             "{image} \"{params} -i /input -o /output -u /custom -s skip -Xrun_mode=singularity {extra_params}\""
         ).format(


### PR DESCRIPTION
This push addresses the issue mentioned on #92 

The problem statement is that singularity sometimes doesn't translate the docker workdir very well, and we want to enforce it with the pwd directive 