### PR TITLE
Fix port configuration in H2O for multiple runs

### DIFF
--- a/frameworks/H2OAutoML/exec.py
+++ b/frameworks/H2OAutoML/exec.py
@@ -37,7 +37,7 @@ def run(dataset: Dataset, config: TaskConfig):
 
         log.info("Starting H2O cluster with %s cores, %sMB memory.", nthreads, config.max_mem_size_mb)
         max_port_range = 49151
-        min_port_range = 1000
+        min_port_range = 1024
         port = os.getpid() % (max_port_range-min_port_range) + min_port_range
         h2o.init(nthreads=nthreads,
                  port=port,

--- a/frameworks/H2OAutoML/exec.py
+++ b/frameworks/H2OAutoML/exec.py
@@ -36,8 +36,8 @@ def run(dataset: Dataset, config: TaskConfig):
         nthreads = config.framework_params.get('_nthreads', config.cores)
 
         log.info("Starting H2O cluster with %s cores, %sMB memory.", nthreads, config.max_mem_size_mb)
-        max_port_range = 65535
-        min_port_range = 45535
+        max_port_range = 49151
+        min_port_range = 1000
         port = os.getpid() % (max_port_range-min_port_range) + min_port_range
         h2o.init(nthreads=nthreads,
                  port=port,

--- a/frameworks/H2OAutoML/exec.py
+++ b/frameworks/H2OAutoML/exec.py
@@ -36,7 +36,11 @@ def run(dataset: Dataset, config: TaskConfig):
         nthreads = config.framework_params.get('_nthreads', config.cores)
 
         log.info("Starting H2O cluster with %s cores, %sMB memory.", nthreads, config.max_mem_size_mb)
+        max_port_range = 65535
+        min_port_range = 45535
+        port = os.getpid() % (max_port_range-min_port_range) + min_port_range
         h2o.init(nthreads=nthreads,
+                 port=port,
                  min_mem_size=str(config.max_mem_size_mb)+"M",
                  max_mem_size=str(config.max_mem_size_mb)+"M",
                  # log_dir=os.path.join(config.output_dir, 'logs', config.name, str(config.fold))


### PR DESCRIPTION
This request is related to #107 and it only makes sure that the h2o runs are isolated.

To do so we condition on the PID to build the port number.
