### PR TITLE
Fix params in results when passing custom framework params on command line.

### DIFF
--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -413,5 +413,7 @@ class BenchmarkTask:
             result = ErrorResult(e)
         finally:
             self._dataset.release()
+            meta_result = meta_result or {}
+            meta_result['params'] = task_config.framework_params
             return results.compute_scores(framework_name, task_config.metrics, result=result, meta_result=meta_result)
 

--- a/amlb/results.py
+++ b/amlb/results.py
@@ -270,20 +270,22 @@ class TaskResult:
     @profile(logger=log)
     def compute_scores(self, framework_name, metrics, result=None, meta_result=None):
         framework_def, _ = rget().framework_definition(framework_name)
-        meta_result = Namespace({} if meta_result is None else meta_result) % Namespace(models_count=nan, training_duration=nan)
+        meta_result = Namespace({} if meta_result is None else meta_result)
         scores = Namespace(
             id=self.task.id,
             task=self.task.name,
             framework=framework_name,
             version=framework_def.version,
-            params=str(framework_def.params) if len(framework_def.params) > 0 else '',
+            params=(str(meta_result.params) if 'params' in meta_result
+                    else str(framework_def.params) if len(framework_def.params) > 0
+                    else ''),
             fold=self.fold,
             mode=rconfig().run_mode,
             seed=rget().seed(self.fold),
             tag=rget().project_info.tag,
             utc=datetime_iso(),
-            duration=meta_result.training_duration,
-            models=meta_result.models_count
+            duration=meta_result.training_duration if 'training_duration' in meta_result else nan,
+            models=meta_result.models_count if 'models_count' in meta_result else nan,
         )
         result = self.get_result(framework_name) if result is None else result
         for metric in metrics:


### PR DESCRIPTION
Note that passing custom framework params on command line works only in local mode, those params are not propagated to docker or ec2 instances in docker and aws modes.

Example, to change `n_estimators` when using `randomforest`:
```
python runbenchmark.py randomforest -Xf.n_estimators=50
```

https://github.com/openml/automlbenchmark/issues/106
See discussion there though to properly run frameworks with custom params in docker and/or AWS.

Also added support for additional custom columns in results.