### PR TITLE
remove unnecessary AutoGluon artifacts by default

### DIFF
--- a/frameworks/AutoGluon/exec.py
+++ b/frameworks/AutoGluon/exec.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import shutil
 import warnings
 warnings.simplefilter("ignore")
 
@@ -97,9 +98,18 @@ def make_subdir(name, config):
 def save_artifacts(predictor, leaderboard, config):
     artifacts = config.framework_params.get('_save_artifacts', ['leaderboard'])
     try:
+        models_dir = make_subdir("models", config)
+        shutil.rmtree(os.path.join(models_dir, "utils"), ignore_errors=True)
+
         if 'leaderboard' in artifacts:
-            models_dir = make_subdir("models", config)
             save_pd.save(path=os.path.join(models_dir, "leaderboard.csv"), df=leaderboard)
+
+        if 'models' not in artifacts:
+            shutil.rmtree(os.path.join(models_dir, "models"), ignore_errors=True)
+            with os.scandir(models_dir) as it:
+                for f in it:
+                    if f.is_file() and os.path.splitext(f.name)[1] == '.pkl':
+                        os.remove(f.path)
 
         if 'info' in artifacts:
             ag_info = predictor.info()


### PR DESCRIPTION
models artifacts are unnecessary in a usual benchmark context and can use a lot of space + bandwidth (esp. in AWS mode: EC2+S3+network...) 
user can still keep/download models artifacts by creating a virtual framework in his custom `frameworks.yaml` file, for example:

```
autogluon:
  module: frameworks.AutoGluon
  version: '0.0.9'
  params:
     _save_artifacts: ['leaderboard', 'info', 'models']
```