### PR TITLE
TPOT: fix metric mapping for regression

### DIFF
--- a/frameworks/TPOT/exec.py
+++ b/frameworks/TPOT/exec.py
@@ -31,7 +31,8 @@ def run(dataset, config):
         mae='neg_mean_absolute_error',
         mse='neg_mean_squared_error',
         msle='neg_mean_squared_log_error',
-        r2='r2'
+        r2='r2',
+        rmse='neg_mean_squared_error',  # TPOT can score on mse, as app computes rmse independently on predictions
     )
     scoring_metric = metrics_mapping[config.metric] if config.metric in metrics_mapping else None
     if scoring_metric is None:


### PR DESCRIPTION
TPOT didn't have any mapping for `rmse` (which we use as default metric for regression)