### PR TITLE
Offer an option to monitor h2o memory usage during benchmark

### DIFF
--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -158,7 +158,8 @@ class Benchmark:
             runner = MultiThreadingJobRunner(jobs, self.parallel_jobs, delay_secs=rconfig().delay_between_jobs, done_async=True)
 
         try:
-            with OSMonitoring(frequency_seconds=rconfig().monitoring.frequency_seconds,
+            with OSMonitoring(name=jobs[0].name if len(jobs) == 1 else None,
+                              frequency_seconds=rconfig().monitoring.frequency_seconds,
                               check_on_exit=True,
                               statistics=rconfig().monitoring.statistics,
                               verbosity=rconfig().monitoring.verbosity):

--- a/frameworks/H2OAutoML/exec.py
+++ b/frameworks/H2OAutoML/exec.py
@@ -39,6 +39,7 @@ def run(dataset: Dataset, config: TaskConfig):
         h2o.init(nthreads=nthreads,
                  min_mem_size=str(config.max_mem_size_mb)+"M",
                  max_mem_size=str(config.max_mem_size_mb)+"M",
+                 strict_version_check=config.framework_params.get('_strict_version_check', True)
                  # log_dir=os.path.join(config.output_dir, 'logs', config.name, str(config.fold))
                  )
 

--- a/frameworks/H2OAutoML/exec.py
+++ b/frameworks/H2OAutoML/exec.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import psutil
 
 import h2o
 from h2o.automl import H2OAutoML
@@ -24,6 +25,7 @@ class BackendMemoryMonitoring(Monitoring):
 
     def _check_state(self):
         sd = h2o.cluster().get_status_details()
+        log.log(self._log_level, "System memory (bytes): %s", psutil.virtual_memory())
         log.log(self._log_level, "DKV: %s MB; Other: %s MB", sd['mem_value_size'][0] >> 20, sd['pojo_mem'][0] >> 20)
 
 


### PR DESCRIPTION
activated using `-Xf._monitor_backend=True`
or
```
H2OAutoML:
  extends: H2OAutoML
  params:
    _monitor_backend: true
```