### PR TITLE
support multiple setup args as array

### DIFF
--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -102,7 +102,7 @@ class Benchmark:
         log.info("Setting up framework {}.".format(self.framework_name))
 
         if hasattr(self.framework_module, 'setup'):
-            self.framework_module.setup(self.framework_def.setup_args,
+            self.framework_module.setup(*self.framework_def.setup_args,
                                         _live_output_=rconfig().setup.live_output,
                                         _activity_timeout_=rconfig().setup.activity_timeout)
 

--- a/amlb/resources.py
+++ b/amlb/resources.py
@@ -210,7 +210,9 @@ class Resources:
             framework.module = '.'.join([self.config.frameworks.root_module, framework.name])
 
         if framework['setup_args'] is None:
-            framework.setup_args = None
+            framework.setup_args = []
+        elif isinstance(framework.setup_args, str):
+            framework.setup_args = [framework.setup_args]
 
         if framework['setup_script'] is None:
             framework.setup_script = None

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -40,7 +40,7 @@ benchmarks:
   os_vol_size_mb: 2048        # the default amount of volume left to the OS when task volume memory is verified.
   overhead_time_seconds: 3600   # amount of additional time allowed for the job to complete before sending an interruption signal
   metrics:                    # default metrics by dataset type (as listed by amlb.data.DatasetType)
-    binary: ['auc', 'acc']
+    binary: ['auc', 'logloss', 'acc']
     multiclass: ['logloss', 'acc']
     regression: ['rmse', 'r2']
   defaults:


### PR DESCRIPTION
the `setup_args` used mainly in custom framework definitions didn't allow representation as array (better for self-documentation)