### PR TITLE
Ensure all non-numerical columns are encoded

### DIFF
--- a/amlb/data.py
+++ b/amlb/data.py
@@ -51,13 +51,16 @@ class Feature:
         if strict:
             return self.data_type in ['categorical', 'nominal', 'enum']
         else:
-            return self.data_type not in [None, 'numeric', 'integer', 'real']
+            return self.data_type is not None and not self.is_numerical()
+
+    def is_numerical(self):
+        return self.data_type in ['numeric', 'integer', 'real']
 
     @lazy_property
     def label_encoder(self):
         return Encoder('label' if self.values is not None else 'no-op',
                        target=self.is_target,
-                       encoded_type=int if self.is_target and self.is_categorical() else float,
+                       encoded_type=int if self.is_target and not self.is_numerical() else float,
                        missing_policy='mask' if self.has_missing_values else 'ignore'
                        ).fit(self.values)
 
@@ -65,7 +68,7 @@ class Feature:
     def one_hot_encoder(self):
         return Encoder('one-hot' if self.values is not None else 'no-op',
                        target=self.is_target,
-                       encoded_type=int if self.is_target and self.is_categorical() else float,
+                       encoded_type=int if self.is_target and not self.is_numerical() else float,
                        missing_policy='mask' if self.has_missing_values else 'ignore'
                        ).fit(self.values)
 

--- a/frameworks/autosklearn/__init__.py
+++ b/frameworks/autosklearn/__init__.py
@@ -20,7 +20,7 @@ def run(dataset: Dataset, config: TaskConfig):
             X_enc=dataset.test.X_enc,
             y_enc=dataset.test.y_enc
         ),
-        predictors_type=['Categorical' if p.is_categorical(strict=False) else 'Numerical' for p in dataset.predictors]
+        predictors_type=['Numerical' if p.is_numerical() else 'Categorical' for p in dataset.predictors]
     )
 
     return run_in_venv(__file__, "exec.py",


### PR DESCRIPTION
for frameworks using encoded data, ensure that all non-numerical columns are encoded (not only categorical ones).
This is a quickfix/improved semantic before implementing https://github.com/openml/automlbenchmark/issues/116