### PR TITLE
Archive framework artifacts 

### DIFF
--- a/amlb/aws.py
+++ b/amlb/aws.py
@@ -37,7 +37,7 @@ from .docker import DockerBenchmark
 from .job import Job
 from .resources import config as rconfig, get as rget
 from .results import ErrorResult, Scoreboard, TaskResult
-from .utils import Namespace as ns, datetime_iso, flatten, list_all_files, normalize_path, str_def, tail, touch
+from .utils import Namespace as ns, datetime_iso, file_filter, flatten, list_all_files, normalize_path, str_def, tail, touch
 
 
 log = logging.getLogger(__name__)
@@ -626,7 +626,7 @@ class AWSBenchmark(Benchmark):
 
     def _upload_resources(self):
         upload_paths = [self.benchmark_path] + rconfig().aws.resource_files
-        upload_files = list_all_files(upload_paths, exclude=rconfig().aws.resource_ignore)
+        upload_files = list_all_files(upload_paths, file_filter(exclude=rconfig().aws.resource_ignore))
         log.debug("Uploading files to S3: %s", upload_files)
         uploaded_resources = []
         for res in upload_files:

--- a/amlb/results.py
+++ b/amlb/results.py
@@ -202,7 +202,8 @@ class TaskResult:
     def save_predictions(dataset: Dataset, output_file: str,
                          predictions=None, truth=None,
                          probabilities=None, probabilities_labels=None,
-                         target_is_encoded=False):
+                         target_is_encoded=False,
+                         preview=True):
         """ Save class probabilities and predicted labels to file in csv format.
 
         :param dataset:
@@ -234,7 +235,8 @@ class TaskResult:
 
         df = df.assign(predictions=preds)
         df = df.assign(truth=truth)
-        log.info("Predictions preview:\n %s\n", df.head(20).to_string())
+        if preview:
+            log.info("Predictions preview:\n %s\n", df.head(20).to_string())
         backup_file(output_file)
         write_csv(df, path=output_file)
         log.info("Predictions saved to `%s`.", output_file)
@@ -428,8 +430,10 @@ _encode_predictions_and_truth_ = False
 def save_predictions_to_file(dataset: Dataset, output_file: str,
                              predictions=None, truth=None,
                              probabilities=None, probabilities_labels=None,
-                             target_is_encoded=False):
+                             target_is_encoded=False,
+                             preview=True):
     TaskResult.save_predictions(dataset, output_file=output_file,
                                 predictions=predictions, truth=truth,
                                 probabilities=probabilities, probabilities_labels=probabilities_labels,
-                                target_is_encoded=target_is_encoded)
+                                target_is_encoded=target_is_encoded,
+                                preview=preview)

--- a/amlb/utils/os.py
+++ b/amlb/utils/os.py
@@ -4,6 +4,7 @@ import logging
 import os
 import shutil
 import tempfile
+import zipfile
 
 from .core import Namespace
 from .time import datetime_iso
@@ -102,6 +103,15 @@ def backup_file(file_path):
     dest_path = os.path.join(dest_dir, dest_name)
     shutil.copyfile(src_path, dest_path)
     log.debug('File `%s` was backed up to `%s`.', src_path, dest_path)
+
+
+def zip_dir(directory, dest_archive):
+    with zipfile.ZipFile(dest_archive, 'w', zipfile.ZIP_DEFLATED) as zf:
+        for dir, subdirs, files in os.walk(directory):
+            for file in files:
+                file_path = os.path.join(dir, file)
+                in_archive = os.path.relpath(file_path, directory)
+                zf.write(file_path, in_archive)
 
 
 class TmpDir:

--- a/amlb/utils/os.py
+++ b/amlb/utils/os.py
@@ -110,9 +110,13 @@ def file_filter(include=None, exclude=None):
     return lambda p: includes(p) and not excludes(p)
 
 
-def walk_apply(dir_path, apply, topdown=True, filtr=None):
+def walk_apply(dir_path, apply, topdown=True, max_depth=-1, filtr=None):
     dir_path = normalize_path(dir_path)
     for dir, subdirs, files in os.walk(dir_path, topdown=topdown):
+        if max_depth >= 0:
+            depth = 0 if dir == dir_path else len(str.split(os.path.relpath(dir, dir_path), os.sep))
+            if depth > max_depth:
+                continue
         for p in itertools.chain(files, subdirs):
             path = os.path.join(dir, p)
             if filtr is None or filtr(path):

--- a/amlb/utils/os.py
+++ b/amlb/utils/os.py
@@ -92,7 +92,7 @@ def touch(path, as_dir=False):
 
 
 def backup_file(file_path):
-    src_path = os.path.realpath(file_path)
+    src_path = normalize_path(file_path)
     if not os.path.isfile(src_path):
         return
     p = split_path(src_path)
@@ -105,13 +105,19 @@ def backup_file(file_path):
     log.debug('File `%s` was backed up to `%s`.', src_path, dest_path)
 
 
-def zip_dir(directory, dest_archive):
-    with zipfile.ZipFile(dest_archive, 'w', zipfile.ZIP_DEFLATED) as zf:
-        for dir, subdirs, files in os.walk(directory):
-            for file in files:
-                file_path = os.path.join(dir, file)
-                in_archive = os.path.relpath(file_path, directory)
-                zf.write(file_path, in_archive)
+def zip_path(path, dest_archive, compression=zipfile.ZIP_DEFLATED):
+    path = normalize_path(path)
+    if not os.path.exists(path): return
+    with zipfile.ZipFile(dest_archive, 'w', compression) as zf:
+        if os.path.isfile(path):
+            in_archive = os.path.basename(path)
+            zf.write(path, in_archive)
+        elif os.path.isdir(path):
+            for dir, subdirs, files in os.walk(path):
+                for file in files:
+                    file_path = os.path.join(dir, file)
+                    in_archive = os.path.relpath(file_path, path)
+                    zf.write(file_path, in_archive)
 
 
 class TmpDir:

--- a/amlb/utils/os.py
+++ b/amlb/utils/os.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import fnmatch
+import itertools
 import logging
 import os
 import shutil
@@ -44,11 +45,10 @@ def dir_of(caller_file, rel_to_project_root=False):
         return abs_path
 
 
-def list_all_files(paths, include=None, exclude=None):
+def list_all_files(paths, filtr=None):
     """
     :param paths: the directories to look into.
-    :param include: a UNIX path pattern for the files to be included in the result list
-    :param exclude: a UNIX path pattern for the files to be excluded from the result list
+    :param filtr: None, or a predicate function returning True iff the file should be listed.
     """
     all_files = []
     paths = paths if isinstance(paths, list) else [paths]
@@ -57,25 +57,14 @@ def list_all_files(paths, include=None, exclude=None):
         if os.path.isdir(path):
             for root_dir, sub_dirs, files in os.walk(path):
                 for name in files:
-                    all_files.append(os.path.join(root_dir, name))
+                    full_path = os.path.join(root_dir, name)
+                    if filtr(full_path):
+                        all_files.append(full_path)
         elif os.path.isfile(path):
-            all_files.append(path)
+            if filtr(path):
+                all_files.append(path)
         else:
             log.warning("Skipping file `%s` as it doesn't exist.", path)
-
-    if include is not None:
-        include = include if isinstance(include, list) else [include]
-        included = []
-        for pattern in include:
-            included.extend(fnmatch.filter(all_files, pattern))
-        all_files = [file for file in all_files if file in included]
-
-    if exclude is not None:
-        exclude = exclude if isinstance(exclude, list) else [exclude]
-        excluded = []
-        for pattern in exclude:
-            excluded.extend(fnmatch.filter(all_files, pattern))
-        all_files = [file for file in all_files if file not in excluded]
 
     return all_files
 
@@ -105,7 +94,32 @@ def backup_file(file_path):
     log.debug('File `%s` was backed up to `%s`.', src_path, dest_path)
 
 
-def zip_path(path, dest_archive, compression=zipfile.ZIP_DEFLATED):
+def _create_file_filter(filtr, default_value=True):
+    matches = (lambda: default_value if filtr is None
+               else filtr if callable(filtr)
+               else lambda p: fnmatch.fnmatch(p, filtr) if isinstance(filtr, str)
+               else lambda p: any(fnmatch.fnmatch(p, pat) for pat in filtr) if isinstance(filtr, (list, tuple))
+               else None)
+    if matches is None:
+        raise ValueError("filter should be None, a predicate function, a wildcard pattern or a list of those.")
+
+
+def file_filter(include=None, exclude=None):
+    includes = _create_file_filter(include, True)
+    excludes = _create_file_filter(exclude, False)
+    return lambda p: includes(p) and not excludes(p)
+
+
+def walk_apply(dir_path, apply, topdown=True, filtr=None):
+    dir_path = normalize_path(dir_path)
+    for dir, subdirs, files in os.walk(dir_path, topdown=topdown):
+        for p in itertools.chain(files, subdirs):
+            path = os.path.join(dir, p)
+            if filtr is None or filtr(path):
+                apply(path, isdir=(p in subdirs))
+
+
+def zip_path(path, dest_archive, compression=zipfile.ZIP_DEFLATED, filtr=None):
     path = normalize_path(path)
     if not os.path.exists(path): return
     with zipfile.ZipFile(dest_archive, 'w', compression) as zf:
@@ -113,11 +127,12 @@ def zip_path(path, dest_archive, compression=zipfile.ZIP_DEFLATED):
             in_archive = os.path.basename(path)
             zf.write(path, in_archive)
         elif os.path.isdir(path):
-            for dir, subdirs, files in os.walk(path):
-                for file in files:
-                    file_path = os.path.join(dir, file)
-                    in_archive = os.path.relpath(file_path, path)
-                    zf.write(file_path, in_archive)
+            def add_to_archive(file, isdir):
+                if isdir: return
+                in_archive = os.path.relpath(file, path)
+                zf.write(file, in_archive)
+            walk_apply(path, add_to_archive,
+                       filtr=lambda p: (filtr is None or filtr(p)) and not os.path.samefile(dest_archive, p))
 
 
 class TmpDir:

--- a/frameworks/H2OAutoML/exec.py
+++ b/frameworks/H2OAutoML/exec.py
@@ -139,6 +139,13 @@ def save_artifacts(automl, dataset, config):
             else:
                 for mid in lb['model_id']:
                     save_model(mid, dest_dir=models_dir, mformat=mformat)
+                models_archive = os.path.join(models_dir, "models.zip")
+                zip_path(models_dir, models_archive)
+
+                def delete(path, isdir):
+                    if path != models_archive and os.path.splitext(path)[1] in ['.json', '.zip']:
+                        os.remove(path)
+                walk_apply(models_dir, delete, max_depth=0)
 
         if 'models_predictions' in artifacts:
             predictions_dir = output_subdir("predictions", config)

--- a/frameworks/TPOT/exec.py
+++ b/frameworks/TPOT/exec.py
@@ -12,7 +12,7 @@ os.environ['OPENBLAS_NUM_THREADS'] = '1'
 os.environ['MKL_NUM_THREADS'] = '1'
 from tpot import TPOTClassifier, TPOTRegressor
 
-from frameworks.shared.callee import call_run, result, Timer, touch
+from frameworks.shared.callee import call_run, result, output_subdir, utils
 
 
 log = logging.getLogger(__name__)
@@ -55,7 +55,7 @@ def run(dataset, config):
                      random_state=config.seed,
                      **training_params)
 
-    with Timer() as training:
+    with utils.Timer() as training:
         tpot.fit(X_train, y_train)
 
     log.info('Predicting on the test set.')
@@ -79,12 +79,6 @@ def run(dataset, config):
                   training_duration=training.duration)
 
 
-def make_subdir(name, config):
-    subdir = os.path.join(config.output_dir, name, config.name, str(config.fold))
-    touch(subdir, as_dir=True)
-    return subdir
-
-
 def save_artifacts(estimator, config):
     try:
         log.debug("All individuals :\n%s", list(estimator.evaluated_individuals_.items()))
@@ -92,7 +86,7 @@ def save_artifacts(estimator, config):
         hall_of_fame = list(zip(reversed(estimator._pareto_front.keys), estimator._pareto_front.items))
         artifacts = config.framework_params.get('_save_artifacts', False)
         if 'models' in artifacts:
-            models_file = os.path.join(make_subdir('models', config), 'models.txt')
+            models_file = os.path.join(output_subdir('models', config), 'models.txt')
             with open(models_file, 'w') as f:
                 for m in hall_of_fame:
                     pprint.pprint(dict(

--- a/frameworks/autosklearn/exec.py
+++ b/frameworks/autosklearn/exec.py
@@ -11,8 +11,7 @@ os.environ['MKL_NUM_THREADS'] = '1'
 from autosklearn.estimators import AutoSklearnClassifier, AutoSklearnRegressor
 import autosklearn.metrics as metrics
 
-from frameworks.shared.callee import call_run, result, Timer, touch
-from utils import system_memory_mb
+from frameworks.shared.callee import call_run, result, output_subdir, utils
 
 log = logging.getLogger(__name__)
 
@@ -59,7 +58,7 @@ def run(dataset, config):
 
     # when memory is large enough, we should have:
     # (cores - 1) * ml_memory_limit_mb + ensemble_memory_limit_mb = config.max_mem_size_mb
-    total_memory_mb = system_memory_mb().total
+    total_memory_mb = utils.system_memory_mb().total
     if ml_memory_limit == 'auto':
         ml_memory_limit = max(min(config.max_mem_size_mb,
                                   math.ceil(total_memory_mb / n_jobs)),
@@ -79,7 +78,7 @@ def run(dataset, config):
                              ensemble_memory_limit=ensemble_memory_limit,
                              seed=config.seed,
                              **training_params)
-    with Timer() as training:
+    with utils.Timer() as training:
         auto_sklearn.fit(X_train, y_train, metric=perf_metric, feat_type=predictors_type)
 
     # Convert output to strings for classification
@@ -100,19 +99,13 @@ def run(dataset, config):
                   training_duration=training.duration)
 
 
-def make_subdir(name, config):
-    subdir = os.path.join(config.output_dir, name, config.name, str(config.fold))
-    touch(subdir, as_dir=True)
-    return subdir
-
-
 def save_artifacts(estimator, config):
     try:
         models_repr = estimator.show_models()
         log.debug("Trained Ensemble:\n%s", models_repr)
         artifacts = config.framework_params.get('_save_artifacts', [])
         if 'models' in artifacts:
-            models_file = os.path.join(make_subdir('models', config), 'models.txt')
+            models_file = os.path.join(output_subdir('models', config), 'models.txt')
             with open(models_file, 'w') as f:
                 f.write(models_repr)
     except Exception:

--- a/frameworks/shared/callee.py
+++ b/frameworks/shared/callee.py
@@ -4,9 +4,13 @@ import os
 import re
 import sys
 
-# for backwards compatibility, imports the utility functions that used to be duplicated here
-from utils import Namespace as NS, Timer, touch
-import utils  # alias amlb utils
+try:
+    # for backwards compatibility, imports the utility functions that used to be duplicated here
+    from utils import Namespace as NS, Timer, touch
+    import utils  # alias amlb utils
+except ImportError:
+    # callee was not imported from subprocess created by caller
+    from amlb.utils import Namespace as NS, touch
 
 
 def setup_logger():

--- a/frameworks/shared/callee.py
+++ b/frameworks/shared/callee.py
@@ -149,10 +149,20 @@ def touch(path, as_dir=False):
     os.utime(path, times=None)
 
 
-def zip_dir(directory, dest_archive):
-    with zipfile.ZipFile(dest_archive, 'w', zipfile.ZIP_DEFLATED) as zf:
-        for dir, subdirs, files in os.walk(directory):
-            for file in files:
-                file_path = os.path.join(dir, file)
-                in_archive = os.path.relpath(file_path, directory)
-                zf.write(file_path, in_archive)
+def normalize_path(path):
+    return os.path.realpath(os.path.expanduser(path))
+
+
+def zip_path(path, dest_archive, compression=zipfile.ZIP_DEFLATED):
+    path = normalize_path(path)
+    if not os.path.exists(path): return
+    with zipfile.ZipFile(dest_archive, 'w', compression) as zf:
+        if os.path.isfile(path):
+            in_archive = os.path.basename(path)
+            zf.write(path, in_archive)
+        elif os.path.isdir(path):
+            for dir, subdirs, files in os.walk(path):
+                for file in files:
+                    file_path = os.path.join(dir, file)
+                    in_archive = os.path.relpath(file_path, path)
+                    zf.write(file_path, in_archive)

--- a/frameworks/shared/callee.py
+++ b/frameworks/shared/callee.py
@@ -4,6 +4,7 @@ import os
 import re
 import sys
 import time
+import zipfile
 
 
 def setup_logger():
@@ -146,3 +147,12 @@ def touch(path, as_dir=False):
         if basename:
             open(path, 'a').close()
     os.utime(path, times=None)
+
+
+def zip_dir(directory, dest_archive):
+    with zipfile.ZipFile(dest_archive, 'w', zipfile.ZIP_DEFLATED) as zf:
+        for dir, subdirs, files in os.walk(directory):
+            for file in files:
+                file_path = os.path.join(dir, file)
+                in_archive = os.path.relpath(file_path, directory)
+                zf.write(file_path, in_archive)

--- a/resources/frameworks.yaml
+++ b/resources/frameworks.yaml
@@ -49,6 +49,8 @@ TunedRandomForest:
 AutoGluon:
   version: "0.0.9"
   project: https://autogluon.mxnet.io
+#  params:
+#    _save_artifacts: ['leaderboard', 'models', 'info']
 
 AutoGluon_best:
   extends: AutoGluon
@@ -59,6 +61,8 @@ AutoGluon_best:
 autosklearn:
   version: '0.6.0'
   project: https://automl.github.io/auto-sklearn/stable/
+#  params:
+#    _save_artifacts: ['models']
 
 AutoWEKA:
   version: '2.6'
@@ -93,6 +97,7 @@ TPOT:
   version: '0.11.1'
   project: https://github.com/EpistasisLab/tpot
 #  params:
+#    _save_artifacts: ['models']
 #    max_eval_time_mins: 2
 #    population_size: 25
 #    verbosity: 2


### PR DESCRIPTION
Archive artifacts when it leads to too much network traffic, especially too many files (from ec2 to s3, and then to local computer): esp. for H2OAutoML and AutoGluon.

At the same occasion, now that `amlb.utility` functions can be aliased in `callee.py` (they mainly rely only on python standard library), removed the duplicate  utility functions that were originally copied in `callee.py`