### PR TITLE
KeyboardInterrupt should interrupt the entire benchmark

### DIFF
--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -420,7 +420,8 @@ class BenchmarkTask:
             result = ErrorResult(e)
         finally:
             self._dataset.release()
-            meta_result = meta_result or {}
-            meta_result['params'] = task_config.framework_params
-            return results.compute_scores(framework_name, task_config.metrics, result=result, meta_result=meta_result)
+
+        meta_result = meta_result or {}
+        meta_result['params'] = task_config.framework_params
+        return results.compute_scores(framework_name, task_config.metrics, result=result, meta_result=meta_result)
 

--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -146,7 +146,8 @@ class Benchmark:
         jobs = flatten([self._task_jobs(task_def, fold) for task_def in task_defs])
         try:
             results = self._run_jobs(jobs)
-            # log.info(results)
+            log.info(f"Processing results for {self.sid}")
+            log.debug(results)
             if task_name is None:
                 scoreboard = self._process_results(results)
             else:

--- a/amlb/docker.py
+++ b/amlb/docker.py
@@ -73,7 +73,7 @@ class DockerBenchmark(ContainerBenchmark):
         except:  # also want to handle KeyboardInterrupt
             try:
                 run_cmd(f"docker kill {inst_name}")
-            except:
+            except Exception:
                 pass
             finally:
                 raise
@@ -87,7 +87,7 @@ class DockerBenchmark(ContainerBenchmark):
         try:
             run_cmd(f"docker pull {self._image_name}", _live_output_=True)
             return True
-        except:
+        except Exception:
             pass
         return False
 

--- a/amlb/job.py
+++ b/amlb/job.py
@@ -15,7 +15,7 @@ import signal
 import threading
 import time
 
-from .utils import Namespace, Timer, InterruptTimeout
+from .utils import Namespace, Timer, InterruptTimeout, TimeoutException
 
 log = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ class Job:
             log.info("\n%s\n%s", '-'*len(start_msg), start_msg)
             self.state = State.running
             with Timer() as t:
-                with InterruptTimeout(self.timeout):
+                with InterruptTimeout(self.timeout, sig=TimeoutException):
                     result = self._run()
             log.info("Job %s executed in %.3f seconds.", self.name, t.duration)
             log.debug("Job %s returned: %s", self.name, result)

--- a/amlb/job.py
+++ b/amlb/job.py
@@ -15,7 +15,7 @@ import signal
 import threading
 import time
 
-from .utils import Namespace, Timer, InterruptTimeout, TimeoutException
+from .utils import Namespace, Timer, InterruptTimeout, raise_in_thread, signal_handler
 
 log = logging.getLogger(__name__)
 
@@ -42,10 +42,12 @@ class Job:
         self.name = name
         self.timeout = timeout_secs
         self.state = State.created
+        self.thread_id = None
 
     def start(self):
         try:
             start_msg = "Starting job {}.".format(self.name)
+            self.thread_id = threading.current_thread().ident
             if self.state == State.stopping:
                 self.state = State.cancelled
                 raise CancelledError("Job was cancelled.")
@@ -55,7 +57,7 @@ class Job:
             log.info("\n%s\n%s", '-'*len(start_msg), start_msg)
             self.state = State.running
             with Timer() as t:
-                with InterruptTimeout(self.timeout, sig=TimeoutException):
+                with InterruptTimeout(self.timeout, sig=TimeoutError):
                     result = self._run()
             log.info("Job %s executed in %.3f seconds.", self.name, t.duration)
             log.debug("Job %s returned: %s", self.name, result)
@@ -89,7 +91,8 @@ class Job:
         pass
 
     def _stop(self):
-        pass
+        if self.thread_id is not None:
+            raise_in_thread(self.thread_id, CancelledError)
 
     def _on_done(self):
         """hook to execute logic after job completion in a thread-safe way as this is executed in the main thread"""
@@ -146,6 +149,7 @@ class MultiThreadingJobRunner(JobRunner):
         self._daemons = use_daemons
 
     def _run(self):
+        signal_handler(signal.SIGINT, self.stop)
         q = queue.Queue()
 
         def worker():
@@ -166,8 +170,6 @@ class MultiThreadingJobRunner(JobRunner):
             thread.start()
             threads.append(thread)
 
-        # previous_handler = signal.signal(signal.SIGINT, self.stop)
-
         try:
             for job in self.jobs:
                 if self.state == State.stopping:
@@ -177,7 +179,6 @@ class MultiThreadingJobRunner(JobRunner):
                     time.sleep(self._delay)
             q.join()
         finally:
-            # signal.signal(signal.SIGINT, previous_handler)
             for _ in range(self.parallel_jobs):
                 q.put(None)     # stopping workers
             for thread in threads:

--- a/amlb/job.py
+++ b/amlb/job.py
@@ -57,7 +57,8 @@ class Job:
             log.info("\n%s\n%s", '-'*len(start_msg), start_msg)
             self.state = State.running
             with Timer() as t:
-                with InterruptTimeout(self.timeout, sig=TimeoutError):
+                # don't propagate interruption error here (sig=None) so that we can collect the timeout in the result
+                with InterruptTimeout(self.timeout, sig=None):
                     result = self._run()
             log.info("Job %s executed in %.3f seconds.", self.name, t.duration)
             log.debug("Job %s returned: %s", self.name, result)

--- a/amlb/results.py
+++ b/amlb/results.py
@@ -319,7 +319,7 @@ class Result:
         if hasattr(self, metric):
             return getattr(self, metric)()
         # raise ValueError("Metric {metric} is not supported for {type}.".format(metric=metric, type=self.type))
-        log.warning("Metric {} is not supported for {}!".format( metric, self.type))
+        log.warning("Metric %s is not supported for %s!", metric, self.type)
         return nan
 
 

--- a/amlb/singularity.py
+++ b/amlb/singularity.py
@@ -112,7 +112,7 @@ class SingularityBenchmark(ContainerBenchmark):
             # also want to handle KeyboardInterrupt
             # In the foreground run mode, the user has to kill the process
             # There is yet no docker kill command. User has to kill PID manually
-            log.warn(f"Container {inst_name} may still be running, please verify and kill it manually.")
+            log.warning(f"Container {inst_name} may still be running, please verify and kill it manually.")
             raise Exception
 
     def _image_exists(self):
@@ -127,7 +127,7 @@ class SingularityBenchmark(ContainerBenchmark):
                 output_file=self._image_name,
             ), _live_output_=True)
             return True
-        except:
+        except Exception:
             try:
                 # If no docker image, pull from singularity hub
                 run_cmd("singularity pull {output_file} library://{library}/{image}".format(
@@ -136,7 +136,7 @@ class SingularityBenchmark(ContainerBenchmark):
                     library=rconfig().singularity.library
                 ), _live_output_=True)
                 return True
-            except:
+            except Exception:
                 pass
         return False
 

--- a/amlb/utils/core.py
+++ b/amlb/utils/core.py
@@ -22,7 +22,7 @@ class Namespace:
             try:
                 if isinstance(v, str):
                     v = literal_eval(v)
-            except:
+            except Exception:
                 pass
             parsed[k] = v
         sublevel = {}

--- a/amlb/utils/process.py
+++ b/amlb/utils/process.py
@@ -64,7 +64,7 @@ def run_subprocess(*popenargs,
             else:
                 process.wait()
             raise subprocess.TimeoutExpired(process.args, timeout, output=stdout, stderr=stderr)
-        except:
+        except:  # also handles kb interrupts
             process.kill()
             raise
         retcode = process.poll()

--- a/amlb/utils/time.py
+++ b/amlb/utils/time.py
@@ -63,8 +63,13 @@ class Timer:
 class Timeout:
 
     def __init__(self, timeout_secs, on_timeout=None):
+        def timeout_handler():
+            self.timed_out = True
+            on_timeout()
+
         enabled = timeout_secs is not None and timeout_secs >= 0
-        self.timer = threading.Timer(timeout_secs, on_timeout) if enabled else None
+        self.timer = threading.Timer(timeout_secs, timeout_handler) if enabled else None
+        self.timed_out = False
 
     @property
     def active(self):

--- a/frameworks/AutoGluon/exec.py
+++ b/frameworks/AutoGluon/exec.py
@@ -115,7 +115,7 @@ def save_artifacts(predictor, leaderboard, config):
                 for f in it:
                     if f.is_file() and os.path.splitext(f.name)[1] == '.pkl':
                         os.remove(f.path)
-    except:
+    except Exception:
         log.warning("Error when saving artifacts.", exc_info=True)
 
 

--- a/frameworks/H2OAutoML/exec.py
+++ b/frameworks/H2OAutoML/exec.py
@@ -158,7 +158,7 @@ def save_artifacts(automl, dataset, config):
         if 'logs' in artifacts:
             logs_dir = make_subdir("logs", config)
             h2o.download_all_logs(dirname=logs_dir)
-    except:
+    except Exception:
         log.debug("Error when saving artifacts.", exc_info=True)
 
 

--- a/frameworks/TPOT/exec.py
+++ b/frameworks/TPOT/exec.py
@@ -100,7 +100,7 @@ def save_artifacts(estimator, config):
                         model=str(m[1]),
                         pipeline=models[str(m[1])],
                     ), stream=f)
-    except:
+    except Exception:
         log.debug("Error when saving artifacts.", exc_info=True)
 
 

--- a/frameworks/autosklearn/exec.py
+++ b/frameworks/autosklearn/exec.py
@@ -115,7 +115,7 @@ def save_artifacts(estimator, config):
             models_file = os.path.join(make_subdir('models', config), 'models.txt')
             with open(models_file, 'w') as f:
                 f.write(models_repr)
-    except:
+    except Exception:
         log.debug("Error when saving artifacts.", exc_info=True)
 
 


### PR DESCRIPTION
reviewed too broad usages of except (catching BaseException only to ensure that subprocesses can be cleaned).

ensure that one single  KBI allows to safely stop all running instances in AWS mode.