### PR TITLE
extend results with constraint and metric name

### DIFF
--- a/amlb/aws.py
+++ b/amlb/aws.py
@@ -271,7 +271,7 @@ class AWSBenchmark(Benchmark):
                 return self._wait_for_results(job_self)
             except Exception as e:
                 fold = int(folds[0]) if len(folds) > 0 else -1
-                results = TaskResult(task_def=task_def, fold=fold)
+                results = TaskResult(task_def=task_def, fold=fold, constraint=self.constraint_name)
                 return results.compute_scores(self.framework_name, [], result=ErrorResult(e))
 
         def _on_done(job_self):

--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -394,7 +394,9 @@ class BenchmarkTask:
         :param framework:
         :return:
         """
-        results = TaskResult(task_def=self._task_def, fold=self.fold, predictions_dir=self.benchmark.output_dirs.predictions)
+        results = TaskResult(task_def=self._task_def, fold=self.fold,
+                             constraint=self.benchmark.constraint_name,
+                             predictions_dir=self.benchmark.output_dirs.predictions)
         framework_def, _ = rget().framework_definition(framework_name)
         task_config = copy(self.task_config)
         task_config.estimate_system_params()


### PR DESCRIPTION
https://github.com/openml/automlbenchmark/issues/117

adding 2 columns to `results.csv` files: 
- `metric` : the one as objective function, and corresponding to the `results` value
- `constraint`: to identify the constraint used for the given run.