### PR TITLE
Custom functions: e.g. custom metrics

### DIFF
--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -279,7 +279,7 @@ class TaskConfig:
 
     def __init__(self, name, fold, metrics, seed,
                  max_runtime_seconds, cores, max_mem_size_mb, min_vol_size_mb,
-                 input_dir, output_dir):
+                 input_dir, output_dir, extensions):
         self.framework = None
         self.framework_params = None
         self.type = None
@@ -295,6 +295,7 @@ class TaskConfig:
         self.input_dir = input_dir
         self.output_dir = output_dir
         self.output_predictions_file = os.path.join(output_dir, "predictions.csv")
+        self.extensions = extensions
 
     def __json__(self):
         return self.__dict__
@@ -350,6 +351,7 @@ class BenchmarkTask:
             min_vol_size_mb=task_def.min_vol_size_mb,
             input_dir=rconfig().input_dir,
             output_dir=benchmark.output_dirs.session,
+            extensions=rconfig().extensions_files,
         )
         # allowing to override some task parameters through command line, e.g.: -Xt.max_runtime_seconds=60
         if rconfig()['t'] is not None:

--- a/frameworks/AutoGluon/exec.py
+++ b/frameworks/AutoGluon/exec.py
@@ -12,7 +12,7 @@ from autogluon.task.tabular_prediction.tabular_prediction import TabularPredicti
 from autogluon.utils.tabular.utils.savers import save_pd, save_pkl
 import autogluon.utils.tabular.metrics as metrics
 
-from frameworks.shared.callee import call_run, result, output_subdir, utils
+from frameworks.shared.callee import call_run, get_extension, result, output_subdir, utils
 
 log = logging.getLogger(__name__)
 
@@ -32,7 +32,8 @@ def run(dataset, config):
         rmse=metrics.mean_squared_error,  # for now, we can let autogluon optimize training on mse: anyway we compute final score from predictions.
     )
 
-    perf_metric = metrics_mapping[config.metric] if config.metric in metrics_mapping else None
+    perf_metric = (metrics_mapping[config.metric] if config.metric in metrics_mapping
+                   else get_extension(config.extensions, config.metric))
     if perf_metric is None:
         # TODO: figure out if we are going to blindly pass metrics through, or if we use a strict mapping
         log.warning("Performance metric %s not supported.", config.metric)

--- a/frameworks/TPOT/exec.py
+++ b/frameworks/TPOT/exec.py
@@ -12,7 +12,7 @@ os.environ['OPENBLAS_NUM_THREADS'] = '1'
 os.environ['MKL_NUM_THREADS'] = '1'
 from tpot import TPOTClassifier, TPOTRegressor
 
-from frameworks.shared.callee import call_run, result, output_subdir, utils
+from frameworks.shared.callee import call_run, get_extension, result, output_subdir, utils
 
 
 log = logging.getLogger(__name__)
@@ -34,7 +34,8 @@ def run(dataset, config):
         r2='r2',
         rmse='neg_mean_squared_error',  # TPOT can score on mse, as app computes rmse independently on predictions
     )
-    scoring_metric = metrics_mapping[config.metric] if config.metric in metrics_mapping else None
+    scoring_metric = (metrics_mapping[config.metric] if config.metric in metrics_mapping
+                      else get_extension(config.extensions, config.metric))
     if scoring_metric is None:
         raise ValueError("Performance metric {} not supported.".format(config.metric))
 

--- a/frameworks/autosklearn/exec.py
+++ b/frameworks/autosklearn/exec.py
@@ -11,7 +11,7 @@ os.environ['MKL_NUM_THREADS'] = '1'
 from autosklearn.estimators import AutoSklearnClassifier, AutoSklearnRegressor
 import autosklearn.metrics as metrics
 
-from frameworks.shared.callee import call_run, result, output_subdir, utils
+from frameworks.shared.callee import call_run, get_extension, result, output_subdir, utils
 
 log = logging.getLogger(__name__)
 
@@ -34,7 +34,8 @@ def run(dataset, config):
         rmse=metrics.mean_squared_error,  # autosklearn can optimize on mse, and we compute rmse independently on predictions
         r2=metrics.r2
     )
-    perf_metric = metrics_mapping[config.metric] if config.metric in metrics_mapping else None
+    perf_metric = (metrics_mapping[config.metric] if config.metric in metrics_mapping
+                   else get_extension(config.extensions, config.metric))
     if perf_metric is None:
         # TODO: figure out if we are going to blindly pass metrics through, or if we use a strict mapping
         log.warning("Performance metric %s not supported.", config.metric)

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -50,6 +50,9 @@ benchmarks:
     max_mem_size_mb: -1       # default amount of memory assigned to each automl task. If <= 0, then the amount of memory is computed from os available memory.
     min_vol_size_mb: -1       # default minimum amount of free space required on the volume. If <= 0, skips verification.
 
+extensions_files:
+  - '{user}/extensions.py'
+
 results:
   error_max_length: 200
   save: true  # set by runbenchmark.py

--- a/resources/frameworks.yaml
+++ b/resources/frameworks.yaml
@@ -61,7 +61,7 @@ AutoGluon_best:
 autosklearn:
   version: '0.6.0'
   project: https://automl.github.io/auto-sklearn/stable/
-#  params:
+  params:
 #    _save_artifacts: ['models']
 
 AutoWEKA:


### PR DESCRIPTION
adding generic support for frameworks extensions with an example of integration for custom metrics.


Extensions are loaded by default from `{user}/extensions.py`.
User can define as many extension files as he wants in his `config.yaml`, e.g.
```
extensions_files: 
   -  '{user}/autosklearn_extensions.py'
   -  'user}/autogluon_extensions.py'
   -  '{user}/tpot_extensions.py'
   - '{user}/extensions.py'
```

a specific variable, function or class defined in those files can be loaded by name from the framework integration using:
```
from frameworks.shared.callee import get_extension
...
ext = get_extension(config.extensions, 'foo')
```

The first name that could be loaded succesfully will be returned.
For example, if 'foo' is defined on all the extensions files above, and we're running `TPOT`, then the first 2 files may fail loading in TPOT integration if  they import `autogluon` or `autosklearn` modules, however loading `{user}/tpot_extensions.py` should succeed, so if there's a variable/function named "foo" there, it will be returned, otherwise it will look into the last file.

This PR shows how this can be used to inject custom metrics in frameworks like `autogluon`, `autosklearn` and `TPOT`.