### PR TITLE
Allow an OpenML suite to define tasks of benchmark

### DIFF
--- a/amlb/aws.py
+++ b/amlb/aws.py
@@ -256,7 +256,7 @@ class AWSBenchmark(Benchmark):
                 instance_def,
                 script_params="{framework} {benchmark} {constraint} {task_param} {folds_param} -Xseed={seed}".format(
                     framework=self.framework_name,
-                    benchmark=(self.benchmark_name if self.benchmark_path.startswith(rconfig().root_dir)
+                    benchmark=(self.benchmark_name if self.benchmark_path is None or self.benchmark_path.startswith(rconfig().root_dir)
                                else "{}/{}".format(resources_root, self._rel_path(self.benchmark_path))),
                     constraint=self.constraint_name,
                     task_param='' if len(task_names) == 0 else ' '.join(['-t']+task_names),
@@ -625,7 +625,8 @@ class AWSBenchmark(Benchmark):
         return self._s3_input(name) if in_input_dir else self._s3_user(name)
 
     def _upload_resources(self):
-        upload_paths = [self.benchmark_path] + rconfig().aws.resource_files
+        default_paths = [self.benchmark_path] if self.benchmark_path is not None else []
+        upload_paths = default_paths + rconfig().aws.resource_files
         upload_files = list_all_files(upload_paths, file_filter(exclude=rconfig().aws.resource_ignore))
         log.debug("Uploading files to S3: %s", upload_files)
         uploaded_resources = []

--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -52,12 +52,6 @@ class Benchmark:
     data_loader = None
 
     def __init__(self, framework_name: str, benchmark_name: str, constraint_name: str):
-        """
-
-        :param framework_name:
-        :param benchmark_name:
-        :param constraint_name:
-        """
         if rconfig().run_mode == 'script':
             self.framework_def, self.framework_name, self.framework_module = None, None, None
             self.benchmark_def, self.benchmark_name, self.benchmark_path = None, None, None

--- a/amlb/benchmarks/file.py
+++ b/amlb/benchmarks/file.py
@@ -1,9 +1,8 @@
 import logging
 import os
-from typing import List
+from typing import List, Tuple, Optional
 
-from amlb.utils import config_load
-
+from amlb.utils import config_load, Namespace
 
 log = logging.getLogger(__name__)
 
@@ -26,9 +25,10 @@ def _find_local_benchmark_definition(name: str, benchmark_definition_dirs: List[
             name, benchmark_definition_dirs))
 
 
-def load_file_benchmark(name: str, benchmark_definition_dirs: List[str]):
+def load_file_benchmark(name: str, benchmark_definition_dirs: List[str]) -> Tuple[str, Optional[str], List[Namespace]]:
+    """ Loads benchmark from a local file. """
     benchmark_file = _find_local_benchmark_definition(name, benchmark_definition_dirs)
     log.info("Loading benchmark definitions from %s.", benchmark_file)
     tasks = config_load(benchmark_file)
     benchmark_name, _ = os.path.splitext(os.path.basename(benchmark_file))
-    return benchmark_name, tasks
+    return benchmark_name, benchmark_file, tasks

--- a/amlb/benchmarks/file.py
+++ b/amlb/benchmarks/file.py
@@ -14,15 +14,13 @@ def _find_local_benchmark_definition(name: str, benchmark_definition_dirs: List[
         return name
 
     for bd in benchmark_definition_dirs:
-        bf = os.path.join(bd, "{}.yaml".format(name))
+        bf = os.path.join(bd, f"{name}.yaml")
         if os.path.exists(bf):
             # We don't account for duplicate definitions (yet).
             return bf
 
     # should we support s3 and check for s3 path before raising error?
-    raise ValueError(
-        "Incorrect benchmark name or path `{}`, name not available in {}.".format(
-            name, benchmark_definition_dirs))
+    raise ValueError(f"Incorrect benchmark name or path `{name}`, name not available in {benchmark_definition_dirs}.")
 
 
 def load_file_benchmark(name: str, benchmark_definition_dirs: List[str]) -> Tuple[str, Optional[str], List[Namespace]]:

--- a/amlb/benchmarks/file.py
+++ b/amlb/benchmarks/file.py
@@ -1,0 +1,34 @@
+import logging
+import os
+from typing import List
+
+from amlb.utils import config_load
+
+
+log = logging.getLogger(__name__)
+
+
+def _find_local_benchmark_definition(name: str, benchmark_definition_dirs: List[str]) -> str:
+    # 'name' should be either a full path to the benchmark,
+    # or a filename (without extension) in the benchmark directory.
+    if os.path.exists(name):
+        return name
+
+    for bd in benchmark_definition_dirs:
+        bf = os.path.join(bd, "{}.yaml".format(name))
+        if os.path.exists(bf):
+            # We don't account for duplicate definitions (yet).
+            return bf
+
+    # should we support s3 and check for s3 path before raising error?
+    raise ValueError(
+        "Incorrect benchmark name or path `{}`, name not available in {}.".format(
+            name, benchmark_definition_dirs))
+
+
+def file_benchmark_to_tasks(name: str, benchmark_definition_dirs: List[str]):
+    benchmark_file = _find_local_benchmark_definition(name, benchmark_definition_dirs)
+    log.info("Loading benchmark definitions from %s.", benchmark_file)
+    tasks = config_load(benchmark_file)
+    benchmark_name, _ = os.path.splitext(os.path.basename(benchmark_file))
+    return tasks

--- a/amlb/benchmarks/file.py
+++ b/amlb/benchmarks/file.py
@@ -26,9 +26,9 @@ def _find_local_benchmark_definition(name: str, benchmark_definition_dirs: List[
             name, benchmark_definition_dirs))
 
 
-def file_benchmark_to_tasks(name: str, benchmark_definition_dirs: List[str]):
+def load_file_benchmark(name: str, benchmark_definition_dirs: List[str]):
     benchmark_file = _find_local_benchmark_definition(name, benchmark_definition_dirs)
     log.info("Loading benchmark definitions from %s.", benchmark_file)
     tasks = config_load(benchmark_file)
     benchmark_name, _ = os.path.splitext(os.path.basename(benchmark_file))
-    return tasks
+    return benchmark_name, tasks

--- a/amlb/benchmarks/openml.py
+++ b/amlb/benchmarks/openml.py
@@ -15,7 +15,7 @@ def is_openml_benchmark(benchmark: str) -> bool:
         domain, oml_type, oml_id = benchmark.split('/')
         supported_types = ['s', 't']
 
-        if oml_id.isdecimal() and float(oml_id).is_integer() and int(oml_id) > 0:
+        if oml_id.isdecimal():
             return domain == "openml" and oml_type in supported_types
     return False
 

--- a/amlb/benchmarks/openml.py
+++ b/amlb/benchmarks/openml.py
@@ -1,0 +1,45 @@
+import logging
+from typing import List, Union
+
+import openml
+
+from amlb.utils import Namespace
+
+
+log = logging.getLogger(__name__)
+
+
+def is_openml_benchmark(benchmark: str) -> bool:
+    """ Check if 'benchmark' is a valid identifier for an openml task or study. """
+    if len(benchmark.split('/')) == 3:
+        domain, oml_type, oml_id = benchmark.split('/')
+        supported_types = ['s', 't']
+
+        valid_id = False
+        try:
+            _ = int(oml_id)
+            valid_id = True
+        except ValueError:
+            pass
+
+        return domain == "openml" or oml_type in supported_types and valid_id
+    return False
+
+
+def oml_benchmark_to_tasks(benchmark: str) -> List[Namespace]:
+    domain, oml_type, oml_id = benchmark.split('/')
+    if oml_type == 't':
+        log.info("Loading openml task %s.", oml_id)
+        return [oml_task_to_ns(oml_id)]
+    elif oml_type == 's':
+        log.info("Loading openml study %s.", oml_id)
+        study = openml.study.get_suite(oml_id)
+        return [oml_task_to_ns(task_id) for task_id in study.tasks]
+    else:
+        raise ValueError("The oml_type is {} but must be 's' or 't'".format(oml_type))
+
+
+def oml_task_to_ns(task_id: Union[str, int]) -> Namespace:
+    t = openml.tasks.get_task(task_id, download_data=False)
+    data = openml.datasets.get_dataset(t.dataset_id, download_data=False)
+    return Namespace(name=data.name, description=data.description, openml_task_id=t.id)

--- a/amlb/benchmarks/openml.py
+++ b/amlb/benchmarks/openml.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Union, Tuple
+from typing import List, Tuple, Optional
 
 import openml
 
@@ -26,25 +26,26 @@ def is_openml_benchmark(benchmark: str) -> bool:
     return False
 
 
-def load_oml_benchmark(benchmark: str) -> Tuple[str, List[Namespace]]:
+def load_oml_benchmark(benchmark: str) -> Tuple[str, Optional[str], List[Namespace]]:
+    """ Loads benchmark defined by openml study or task, from openml/s/X or openml/t/Y. """
     domain, oml_type, oml_id = benchmark.split('/')
+    path = None  # benchmark file does not exist on disk
+    name = benchmark  # name is later passed as cli input again for containers, it needs to remain parsable
     if oml_type == 't':
         log.info("Loading openml task %s.", oml_id)
         # We first have the retrieve the task because we don't know the dataset id
         t = openml.tasks.get_task(oml_id, download_data=False)
         data = openml.datasets.get_dataset(t.dataset_id, download_data=False)
-        return "task_{}".format(oml_id), [Namespace(name=data.name, description=data.description, openml_task_id=t.id)]
+        tasks = [Namespace(name=data.name, description=data.description, openml_task_id=t.id)]
     elif oml_type == 's':
         log.info("Loading openml study %s.", oml_id)
         study = openml.study.get_suite(oml_id)
-        name = "study_{}".format(oml_id) if study.alias is None else study.alias
 
         # Here we know the (task, dataset) pairs so only download dataset meta-data is sufficient
         tasks = []
         for tid, did in zip(study.tasks, study.data):
             data = openml.datasets.get_dataset(did, download_data=False)
             tasks.append(Namespace(name=data.name, description=data.description, openml_task_id=tid))
-
-        return name, tasks
     else:
         raise ValueError("The oml_type is {} but must be 's' or 't'".format(oml_type))
+    return name, path, tasks

--- a/amlb/benchmarks/openml.py
+++ b/amlb/benchmarks/openml.py
@@ -10,24 +10,18 @@ log = logging.getLogger(__name__)
 
 
 def is_openml_benchmark(benchmark: str) -> bool:
-    """ Check if 'benchmark' is a valid identifier for an openml task or study. """
+    """ Check if 'benchmark' is a valid identifier for an openml task or suite. """
     if len(benchmark.split('/')) == 3:
         domain, oml_type, oml_id = benchmark.split('/')
         supported_types = ['s', 't']
 
-        valid_id = False
-        try:
-            _ = int(oml_id)
-            valid_id = True
-        except ValueError:
-            pass
-
-        return domain == "openml" or oml_type in supported_types and valid_id
+        if oml_id.isdecimal() and float(oml_id).is_integer() and int(oml_id) > 0:
+            return domain == "openml" and oml_type in supported_types
     return False
 
 
 def load_oml_benchmark(benchmark: str) -> Tuple[str, Optional[str], List[Namespace]]:
-    """ Loads benchmark defined by openml study or task, from openml/s/X or openml/t/Y. """
+    """ Loads benchmark defined by openml suite or task, from openml/s/X or openml/t/Y. """
     domain, oml_type, oml_id = benchmark.split('/')
     path = None  # benchmark file does not exist on disk
     name = benchmark  # name is later passed as cli input again for containers, it needs to remain parsable
@@ -38,14 +32,14 @@ def load_oml_benchmark(benchmark: str) -> Tuple[str, Optional[str], List[Namespa
         data = openml.datasets.get_dataset(t.dataset_id, download_data=False)
         tasks = [Namespace(name=data.name, description=data.description, openml_task_id=t.id)]
     elif oml_type == 's':
-        log.info("Loading openml study %s.", oml_id)
-        study = openml.study.get_suite(oml_id)
+        log.info("Loading openml suite %s.", oml_id)
+        suite = openml.study.get_suite(oml_id)
 
         # Here we know the (task, dataset) pairs so only download dataset meta-data is sufficient
         tasks = []
-        for tid, did in zip(study.tasks, study.data):
+        for tid, did in zip(suite.tasks, suite.data):
             data = openml.datasets.get_dataset(did, download_data=False)
             tasks.append(Namespace(name=data.name, description=data.description, openml_task_id=tid))
     else:
-        raise ValueError("The oml_type is {} but must be 's' or 't'".format(oml_type))
+        raise ValueError(f"The oml_type is {oml_type} but must be 's' or 't'")
     return name, path, tasks

--- a/amlb/benchmarks/parser.py
+++ b/amlb/benchmarks/parser.py
@@ -1,0 +1,26 @@
+import os
+from typing import Tuple, List
+
+from amlb.utils import Namespace
+from .openml import is_openml_benchmark, oml_benchmark_to_tasks
+from .file import file_benchmark_to_tasks
+
+
+def benchmark_load(name, benchmark_definition_dirs: List[str]):
+    # Identify where the resource is located, all name structures are clearly defined,
+    # but local file benchmark can require probing from disk to see if it is valid,
+    # which is why it is tried last.
+    if is_openml_benchmark(name):
+        tasks = oml_benchmark_to_tasks(name)
+        benchmark_name = "study_{}".format(name.split('/')[-1])
+    # elif is_kaggle_benchmark(name):
+    else:
+        tasks = file_benchmark_to_tasks(name, benchmark_definition_dirs)
+        benchmark_name, _ = os.path.splitext(os.path.basename(name))
+
+    hard_defaults = next((task for task in tasks if task.name == '__defaults__'), None)
+    tasks = [task for task in tasks if task is not hard_defaults]
+    return hard_defaults, tasks, 'test_file_name'
+
+
+

--- a/amlb/benchmarks/parser.py
+++ b/amlb/benchmarks/parser.py
@@ -1,4 +1,3 @@
-import os
 from typing import List
 
 from .openml import is_openml_benchmark, load_oml_benchmark
@@ -6,15 +5,21 @@ from .file import load_file_benchmark
 
 
 def benchmark_load(name, benchmark_definition_dirs: List[str]):
+    """ Loads the benchmark definition for the 'benchmark' cli input string.
+
+    :param name: the value for 'benchmark'
+    :param benchmark_definition_dirs: directories in which benchmark definitions can be found
+    :return: a tuple with constraint defaults, tasks, the benchmark path (if it is a local file) and benchmark name
+    """
     # Identify where the resource is located, all name structures are clearly defined,
     # but local file benchmark can require probing from disk to see if it is valid,
     # which is why it is tried last.
     if is_openml_benchmark(name):
-        benchmark_name, tasks = load_oml_benchmark(name)
+        benchmark_name, benchmark_path, tasks = load_oml_benchmark(name)
     # elif is_kaggle_benchmark(name):
     else:
-        benchmark_name, tasks = load_file_benchmark(name, benchmark_definition_dirs)
+        benchmark_name, benchmark_path, tasks = load_file_benchmark(name, benchmark_definition_dirs)
 
     hard_defaults = next((task for task in tasks if task.name == '__defaults__'), None)
     tasks = [task for task in tasks if task is not hard_defaults]
-    return hard_defaults, tasks, 'test_file_name', benchmark_name
+    return hard_defaults, tasks, benchmark_path, benchmark_name

--- a/amlb/benchmarks/parser.py
+++ b/amlb/benchmarks/parser.py
@@ -1,9 +1,8 @@
 import os
-from typing import Tuple, List
+from typing import List
 
-from amlb.utils import Namespace
-from .openml import is_openml_benchmark, oml_benchmark_to_tasks
-from .file import file_benchmark_to_tasks
+from .openml import is_openml_benchmark, load_oml_benchmark
+from .file import load_file_benchmark
 
 
 def benchmark_load(name, benchmark_definition_dirs: List[str]):
@@ -11,16 +10,11 @@ def benchmark_load(name, benchmark_definition_dirs: List[str]):
     # but local file benchmark can require probing from disk to see if it is valid,
     # which is why it is tried last.
     if is_openml_benchmark(name):
-        tasks = oml_benchmark_to_tasks(name)
-        benchmark_name = "study_{}".format(name.split('/')[-1])
+        benchmark_name, tasks = load_oml_benchmark(name)
     # elif is_kaggle_benchmark(name):
     else:
-        tasks = file_benchmark_to_tasks(name, benchmark_definition_dirs)
-        benchmark_name, _ = os.path.splitext(os.path.basename(name))
+        benchmark_name, tasks = load_file_benchmark(name, benchmark_definition_dirs)
 
     hard_defaults = next((task for task in tasks if task.name == '__defaults__'), None)
     tasks = [task for task in tasks if task is not hard_defaults]
-    return hard_defaults, tasks, 'test_file_name'
-
-
-
+    return hard_defaults, tasks, 'test_file_name', benchmark_name

--- a/amlb/resources.py
+++ b/amlb/resources.py
@@ -171,8 +171,7 @@ class Resources:
         :param defaults: defaults used as a base config for each task in the benchmark definition
         :return:
         """
-        benchmark_name = name
-        hard_defaults, tasks, benchmark_file = benchmark_load(name, self.config.benchmarks.definition_dir)
+        hard_defaults, tasks, benchmark_file, benchmark_name = benchmark_load(name, self.config.benchmarks.definition_dir)
 
         defaults = Namespace.merge(defaults, hard_defaults, Namespace(name='__defaults__'))
         for task in tasks:

--- a/amlb/resources.py
+++ b/amlb/resources.py
@@ -4,6 +4,7 @@ as well as handy methods to access other resources like *automl frameworks* and 
 """
 import copy
 import logging
+import openml
 import os
 import random
 import re
@@ -165,34 +166,48 @@ class Resources:
     # @memoize
     def benchmark_definition(self, name, defaults=None):
         """
-        :param name: name of the benchmark as defined by resources/benchmarks/{name}.yaml or the path to a user-defined benchmark description file.
+        :param name: name of the benchmark as defined by resources/benchmarks/{name}.yaml, the path to a user-defined benchmark description file or a study id.
         :param defaults: defaults used as a base config for each task in the benchmark definition
         :return:
         """
         benchmark_name = name
-        benchmark_dir = self.config.benchmarks.definition_dir
-        if not isinstance(benchmark_dir, list):
-            benchmark_dir = [benchmark_dir]
 
-        benchmark_file = None
-        for bd in benchmark_dir:
-            bf = os.path.join(bd, "{}.yaml".format(benchmark_name))
-            if os.path.exists(bf):
-                benchmark_file = bf
-                break
+        try:
+            study_id = int(benchmark_name)
+        except ValueError:
+            study_id = None
 
-        if benchmark_file is None:
-            benchmark_file = name
-            benchmark_name, _ = os.path.splitext(os.path.basename(name))
+        if study_id:
+            study = openml.study.get_suite(study_id)
+            oml_tasks = [openml.tasks.get_task(tid, download_data=False) for tid in study.tasks]
+            oml_datasets = [openml.datasets.get_dataset(t.dataset_id, download_data=False) for t in oml_tasks]
+            tasks = [Namespace(name=d.name, description=d.description, openml_task_id=t.id) for t, d in zip(oml_tasks, oml_datasets)]
+            hard_defaults = Namespace()
+            benchmark_file = "study_{}".format(study_id)
+        else:
+            benchmark_dir = self.config.benchmarks.definition_dir
+            if not isinstance(benchmark_dir, list):
+                benchmark_dir = [benchmark_dir]
 
-        if not os.path.exists(benchmark_file):
-            # should we support s3 and check for s3 path before raising error?
-            raise ValueError("Incorrect benchmark name or path `{}`, name not available in {}.".format(name, self.config.benchmarks.definition_dir))
+            benchmark_file = None
+            for bd in benchmark_dir:
+                bf = os.path.join(bd, "{}.yaml".format(benchmark_name))
+                if os.path.exists(bf):
+                    benchmark_file = bf
+                    break
 
-        log.info("Loading benchmark definitions from %s.", benchmark_file)
-        tasks = config_load(benchmark_file)
-        hard_defaults = next((task for task in tasks if task.name == '__defaults__'), None)
-        tasks = [task for task in tasks if task is not hard_defaults]
+            if benchmark_file is None:
+                benchmark_file = name
+                benchmark_name, _ = os.path.splitext(os.path.basename(name))
+
+            if not os.path.exists(benchmark_file):
+                # should we support s3 and check for s3 path before raising error?
+                raise ValueError("Incorrect benchmark name or path `{}`, name not available in {}.".format(name, self.config.benchmarks.definition_dir))
+
+            log.info("Loading benchmark definitions from %s.", benchmark_file)
+            tasks = config_load(benchmark_file)
+            hard_defaults = next((task for task in tasks if task.name == '__defaults__'), None)
+            tasks = [task for task in tasks if task is not hard_defaults]
 
         defaults = Namespace.merge(defaults, hard_defaults, Namespace(name='__defaults__'))
         for task in tasks:

--- a/amlb/resources.py
+++ b/amlb/resources.py
@@ -4,7 +4,6 @@ as well as handy methods to access other resources like *automl frameworks* and 
 """
 import copy
 import logging
-import openml
 import os
 import random
 import re
@@ -171,7 +170,7 @@ class Resources:
         :param defaults: defaults used as a base config for each task in the benchmark definition
         :return:
         """
-        hard_defaults, tasks, benchmark_file, benchmark_name = benchmark_load(name, self.config.benchmarks.definition_dir)
+        hard_defaults, tasks, benchmark_path, benchmark_name = benchmark_load(name, self.config.benchmarks.definition_dir)
 
         defaults = Namespace.merge(defaults, hard_defaults, Namespace(name='__defaults__'))
         for task in tasks:
@@ -182,7 +181,7 @@ class Resources:
         defaults.enabled = False
         tasks.append(defaults)
         log.debug("Available task definitions:\n%s", tasks)
-        return tasks, benchmark_name, benchmark_file
+        return tasks, benchmark_name, benchmark_path
 
     def _validate_framework(self, framework):
         if framework['module'] is None:

--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -112,7 +112,8 @@ Each dataset must contain a training set and a test set. There can be multiple t
 
 ### Datasets definition
 
-A dataset definition consists in a `yaml` file listing all the task/datasets that will used for the complete benchmark.
+A dataset definition consists in a `yaml` file listing all the task/datasets that will used for the complete benchmark, 
+or as an OpenML suite.
 
 Default dataset definitions are available under folder `resources/benchmarks`.
 
@@ -154,11 +155,10 @@ The automlbenchmark application can directly consume those tasks using the follo
 ```
 where `openml_task_id` allows accessing the OpenML task at `https://www.openml.org/t/{openml_task_id}` (in this example: <https://www.openml.org/t/9910>). 
 
-
-#### OpenML studies
-
-[OpenML] studies are a collection of OpenML tasks, for example <https://www.openml.org/s/218>.
-The application doesn't directly support OpenML studies for now: they need to be converted into a proper benchmark definition file including all the tasks from the study, but we're thinking about improving this: cf. <https://github.com/openml/automlbenchmark/issues/61>.
+Alternatively, you can run the benchmark on a single OpenML task without writing a benchmark definition:
+```bash
+python runbenchmark.py randomforest openml/t/59
+```
 
 #### File datasets
 
@@ -243,6 +243,19 @@ Then the datasets can be declared in the benchmark definition file as follow:
   0. using the last column as a fallback.
 - the `folds` attribute is also optional but recommended for those datasets as the default value is `folds=10` (default amount of folds in openml datasets), so if you don't have that many folds for your custom datasets, it is better to declare it explicitly here.
 - Remote files are downloaded to the `input_dir` folder and archives are decompressed there as well, so you may want to change the value of this folder in your [custom config.yaml file](#custom-configuration) or specify it at the command line with the `-i` or `--indir` argument (by default, it points to the `~/.openml/cache` folder).
+
+#### OpenML suites
+
+[OpenML] suites are a collection of OpenML tasks, for example <https://www.openml.org/s/218>.
+You can run the benchmark on an openml suite directly, without defining the benchmark in a local file:
+```bash
+python runbenchmark.py randomforest openml/s/218
+```
+
+You can define a new OpenML suite yourself, for example through the Python API.
+[This openml-python tutorial](https://openml.github.io/openml-python/master/examples/30_extended/suites_tutorial.html#sphx-glr-examples-30-extended-suites-tutorial-py)
+explains how to build your own suite.
+An advantage of using an OpenML suite is that sharing it is easy as the suite and its datasets can be accessed through APIs in many programming languages.
 
 ### Constraints definition
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,11 +57,17 @@ Optional: create a Python3 virtual environment.
 _Those virtual environments are created internally using `python -m venv` and we encountered issues with `pip` when `venv` is used on top of a `virtualenv` environment._
 _Therefore, we rather suggest one of the method below:_ 
 
-using venv:
+using venv on Linux/macOS:
 ```bash
 python3 -m venv ./venv
 source venv/bin/activate
 # remember to call `deactivate` once you're done using the application
+```
+using venv on Windows:
+```bash
+python3 -m venv ./venv
+venv\Scripts\activate
+# remember to call `venv\Scripts\deactivate` once you're done using the application
 ```
 
 or using pyenv:
@@ -85,7 +91,7 @@ pip3 install -r requirements.txt
 To run a benchmark call the `runbenchmark.py` script with at least the following arguments:
 
 1. The AutoML framework that should be evaluated, see [frameworks.yaml](../resources/frameworks.yaml) for supported frameworks. If you want to add a framework see [HOWTO](./HOWTO.md#add-an-automl-framework).
-2. The benchmark suite to run should be one implemented in [benchmarks folder](../resources/benchmarks).
+2. The benchmark suite to run should be one implemented in [benchmarks folder](../resources/benchmarks), or an OpenML study or task (formatted as `openml/s/X` or `openml/t/Y` respectively).
 3. (Optional) The constraints applied to the benchmark as defined by default in [constraints.yaml](../resources/constraints.yaml). Default constraint is `test` (1 single fold for 10 min).
 4. (Optional) If the benchmark should be run `local` (default, tested on Linux and macOS only), in a `docker` container or on `aws` using multiple ec2 instances.
 
@@ -94,7 +100,7 @@ Examples:
 python3 runbenchmark.py 
 python3 runbenchmark.py constantpredictor
 python3 runbenchmark.py tpot test
-python3 runbenchmark.py autosklearn test -m docker
+python3 runbenchmark.py autosklearn openml/t/59 -m docker
 python3 runbenchmark.py h2oautoml validation 1h4c -m aws
 ```
 
@@ -114,9 +120,10 @@ usage: runbenchmark.py [-h] [-m {local,docker,aws}]
 positional arguments:
   framework             The framework to evaluate as defined by default in
                         resources/frameworks.yaml.
-  benchmark             The benchmark type to run as defined by default in
-                        resources/benchmarks/{benchmark}.yaml or the path to a
-                        benchmark description file. Defaults to `test`.
+  benchmark             The benchmark type to run as defined by default in resources/benchmarks/{benchmark}.yaml, 
+                        a path to a benchmark description file, or an openml suite or task. 
+                        OpenML references should be formatted as 'openml/s/X'  and 'openml/t/Y', 
+                        for studies and tasks respectively. Defaults to `test`.
   constraint            The constraint definition to use as defined by default in
                         resources/constraints.yaml. Defaults to `test`.
 
@@ -127,8 +134,9 @@ optional arguments:
                         will be running. Defaults to local.
   -t [task_id [task_id ...]], --task [task_id [task_id ...]]
                         The specific task name (as defined in the benchmark
-                        file) to run. If not provided, then all tasks from the
-                        benchmark will be run.
+                        file) to run. When an OpenML reference is used as benchmark, 
+                        the dataset name should be used instead. If not provided, 
+                        then all tasks from the benchmark will be run.
   -f [fold_num [fold_num ...]], --fold [fold_num [fold_num ...]]
                         If task is provided, the specific fold(s) to run. If
                         fold is not provided, then all folds from the task

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -34,7 +34,8 @@ frameworks:
   root_module: frameworks
 
 benchmarks:
-  definition_dir: '{root}/resources/benchmarks'
+  definition_dir:
+    - '{root}/resources/benchmarks'
   constraints_file: '{root}/resources/constraints.yaml'
   os_mem_size_mb: 2048        # the default amount of memory left to the OS when task assigned memory is computed automatically.
   os_vol_size_mb: 2048        # the default amount of volume left to the OS when task volume memory is verified.

--- a/runbenchmark.py
+++ b/runbenchmark.py
@@ -15,8 +15,8 @@ parser = argparse.ArgumentParser()
 parser.add_argument('framework', type=str,
                     help="The framework to evaluate as defined by default in resources/frameworks.yaml.")
 parser.add_argument('benchmark', type=str, nargs='?', default='test',
-                    help="The benchmark type to run as defined by default in resources/benchmarks/{benchmark}.yaml "
-                         "or the path to a benchmark description file. Defaults to `%(default)s`.")
+                    help="The benchmark type to run as defined by default in resources/benchmarks/{benchmark}.yaml, "
+                         "a path to a benchmark description file, or an openml suite ID. Defaults to `%(default)s`.")
 parser.add_argument('constraint', type=str, nargs='?', default='test',
                     help="The constraint definition to use as defined by default in resources/constraints.yaml. Defaults to `test`.")
 parser.add_argument('-m', '--mode', choices=['local', 'docker', 'aws', 'singularity'], default='local',

--- a/runbenchmark.py
+++ b/runbenchmark.py
@@ -16,13 +16,15 @@ parser.add_argument('framework', type=str,
                     help="The framework to evaluate as defined by default in resources/frameworks.yaml.")
 parser.add_argument('benchmark', type=str, nargs='?', default='test',
                     help="The benchmark type to run as defined by default in resources/benchmarks/{benchmark}.yaml, "
-                         "a path to a benchmark description file, or an openml suite ID. Defaults to `%(default)s`.")
+                         "a path to a benchmark description file, or an openml suite or task. OpenML references should "
+                         "be formatted as 'openml/s/X' and 'openml/t/Y', for studies and tasks respectively. Defaults to `%(default)s`.")
 parser.add_argument('constraint', type=str, nargs='?', default='test',
                     help="The constraint definition to use as defined by default in resources/constraints.yaml. Defaults to `test`.")
 parser.add_argument('-m', '--mode', choices=['local', 'docker', 'aws', 'singularity'], default='local',
                     help="The mode that specifies how/where the benchmark tasks will be running. Defaults to %(default)s.")
 parser.add_argument('-t', '--task', metavar='task_id', nargs='*', default=None,
                     help="The specific task name (as defined in the benchmark file) to run. "
+                         "When an OpenML reference is used as benchmark, the dataset name should be used instead. "
                          "If not provided, then all tasks from the benchmark will be run.")
 parser.add_argument('-f', '--fold', metavar='fold_num', type=int, nargs='*', default=None,
                     help="If task is provided, the specific fold(s) to run. "


### PR DESCRIPTION
When specifying the benchmark to run any integer name is interpreted as an openml study.
E.g. `python runbenchmark.py constantpredictor openml/s/218`.

An unnecessary amount of meta-data is still downloaded, which is (mostly) due to openml tasks not having the associated dataset name. 

I'm looking for feedback. For example:
 - Allowing a study id instead of benchmark name seems natural to me, but do you foresee problems? The only thing I can think of is 
 - I think I found the best place to do the conversion, but is there a better spot?
 - I am not entirely sure why the `Namespace` are used, but I simply adopted it. Does this seem reasonable?

Related to #61. However uses the study directly instead of writing to intermediate file. 

If approved I'll add/update docs.