### PR TITLE
upgrade liac-arff, older version prevents correct parsing since openml upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3>=1.9,<2.0
-liac-arff==2.3
+liac-arff>=2.4,<3.0
 numpy>=1.15,<2.0
 pandas>=0.23,<1.0
 psutil>=5.4,<6.0


### PR DESCRIPTION
blocker for new users running app locally on `master` branch (aws and docker modes don't use `master` branch by default, so got undetected).