### PR TITLE
update mljar-supervised version to 0.6.0

### DIFF
--- a/resources/frameworks.yaml
+++ b/resources/frameworks.yaml
@@ -114,7 +114,7 @@ TPOT:
 #    verbosity: 2
 
 mljarsupervised:
-  version: '0.5.5'
+  version: '0.6.0'
   project: https://github.com/mljar/mljar-supervised
   params:
     mode: "Compete"   # set mode for Compete, default mode is Explain


### PR DESCRIPTION
Updating mljar-supervised version to 0.6.0. Is there an option to use the latest version from github or pypi?