### PR TITLE
Allow custom metrics to be reported in results

### DIFF
--- a/amlb/results.py
+++ b/amlb/results.py
@@ -329,8 +329,6 @@ class Result:
             # as a scikit-learn scorer), and once in the amlb-compatible format.
             # The amlb-compatible format is marked with a trailing underscore.
             custom_metric = get_extension(rconfig().extensions_files, f"{metric}_")
-            if custom_metric is None:
-                custom_metric = get_extension(rconfig().extensions_files, metric)
             if custom_metric is not None:
                 return custom_metric(self)
         # raise ValueError("Metric {metric} is not supported for {type}.".format(metric=metric, type=self.type))

--- a/amlb/results.py
+++ b/amlb/results.py
@@ -17,6 +17,7 @@ from .data import Dataset, DatasetType, Feature
 from .datautils import accuracy_score, confusion_matrix, f1_score, log_loss, balanced_accuracy_score, mean_absolute_error, mean_squared_error, mean_squared_log_error, r2_score, roc_auc_score, read_csv, write_csv, is_data_frame, to_data_frame
 from .resources import get as rget, config as rconfig, output_dirs
 from .utils import Namespace, backup_file, cached, datetime_iso, memoize, profile
+from frameworks.shared.callee import get_extension
 
 log = logging.getLogger(__name__)
 
@@ -323,6 +324,15 @@ class Result:
     def evaluate(self, metric):
         if hasattr(self, metric):
             return getattr(self, metric)()
+        else:
+            # A metric may be defined twice, once for the automl system to use (e.g.
+            # as a scikit-learn scorer), and once in the amlb-compatible format.
+            # The amlb-compatible format is marked with a trailing underscore.
+            custom_metric = get_extension(rconfig().extensions_files, f"{metric}_")
+            if custom_metric is None:
+                custom_metric = get_extension(rconfig().extensions_files, metric)
+            if custom_metric is not None:
+                return custom_metric(self)
         # raise ValueError("Metric {metric} is not supported for {type}.".format(metric=metric, type=self.type))
         log.warning("Metric %s is not supported for %s!", metric, self.type)
         return nan


### PR DESCRIPTION
As far as I could tell, the custom metric could be used for optimization, but was never reported.
I set up a separate branch because I wasn't sure if this was correct (maybe I misinterpreted the documentation on the pr).

In general, we can expect AutoML frameworks to expect different signatures for their metric function. For example, TPOT requires a scikit-learn scorer: 
```python
from sklearn.metrics import make_scorer

# Make a custom metric function
def my_custom_accuracy(y_true, y_pred):
    y_true = y_true.ravel()  # amlb provides a (N,1)-vector but we need (N,)
    y_pred = y_pred.ravel()  # probably not required
    score = float(sum(y_pred == y_true)) / len(y_true)
    return score

# Make a custom a scorer from the custom metric function
foo = make_scorer(my_custom_accuracy, greater_is_better=True)
```
However we want a uniform signature for our own score calculations. So in addition to defining the custom metric for the automl framework(s), one needs to be defined for the automl benchmark. This be a function with the same name as the metric, but with a trailing underscore. The signature is `Callable[[amlb.results.Result], float]`:

```python
def foo_(result):
    return my_custom_accuracy(result.truth, result.predictions)
```
This provides the user with `result.truth`, `result.predictions` and, if applicable, `result.probabilities`.