### PR TITLE
Remove relative or unused imports, extra newlines

### DIFF
--- a/amlb/__init__.py
+++ b/amlb/__init__.py
@@ -2,14 +2,14 @@
 amlb entrypoint package.
 """
 
-from .logger import app_logger as log
-from .errors import AutoMLError
-from .resources import Resources
-from .benchmark import Benchmark, SetupMode
-from .docker import DockerBenchmark
-from .singularity import SingularityBenchmark
-from .aws import AWSBenchmark, AWSRemoteBenchmark
-from .results import TaskResult
+from amlb.logger import app_logger as log
+from amlb.errors import AutoMLError
+from amlb.resources import Resources
+from amlb.benchmark import Benchmark, SetupMode
+from amlb.docker import DockerBenchmark
+from amlb.singularity import SingularityBenchmark
+from amlb.aws import AWSBenchmark, AWSRemoteBenchmark
+from amlb.results import TaskResult
 
 __all__ = [
     "log",

--- a/amlb/aws.py
+++ b/amlb/aws.py
@@ -31,13 +31,13 @@ from urllib.parse import quote_plus as uenc
 import boto3
 import botocore.exceptions
 
-from .benchmark import Benchmark, SetupMode
-from .datautils import read_csv, write_csv
-from .docker import DockerBenchmark
-from .job import Job
-from .resources import config as rconfig, get as rget
-from .results import ErrorResult, Scoreboard, TaskResult
-from .utils import Namespace as ns, datetime_iso, file_filter, flatten, list_all_files, normalize_path, str_def, tail, touch
+from amlb.benchmark import Benchmark, SetupMode
+from amlb.datautils import read_csv, write_csv
+from amlb.docker import DockerBenchmark
+from amlb.job import Job
+from amlb.resources import config as rconfig, get as rget
+from amlb.results import ErrorResult, Scoreboard, TaskResult
+from amlb.utils import Namespace as ns, datetime_iso, file_filter, flatten, list_all_files, normalize_path, str_def, tail, touch
 
 
 log = logging.getLogger(__name__)
@@ -1051,4 +1051,3 @@ class AWSRemoteBenchmark(Benchmark):
 
     def _upload_results(self):
         pass
-

--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -15,12 +15,12 @@ import logging
 import math
 import os
 
-from .job import Job, SimpleJobRunner, MultiThreadingJobRunner, ThreadPoolExecutorJobRunner, ProcessPoolExecutorJobRunner
-from .datasets import DataLoader, DataSourceType
-from .data import DatasetType
-from .resources import get as rget, config as rconfig, output_dirs as routput_dirs
-from .results import ErrorResult, Scoreboard, TaskResult
-from .utils import Namespace as ns, OSMonitoring, as_list, datetime_iso, flatten, lazy_property, profile, repr_def, \
+from amlb.job import Job, SimpleJobRunner, MultiThreadingJobRunner
+from amlb.datasets import DataLoader, DataSourceType
+from amlb.data import DatasetType
+from amlb.resources import get as rget, config as rconfig, output_dirs as routput_dirs
+from amlb.results import ErrorResult, Scoreboard, TaskResult
+from amlb.utils import Namespace as ns, OSMonitoring, as_list, datetime_iso, flatten, lazy_property, profile, repr_def, \
     run_cmd, run_script, str2bool, system_cores, system_memory_mb, system_volume_mb, touch
 
 
@@ -421,4 +421,3 @@ class BenchmarkTask:
         meta_result = meta_result or {}
         meta_result['params'] = task_config.framework_params
         return results.compute_scores(framework_name, task_config.metrics, result=result, meta_result=meta_result)
-

--- a/amlb/benchmarks/parser.py
+++ b/amlb/benchmarks/parser.py
@@ -1,7 +1,7 @@
 from typing import List
 
-from .openml import is_openml_benchmark, load_oml_benchmark
-from .file import load_file_benchmark
+from amlb.benchmarks.openml import is_openml_benchmark, load_oml_benchmark
+from amlb.benchmarks.file import load_file_benchmark
 
 
 def benchmark_load(name, benchmark_definition_dirs: List[str]):

--- a/amlb/container.py
+++ b/amlb/container.py
@@ -6,14 +6,13 @@ providing the same parameters and features allowing to import config and export 
 """
 from abc import abstractmethod
 import logging
-import os
 import re
 
-from .benchmark import Benchmark, SetupMode
-from .errors import InvalidStateError
-from .job import Job
-from .resources import config as rconfig, get as rget
-from .utils import dir_of, run_cmd
+from amlb.benchmark import Benchmark, SetupMode
+from amlb.errors import InvalidStateError
+from amlb.job import Job
+from amlb.resources import config as rconfig, get as rget
+from amlb.utils import run_cmd
 
 
 log = logging.getLogger(__name__)

--- a/amlb/data.py
+++ b/amlb/data.py
@@ -11,7 +11,7 @@
 - **Feature** provides metadata for a given feature/column as well as encoding functions.
 """
 from abc import ABC, abstractmethod
-from enum import Enum, auto
+from enum import Enum
 import logging
 from typing import List
 
@@ -224,4 +224,3 @@ class Dataset(ABC):
         self.train.release()
         self.test.release()
         clear_cache(self, properties)
-

--- a/amlb/datasets/__init__.py
+++ b/amlb/datasets/__init__.py
@@ -1,7 +1,7 @@
 from enum import Enum, auto
 
-from .file import FileLoader
-from .openml import OpenmlLoader
+from amlb.datasets.file import FileLoader
+from amlb.datasets.openml import OpenmlLoader
 
 
 class DataSourceType(Enum):

--- a/amlb/datasets/file.py
+++ b/amlb/datasets/file.py
@@ -8,12 +8,12 @@ from typing import List, Union
 import arff
 import numpy as np
 
-from ..data import Dataset, DatasetType, Datasplit, Feature
-from ..datautils import read_csv, to_data_frame
-from ..resources import get as rget
-from ..utils import Namespace, as_list, cached, lazy_property, list_all_files, profile
+from amlb.data import Dataset, DatasetType, Datasplit, Feature
+from amlb.datautils import read_csv, to_data_frame
+from amlb.resources import get as rget
+from amlb.utils import Namespace, as_list, cached, lazy_property, list_all_files, profile
 
-from .fileutils import *
+from amlb.datasets.fileutils import *
 
 
 log = logging.getLogger(__name__)

--- a/amlb/datasets/fileutils.py
+++ b/amlb/datasets/fileutils.py
@@ -4,10 +4,10 @@ import shutil
 import tarfile
 from urllib.error import URLError
 from urllib.parse import urlparse
-from urllib.request import Request, urlopen, urlretrieve
+from urllib.request import Request, urlopen
 import zipfile
 
-from ..utils import touch
+from amlb.utils import touch
 
 log = logging.getLogger(__name__)
 
@@ -52,4 +52,3 @@ def unarchive_file(path, dest_folder=None):
         with tarfile.open(path) as tf:
             tf.extractall(path=dest_folder)
     return dest
-

--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -10,8 +10,8 @@ import openml as oml
 import arff
 import numpy as np
 
-from ..data import Dataset, DatasetType, Datasplit, Feature
-from ..utils import lazy_property, obj_size, profile, to_mb
+from amlb.data import Dataset, DatasetType, Datasplit, Feature
+from amlb.utils import lazy_property, profile
 
 
 log = logging.getLogger(__name__)
@@ -219,5 +219,3 @@ def _save_split_set(path, name, full_dataset=None, indexes=None):
             'attributes': full_dataset['attributes'],
             'data': split_data
         }, file)
-
-

--- a/amlb/datautils.py
+++ b/amlb/datautils.py
@@ -14,10 +14,9 @@ import arff
 import numpy as np
 import pandas as pd
 from sklearn.base import TransformerMixin
-from sklearn.metrics import accuracy_score, confusion_matrix, f1_score, log_loss, balanced_accuracy_score, mean_absolute_error, mean_squared_error, mean_squared_log_error, r2_score, roc_auc_score  # just aliasing
 from sklearn.preprocessing import LabelEncoder, LabelBinarizer, OneHotEncoder
 
-from .utils import profile, path_from_split, split_path, touch
+from amlb.utils import profile, path_from_split, split_path, touch
 
 try:
     from sklearn.preprocessing import OrdinalEncoder    # from sklearn 0.20
@@ -295,4 +294,3 @@ def impute(X_fit, *X_s, missing_values=np.NaN, strategy='mean'):
         return result
     else:
         return imputed
-

--- a/amlb/docker.py
+++ b/amlb/docker.py
@@ -8,9 +8,9 @@ import logging
 import os
 import re
 
-from .container import ContainerBenchmark
-from .resources import config as rconfig, get as rget
-from .utils import dir_of, run_cmd, touch
+from amlb.container import ContainerBenchmark
+from amlb.resources import config as rconfig
+from amlb.utils import dir_of, run_cmd, touch
 
 
 log = logging.getLogger(__name__)

--- a/amlb/job.py
+++ b/amlb/job.py
@@ -6,16 +6,15 @@
   - SimpleJobRunner runs the jobs sequentially.
   - ParallelJobRunner queues the jobs and run them in a dedicated thread
 """
-from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 from enum import Enum, auto
 import logging
-import multiprocessing
 import queue
 import signal
 import threading
 import time
 
-from .utils import Namespace, Timer, InterruptTimeout, raise_in_thread, signal_handler
+from amlb.utils import Namespace, Timer, InterruptTimeout, raise_in_thread, signal_handler
 
 log = logging.getLogger(__name__)
 
@@ -228,4 +227,3 @@ class ThreadPoolExecutorJobRunner(ExecutorJobRunner):
 class ProcessPoolExecutorJobRunner(ExecutorJobRunner):
     def __init__(self, jobs, parallel_jobs):
         super().__init__(ProcessPoolExecutor, jobs, parallel_jobs)
-

--- a/amlb/resources.py
+++ b/amlb/resources.py
@@ -11,7 +11,7 @@ import sys
 
 from amlb.benchmarks.parser import benchmark_load
 from amlb.framework_definitions import load_framework_definitions
-from .utils import Namespace, config_load, lazy_property, memoize, normalize_path, touch
+from amlb.utils import Namespace, config_load, lazy_property, memoize, normalize_path, touch
 
 
 log = logging.getLogger(__name__)
@@ -229,4 +229,3 @@ def output_dirs(root, session=None, subdirs=None, create=False):
         if create and not os.path.exists(dirs[d]):
             touch(dirs[d], as_dir=True)
     return dirs
-

--- a/amlb/results.py
+++ b/amlb/results.py
@@ -13,11 +13,13 @@ import statistics
 import numpy as np
 from numpy import nan, sort
 import pandas as pd
+from sklearn.metrics import accuracy_score, confusion_matrix, f1_score, log_loss, balanced_accuracy_score, mean_absolute_error, mean_squared_error, mean_squared_log_error, r2_score, roc_auc_score
 
-from .data import Dataset, DatasetType, Feature
-from .datautils import accuracy_score, confusion_matrix, f1_score, log_loss, balanced_accuracy_score, mean_absolute_error, mean_squared_error, mean_squared_log_error, r2_score, roc_auc_score, read_csv, write_csv, is_data_frame, to_data_frame
-from .resources import get as rget, config as rconfig, output_dirs
-from .utils import Namespace, backup_file, cached, datetime_iso, memoize, profile
+
+from amlb.datautils import read_csv, write_csv, is_data_frame, to_data_frame
+from amlb.data import Dataset, DatasetType, Feature
+from amlb.resources import get as rget, config as rconfig, output_dirs
+from amlb.utils import Namespace, backup_file, cached, datetime_iso, memoize, profile
 
 log = logging.getLogger(__name__)
 

--- a/amlb/singularity.py
+++ b/amlb/singularity.py
@@ -9,9 +9,9 @@ import logging
 import os
 import re
 
-from .container import ContainerBenchmark
-from .resources import config as rconfig, get as rget
-from .utils import dir_of, run_cmd, touch
+from amlb.container import ContainerBenchmark
+from amlb.resources import config as rconfig, get as rget
+from amlb.utils import dir_of, run_cmd, touch
 
 
 log = logging.getLogger(__name__)

--- a/amlb/utils/__init__.py
+++ b/amlb/utils/__init__.py
@@ -8,10 +8,10 @@ important
     and should have no dependency to any other **amlb** module.
 """
 
-from .cache import *
-from .config import *
-from .core import *
-from .modules import *
-from .os import *
-from .process import *
-from .time import *
+from amlb.utils.cache import *
+from amlb.utils.config import *
+from amlb.utils.core import *
+from amlb.utils.modules import *
+from amlb.utils.os import *
+from amlb.utils.process import *
+from amlb.utils.time import *

--- a/amlb/utils/cache.py
+++ b/amlb/utils/cache.py
@@ -73,5 +73,3 @@ def lazy_property(prop_fn):
         return cache(self, prop_name, prop_fn)
 
     return decorator
-
-

--- a/amlb/utils/config.py
+++ b/amlb/utils/config.py
@@ -3,8 +3,8 @@ import os
 
 from ruamel import yaml
 
-from .core import Namespace, json_load
-from .os import normalize_path
+from amlb.utils.core import Namespace, json_load
+from amlb.utils.os import normalize_path
 
 log = logging.getLogger(__name__)
 
@@ -43,4 +43,3 @@ def config_load(path, verbose=False):
     log.log(logging.INFO if verbose else logging.DEBUG, "Loading config file `%s`.", path)
     with open(path, 'r') as file:
         return loader(file, as_namespace=True)
-

--- a/amlb/utils/core.py
+++ b/amlb/utils/core.py
@@ -1,6 +1,6 @@
 from ast import literal_eval
 from collections.abc import Iterable
-from functools import reduce, wraps
+from functools import reduce
 import json
 import logging
 import pprint
@@ -269,4 +269,3 @@ def json_dumps(o, style='default'):
         return json.encoder.JSONEncoder.default(None, o)
 
     return json.dumps(o, indent=indent, separators=separators, default=default_encode)
-

--- a/amlb/utils/modules.py
+++ b/amlb/utils/modules.py
@@ -18,4 +18,3 @@ def pip_install(module_or_requirements, is_requirements=False):
     except SystemExit as se:
         log.error("Error when trying to install python modules %s.", module_or_requirements)
         log.exception(se)
-

--- a/amlb/utils/os.py
+++ b/amlb/utils/os.py
@@ -7,8 +7,8 @@ import shutil
 import tempfile
 import zipfile
 
-from .core import Namespace
-from .time import datetime_iso
+from amlb.utils.core import Namespace
+from amlb.utils.time import datetime_iso
 
 log = logging.getLogger(__name__)
 
@@ -151,6 +151,3 @@ class TmpDir:
 
     def __exit__(self, *args):
         shutil.rmtree(self.tmp_dir)
-        # pass
-
-

--- a/amlb/utils/process.py
+++ b/amlb/utils/process.py
@@ -1,7 +1,6 @@
 from concurrent.futures import ThreadPoolExecutor
-from functools import reduce, wraps
+from functools import wraps
 import inspect
-import io
 import logging
 import multiprocessing as mp
 import os
@@ -13,14 +12,12 @@ import stat
 import subprocess
 import sys
 import threading
-import _thread
-import traceback
 
 import psutil
 
-from .core import Namespace, as_list, flatten, fn_name
-from .os import dir_of, to_mb
-from .time import Timeout, Timer
+from amlb.utils.core import Namespace, as_list, flatten, fn_name
+from amlb.utils.os import dir_of, to_mb
+from amlb.utils.time import Timeout, Timer
 
 log = logging.getLogger(__name__)
 
@@ -536,6 +533,3 @@ def profile(logger=log, log_level=None, duration=True, memory=True):
         return profiler
 
     return decorator
-
-
-

--- a/amlb/utils/time.py
+++ b/amlb/utils/time.py
@@ -83,5 +83,3 @@ class Timeout:
     def __exit__(self, *args):
         if self.timer:
             self.timer.cancel()
-
-


### PR DESCRIPTION
It allows submodules to be imported, which avoids #175 behavior.

Also removed unused imports and any superfluous newlines at the end of files.

@sebhrusen  I was a bit confused about `amlb.dateutils` importing [sklearn metrics](https://github.com/openml/automlbenchmark/blob/74e532211ef119e279ce6453bb0f5daa5c2f7910/amlb/datautils.py#L17) which were unused in the module itself. They were then subsequently imported from `amlb.dateutils` by [`amlb.results`](https://github.com/openml/automlbenchmark/blob/74e532211ef119e279ce6453bb0f5daa5c2f7910/amlb/results.py#L18). I assume just importing from `sklearn.metrics` in the `amlb.results` module itself doesn't hurt anything? And that the old import is just some legacy stuff.
