### PR TITLE
Fix module loading

### DIFF
--- a/amlb/framework_definitions.py
+++ b/amlb/framework_definitions.py
@@ -60,7 +60,7 @@ def _add_and_normalize_names(frameworks: Namespace):
     framework_names = dir(frameworks)
     for name in framework_names:
         framework = frameworks[name]
-        framework.name = name.lower()
+        framework.name = name
         if name.lower() != name:
             del frameworks[name]
             frameworks[name.lower()] = framework

--- a/amlb/framework_definitions.py
+++ b/amlb/framework_definitions.py
@@ -56,10 +56,8 @@ def _sanitize_and_add_defaults(frameworks, resource):
 
 
 def _add_framework_name(frameworks: Namespace):
-    """ Converts each framework definition to lowercase and adds a 'name' field. """
-    framework_names = dir(frameworks)
-    for name in framework_names:
-        framework = frameworks[name]
+    """ Adds a 'name' attribute to each framework. """
+    for name, framework in frameworks:
         framework.name = name
 
 

--- a/amlb/framework_definitions.py
+++ b/amlb/framework_definitions.py
@@ -36,7 +36,7 @@ def _load_and_merge_framework_definitions(frameworks_file: Union[str, List[str]]
 
 def _sanitize_definitions(frameworks: Namespace):
     """ Normalize names, add name field, remove invalid extensions. """
-    _add_and_normalize_names(frameworks)
+    _add_framework_name(frameworks)
     _remove_frameworks_with_unknown_parent(frameworks)
     _remove_self_reference_extensions(frameworks)
 
@@ -55,17 +55,12 @@ def _sanitize_and_add_defaults(frameworks, resource):
     _add_defaults_to_frameworks(frameworks, resource)
 
 
-def _add_and_normalize_names(frameworks: Namespace):
+def _add_framework_name(frameworks: Namespace):
     """ Converts each framework definition to lowercase and adds a 'name' field. """
     framework_names = dir(frameworks)
     for name in framework_names:
         framework = frameworks[name]
         framework.name = name
-        if name.lower() != name:
-            del frameworks[name]
-            frameworks[name.lower()] = framework
-        if "extends" in framework:
-            framework.extends = framework.extends.lower()
 
 
 def _add_default_module(framework, config):

--- a/amlb/resources.py
+++ b/amlb/resources.py
@@ -81,7 +81,8 @@ class Resources:
         :param name:
         :return: name of the framework as defined in the frameworks definition file
         """
-        framework = self._frameworks[name.lower()]
+        lname = name.lower()
+        framework = next((f for n, f in self._frameworks if n.lower() == lname), None)
         if not framework:
             raise ValueError("Incorrect framework `{}`: not listed in {}.".format(name, self.config.frameworks.definition_file))
         return framework, framework.name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ def simple_resource():
             ),
             frameworks=Namespace(
                 root_module="frameworks",
+                definition_file=[]
             )
         )
     )

--- a/tests/unit/amlb/framework_definitions/test_framework_definition_processing.py
+++ b/tests/unit/amlb/framework_definitions/test_framework_definition_processing.py
@@ -1,7 +1,7 @@
 import pytest
 from amlb.utils import Namespace
 from amlb.framework_definitions import _sanitize_and_add_defaults, \
-    _add_and_normalize_names, _find_all_parents, \
+    _add_framework_name, _find_all_parents, \
     _update_frameworks_with_parent_definitions, _remove_self_reference_extensions, \
     _remove_frameworks_with_unknown_parent
 
@@ -34,31 +34,18 @@ def test_remove_self_reference_extensions_does_not_remove_reference_to_other():
     assert f.dummy.extends is "some_other_framework"
 
 
-def test_add_and_normalize_names_adds_name():
+def test_add_framework_name_adds_name_attribute_to_framework_definition():
     f = Namespace(dummy=Namespace())
-    _add_and_normalize_names(f)
+    _add_framework_name(f)
     assert "name" in f.dummy
     assert f.dummy.name == "dummy"
 
 
-def test_add_and_normalize_names_keeps_original_name_as_framework_attribute():
+def test_add_framework_name_does_not_change_name_case():
     f = Namespace(Dummy=Namespace())
-    _add_and_normalize_names(f)
-    assert "dummy" in f, "The 'Dummy' entry should be in all lower case."
-    assert f.dummy.name == "Dummy"
-
-
-def test_add_and_normalize_names_uses_lowercase_name_as_lookup_key():
-    f = Namespace(Dummy=Namespace())
-    _add_and_normalize_names(f)
-    assert "Dummy" not in f, "The old name should be invalid."
-    assert "dummy" in f, "The lower case name is available for lookup."
-
-
-def test_add_and_normalize_names_extension_is_normalized():
-    f = Namespace(dummy=Namespace(extends="AnotherDummy"))
-    _add_and_normalize_names(f)
-    assert f.dummy.extends == "anotherdummy"
+    _add_framework_name(f)
+    assert "Dummy" in f
+    assert f.Dummy.name == "Dummy"
 
 
 def test_find_all_parents_returns_empty_list_if_framework_has_no_parent():

--- a/tests/unit/amlb/framework_definitions/test_framework_definition_processing.py
+++ b/tests/unit/amlb/framework_definitions/test_framework_definition_processing.py
@@ -41,17 +41,18 @@ def test_add_and_normalize_names_adds_name():
     assert f.dummy.name == "dummy"
 
 
-def test_add_and_normalize_names_converts_name_to_lower_case():
+def test_add_and_normalize_names_keeps_original_name_as_framework_attribute():
     f = Namespace(Dummy=Namespace())
     _add_and_normalize_names(f)
     assert "dummy" in f, "The 'Dummy' entry should be in all lower case."
-    assert f.dummy.name == "dummy"
+    assert f.dummy.name == "Dummy"
 
 
-def test_add_and_normalize_names_original_removed_for_normalized_framework():
+def test_add_and_normalize_names_uses_lowercase_name_as_lookup_key():
     f = Namespace(Dummy=Namespace())
     _add_and_normalize_names(f)
     assert "Dummy" not in f, "The old name should be invalid."
+    assert "dummy" in f, "The lower case name is available for lookup."
 
 
 def test_add_and_normalize_names_extension_is_normalized():

--- a/tests/unit/amlb/resources/test_framework_definition.py
+++ b/tests/unit/amlb/resources/test_framework_definition.py
@@ -3,22 +3,20 @@ from amlb.resources import Resources
 from amlb.utils import Namespace as NS
 
 
-def test_framework_definition_lookup_is_case_insensitive():
-    res = NS(
-        _frameworks=NS(
-            lower=NS(name="lower"),
-            UPPER=NS(name="UPPER"),
-            Camel=NS(name="CaMel")
-        )
-    )
+@pytest.mark.parametrize(
+    "frameworks, lookup, expected",
+    [
+        (NS(MixedCase=NS(name="MixedCase")), "MixedCase", "MixedCase"),
+        (NS(MixedCase=NS(name="MixedCase")), "mixedcase", "MixedCase"),
+        (NS(MixedCase=NS(name="MixedCase")), "MIXEDCASE", "MixedCase"),
+        (NS(MixedCase=NS(name="MixedCase")), "mIxEdCasE", "MixedCase"),
+    ]
+)
+def test_framework_definition_lookup_is_case_insensitive(frameworks, lookup, expected):
+    res = NS(_frameworks=frameworks)
     # binding `framework_definition` method to our resource mock: use pytest-mock instead?
     res.framework_definition = Resources.framework_definition.__get__(res)
-
-    assert res.framework_definition("lower") == (res._frameworks.lower, "lower")
-    assert res.framework_definition("upper") == (res._frameworks.UPPER, "UPPER")
-    assert res.framework_definition("camel") == (res._frameworks.Camel, "CaMel")
-    assert res.framework_definition("CAMEL") == (res._frameworks.Camel, "CaMel")
-    assert res.framework_definition("Camel") == (res._frameworks.Camel, "CaMel")
+    assert res.framework_definition(lookup) == (frameworks[expected], frameworks[expected].name)
 
 
 def test_framework_definition_raises_error_if_no_matching_framework():

--- a/tests/unit/amlb/resources/test_framework_definition.py
+++ b/tests/unit/amlb/resources/test_framework_definition.py
@@ -1,0 +1,33 @@
+import pytest
+from amlb.resources import Resources
+from amlb.utils import Namespace as NS
+
+
+def test_framework_definition_lookup_is_case_insensitive():
+    res = NS(
+        _frameworks=NS(
+            lower=NS(name="lower"),
+            UPPER=NS(name="UPPER"),
+            Camel=NS(name="CaMel")
+        )
+    )
+    # binding `framework_definition` method to our resource mock: use pytest-mock instead?
+    res.framework_definition = Resources.framework_definition.__get__(res)
+
+    assert res.framework_definition("lower") == (res._frameworks.lower, "lower")
+    assert res.framework_definition("upper") == (res._frameworks.UPPER, "UPPER")
+    assert res.framework_definition("camel") == (res._frameworks.Camel, "CaMel")
+    assert res.framework_definition("CAMEL") == (res._frameworks.Camel, "CaMel")
+    assert res.framework_definition("Camel") == (res._frameworks.Camel, "CaMel")
+
+
+def test_framework_definition_raises_error_if_no_matching_framework():
+    res = NS(
+        config=NS(frameworks=NS(definition_file="none")),
+        _frameworks=NS(present=NS(name="present"))
+    )
+    # binding `framework_definition` method to our resource mock: use pytest-mock instead?
+    res.framework_definition = Resources.framework_definition.__get__(res)
+    assert res.framework_definition("present")
+    with pytest.raises(ValueError, match=r"Incorrect framework `missing`"):
+        res.framework_definition("missing")


### PR DESCRIPTION
module name was forced to lowercase by default, preventing correct loading

```
python runbenchmark.py autogluon
Running `autogluon` on `test` benchmarks in `local` mode.
...
No module named 'frameworks.autogluon'
Traceback (most recent call last):
  File "runbenchmark.py", line 111, in <module>
    bench = amlb.Benchmark(args.framework, args.benchmark, args.constraint)
  File "/Users/seb/repos/ml/automlbenchmark/amlb/benchmark.py", line 78, in __init__
    self.framework_module = import_module(self.framework_def.module)
  File "/Users/seb/.pyenv/versions/3.7.6/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 965, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'frameworks.autogluon'
```