### PR TITLE
Ensure the image name is all lower case

### DIFF
--- a/amlb/framework_definitions.py
+++ b/amlb/framework_definitions.py
@@ -130,7 +130,7 @@ def _add_default_image(framework: Namespace, config: Namespace):
         framework.image.tag = framework.version.lower()
 
     if framework.image.image is None:
-        framework.image.image = framework.name
+        framework.image.image = framework.name.lower()
 
     if framework.image.author is None:
         framework.image.author = ""

--- a/tests/unit/amlb/framework_definitions/test_add_default.py
+++ b/tests/unit/amlb/framework_definitions/test_add_default.py
@@ -202,9 +202,9 @@ def test_image_uses_default_image(simple_resource):
     assert framework.image.image == "img"
 
 
-def test_image_uses_framework_name_if_no_default_image(simple_resource):
+def test_image_uses_lowercase_framework_name_if_no_default_image(simple_resource):
     simple_resource.config.docker.image_defaults.image = None
-    framework = Namespace(name="decision_tree", version="v0.1")
+    framework = Namespace(name="Decision_tree", version="v0.1")
     _add_default_image(framework, simple_resource.config)
     assert framework.image.image == "decision_tree"
 


### PR DESCRIPTION
This is required for docker images.

(Issue identified by @mwever in #179)
