### PR TITLE
Run 2 folds by default when using (default) test constraint

### DIFF
--- a/resources/constraints.yaml
+++ b/resources/constraints.yaml
@@ -1,7 +1,7 @@
 ---
 
 test:
-  folds: 1
+  folds: 2
   max_runtime_seconds: 600
   cores: 4
 


### PR DESCRIPTION
run 2 folds by default in test mode to ensure that all rows from the dataset get through the training process