### PR TITLE
add cpu, memory and swap limits to docker run

### DIFF
--- a/amlb/runners/docker.py
+++ b/amlb/runners/docker.py
@@ -52,11 +52,11 @@ class DockerBenchmark(ContainerBenchmark):
         script_extra_params = ""
         inst_name = self.sid
 
-        if "max_mem_size_mb" in self.constraint_def:
-            memory = "--memory={}m".format(self.constraint_def['max_mem_size_mb'])
-            memory += " " + "--memory-swap={}g".format(2 * float(self.constraint_def['max_mem_size_mb']) / 1024)
-        else:
-            memory = ""
+        memory = ""
+        if rconfig().docker.constraints_enabled:
+            if "max_mem_size_mb" in self.constraint_def:
+                memory = "--memory={}m".format(self.constraint_def['max_mem_size_mb'])
+                memory += " " + "--memory-swap={}".format(self.constraint_def['swap'])
 
         cmd = (
             "docker run --name {name} {options} "

--- a/amlb/runners/docker.py
+++ b/amlb/runners/docker.py
@@ -51,9 +51,17 @@ class DockerBenchmark(ContainerBenchmark):
             touch(d, as_dir=True)
         script_extra_params = ""
         inst_name = self.sid
+
+        if "max_mem_size_mb" in self.constraint_def:
+            memory = "--memory={}m".format(self.constraint_def['max_mem_size_mb'])
+            memory += " " + "--memory-swap={}g".format(2 * float(self.constraint_def['max_mem_size_mb']) / 1024)
+        else:
+            memory = ""
+
         cmd = (
             "docker run --name {name} {options} "
             "-v {input}:/input -v {output}:/output -v {custom}:/custom "
+            "{cpus} {memory} "
             "--rm {image} {params} -i /input -o /output -u /custom -s skip -Xrun_mode=docker {extra_params}"
         ).format(
             name=inst_name,
@@ -64,6 +72,8 @@ class DockerBenchmark(ContainerBenchmark):
             image=self._image_name,
             params=script_params,
             extra_params=script_extra_params,
+            cpus="--cpus={}".format(self.constraint_def['cores']) if "cores" in self.constraint_def else "",
+            memory=memory,
         )
         log.info("Starting docker: %s.", cmd)
         log.info("Datasets are loaded by default from folder %s.", in_dir)

--- a/amlb/runners/docker.py
+++ b/amlb/runners/docker.py
@@ -52,6 +52,11 @@ class DockerBenchmark(ContainerBenchmark):
         script_extra_params = ""
         inst_name = self.sid
 
+        if ' -f ' in script_params:
+             inst_name = inst_name + '_f' + script_params.split(' -f ')[1].split()[0]
+        elif ' --fold ' in script_params:
+            inst_name = inst_name + '_f' + script_params.split(' --fold ')[1].split()[0]
+
         memory = ""
         if rconfig().docker.constraints_enabled:
             if "max_mem_size_mb" in self.constraint_def:

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -76,6 +76,8 @@ container: &container
 docker:
   <<: *container
   run_extra_options: '--shm-size=1024M'
+  constraints_enabled: false  # enable resources constraints for docker container
+  swap: '0' # --memory-swap option to docker run
 
 singularity:
   <<: *container

--- a/resources/constraints.yaml
+++ b/resources/constraints.yaml
@@ -4,27 +4,32 @@ test:
   folds: 1
   max_runtime_seconds: 600
   cores: 4
+  max_mem_size_mb: 32768
 
-1h4c:
+1h4c32g:
   folds: 10
   max_runtime_seconds: 3600
   cores: 4
+  max_mem_size_mb: 32768
 
-1h8c:
+1h8c32g:
   folds: 10
   max_runtime_seconds: 3600
   cores: 8
   min_vol_size_mb: 16384
+  max_mem_size_mb: 32768
 
-4h8c:
+4h8c32g:
   folds: 10
   max_runtime_seconds: 14400
   cores: 8
   min_vol_size_mb: 65536
+  max_mem_size_mb: 32768
 
-8h8c:
+8h8c32g:
   folds: 10
   max_runtime_seconds: 28800
   cores: 8
   min_vol_size_mb: 131072
+  max_mem_size_mb: 32768
 


### PR DESCRIPTION
The case: running multiple bencmark runs on singe machine with lots of resources