### PR TITLE
Standardize framework definitions

### DIFF
--- a/resources/frameworks.yaml
+++ b/resources/frameworks.yaml
@@ -14,38 +14,10 @@ __dummy_framework_with_defaults:
     tag:  # defaults to `framework version`
 
 
-### Non AutoML reference frameworks
-constantpredictor:
-  version: 'latest'
-  project: https://scikit-learn.org/stable/modules/generated/sklearn.dummy.DummyClassifier.html
+#########################
+### AutoML frameworks ###
+#########################
 
-constantpredictor_enc:
-  extends: constantpredictor
-  params:
-    encode: true
-
-DecisionTree:
-  version: '0.22.2'
-  project: https://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeClassifier.html
-
-RandomForest:
-  version: '0.22.2'
-  project: http://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html
-  params:
-    n_estimators: 2000
-#    _n_jobs: 1   # faster, fitter, happier (running OoM on some datasets when using multiprocessing)
-#    verbose: true
-
-TunedRandomForest:
-  version: '0.22.2'
-  project: http://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html
-  params:
-    n_estimators: 2000
-#    _n_jobs: 1  # cf. RandomForest
-#    _tuning:
-#      n_estimators: 500
-
-### AutoML frameworks
 AutoGluon:
   version: "0.0.12"
   project: https://autogluon.mxnet.io
@@ -74,15 +46,15 @@ MLPlan:
   version: '0.2.3'
   project: http://mlplan.org
 
-MLPlanWEKA:
-  extends: MLPlan
-  params:
-    _backend: weka
-
 MLPlanSKLearn:
   extends: MLPlan
   params:
     _backend: sklearn
+
+MLPlanWEKA:
+  extends: MLPlan
+  params:
+    _backend: weka
 
 autoxgboost:
   version: 'latest'
@@ -118,7 +90,7 @@ mljarsupervised_compete:
   extends: mljarsupervised
   description: "MLJar using 'Compete' mode to provide most accurate predictor"
   params:
-    mode: "Compete"   # set mode for Compete, default mode is Explain
+    mode: Compete   # set mode for Compete, default mode is Explain
 
 oboe:
   version: 'latest'
@@ -140,4 +112,43 @@ TPOT:
 #    max_eval_time_mins: 2
 #    population_size: 25
 #    verbosity: 2
+
+
+
+
+
+
+#######################################
+### Non AutoML reference frameworks ###
+#######################################
+
+constantpredictor:
+  version: 'latest'
+  project: https://scikit-learn.org/stable/modules/generated/sklearn.dummy.DummyClassifier.html
+
+constantpredictor_enc:
+  extends: constantpredictor
+  params:
+    encode: true
+
+DecisionTree:
+  version: '0.22.2'
+  project: https://scikit-learn.org/stable/modules/generated/sklearn.tree.DecisionTreeClassifier.html
+
+RandomForest:
+  version: '0.22.2'
+  project: http://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html
+  params:
+    n_estimators: 2000
+#    _n_jobs: 1   # faster, fitter, happier (running OoM on some datasets when using multiprocessing)
+#    verbose: true
+
+TunedRandomForest:
+  version: '0.22.2'
+  project: http://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html
+  params:
+    n_estimators: 2000
+#    _n_jobs: 1  # cf. RandomForest
+#    _tuning:
+#      n_estimators: 500
 

--- a/resources/frameworks.yaml
+++ b/resources/frameworks.yaml
@@ -52,9 +52,9 @@ AutoGluon:
 #  params:
 #    _save_artifacts: ['leaderboard', 'models', 'info']
 
-AutoGluon_best:
+AutoGluon_bestquality:
   extends: AutoGluon
-  description: "provides the most accurate overall predictor"
+  description: "AutoGluon with 'best_quality' preset provides the most accurate overall predictor"
   params:
     presets: best_quality
 
@@ -107,6 +107,19 @@ hyperoptsklearn:
 #    algo: hyperopt.tpe.suggest
 #    verbose: true
 
+mljarsupervised:
+  version: '0.6.0'
+  project: https://github.com/mljar/mljar-supervised
+#  params:
+#    algorithms: ["Baseline"]
+#    _save_artifacts: True
+
+mljarsupervised_compete:
+  extends: mljarsupervised
+  description: "MLJar using 'Compete' mode to provide most accurate predictor"
+  params:
+    mode: "Compete"   # set mode for Compete, default mode is Explain
+
 oboe:
   version: 'latest'
   project: https://github.com/udellgroup/oboe
@@ -128,10 +141,3 @@ TPOT:
 #    population_size: 25
 #    verbosity: 2
 
-mljarsupervised:
-  version: '0.6.0'
-  project: https://github.com/mljar/mljar-supervised
-  params:
-    mode: "Compete"   # set mode for Compete, default mode is Explain
-#    algorithms: ["Baseline"]
-#    _save_artifacts: True


### PR DESCRIPTION
- tested frameworks are now ordered alphabetically in `frameworks.yaml`.
- all framework definitions witth the (exact) name of the framework must have no param set.
- frameworks providing a high-level switch, can provide 2 definitions:
  - a default one (see above).
  - (optional) one with an extended name, with the high-level switch/param.