### PR TITLE
change file token separator from underscore to dot

### DIFF
--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -70,9 +70,16 @@ class Benchmark:
         log.debug("Using benchmark definition: %s.", self.benchmark_def)
 
         self.parallel_jobs = rconfig().parallel_jobs
-        self.sid = rconfig().sid if rconfig().sid is not None \
-            else "{}_{}".format('_'.join([framework_name, benchmark_name, constraint_name, rconfig().run_mode]).lower(),
-                                datetime_iso(micros=True, no_sep=True))
+        self.sid = (rconfig().sid if rconfig().sid is not None
+                    else rconfig().token_separator.join([
+                        rconfig().token_separator.join([
+                            framework_name,
+                            benchmark_name,
+                            constraint_name,
+                            rconfig().run_mode
+                        ]).lower(),
+                        datetime_iso(micros=True, no_sep=True)
+                    ])).replace("/", "_")
 
         self._validate()
         self.framework_module = import_module(self.framework_def.module)
@@ -375,7 +382,7 @@ class BenchmarkTask:
             return self.run(framework, framework_name)
         timeout_secs = min(self.task_config.max_runtime_seconds * 2,
                            self.task_config.max_runtime_seconds + rconfig().benchmarks.overhead_time_seconds)
-        job = Job(name='_'.join(['local', self.task_config.name, str(self.fold), framework_name]),
+        job = Job(name=rconfig().token_separator.join(['local', self.task_config.name, str(self.fold), framework_name]),
                   timeout_secs=timeout_secs)  # this timeout is just to handle edge cases where framework never completes
         job._run = _run
         return job

--- a/amlb/framework_definitions.py
+++ b/amlb/framework_definitions.py
@@ -8,27 +8,28 @@ from .utils import Namespace, config_load
 log = logging.getLogger(__name__)
 
 
-def load_framework_definitions(frameworks_file: Union[str, List[str]], resource) -> Namespace:
+def load_framework_definitions(frameworks_file: Union[str, List[str]], config: Namespace) -> Namespace:
     """ Load the framework definition listed in the framework file(s).
 
     Loads the definition(s) from the file(s),
     :param frameworks_file:
+    :param config:
     :return: Namespace containing each framework definition,
     """
-    frameworks = _load_and_merge_framework_definitions(frameworks_file, resource)
-    _sanitize_and_add_defaults(frameworks, resource)
+    frameworks = _load_and_merge_framework_definitions(frameworks_file, config)
+    _sanitize_and_add_defaults(frameworks, config)
     log.debug("Available framework definitions:\n%s", frameworks)
     return frameworks
 
 
-def _load_and_merge_framework_definitions(frameworks_file: Union[str, List[str]], resource) -> Namespace:
+def _load_and_merge_framework_definitions(frameworks_file: Union[str, List[str]], config) -> Namespace:
     """ Load and merge the framework file(s), does not allow duplicate definitions. """
     log.info("Loading frameworks definitions from %s.", frameworks_file)
     if not isinstance(frameworks_file, list):
         frameworks_file = [frameworks_file]
 
     definitions_by_file = [config_load(file) for file in frameworks_file]
-    if not resource.config.frameworks.allow_duplicates:
+    if not config.frameworks.allow_duplicates:
         for d1, d2 in itertools.combinations([set(dir(d)) for d in definitions_by_file], 2):
             if d1.intersection(d2) != set():
                 raise ValueError(f"Duplicate entry '{d1.intersection(d2).pop()}' found.")

--- a/amlb/framework_definitions.py
+++ b/amlb/framework_definitions.py
@@ -3,7 +3,7 @@ import itertools
 import logging
 from typing import Union, List
 
-from amlb.utils import Namespace, config_load
+from .utils import Namespace, config_load
 
 log = logging.getLogger(__name__)
 
@@ -15,22 +15,23 @@ def load_framework_definitions(frameworks_file: Union[str, List[str]], resource)
     :param frameworks_file:
     :return: Namespace containing each framework definition,
     """
-    frameworks = _load_and_merge_framework_definitions(frameworks_file)
+    frameworks = _load_and_merge_framework_definitions(frameworks_file, resource)
     _sanitize_and_add_defaults(frameworks, resource)
     log.debug("Available framework definitions:\n%s", frameworks)
     return frameworks
 
 
-def _load_and_merge_framework_definitions(frameworks_file: Union[str, List[str]]) -> Namespace:
+def _load_and_merge_framework_definitions(frameworks_file: Union[str, List[str]], resource) -> Namespace:
     """ Load and merge the framework file(s), does not allow duplicate definitions. """
     log.info("Loading frameworks definitions from %s.", frameworks_file)
     if not isinstance(frameworks_file, list):
         frameworks_file = [frameworks_file]
 
     definitions_by_file = [config_load(file) for file in frameworks_file]
-    for d1, d2 in itertools.combinations([set(dir(d)) for d in definitions_by_file], 2):
-        if d1.intersection(d2) != set():
-            raise ValueError(f"Duplicate entry '{d1.intersection(d2).pop()}' found.")
+    if not resource.config.frameworks.allow_duplicates:
+        for d1, d2 in itertools.combinations([set(dir(d)) for d in definitions_by_file], 2):
+            if d1.intersection(d2) != set():
+                raise ValueError(f"Duplicate entry '{d1.intersection(d2).pop()}' found.")
     return Namespace.merge(*definitions_by_file)
 
 

--- a/amlb/resources.py
+++ b/amlb/resources.py
@@ -90,7 +90,7 @@ class Resources:
     @lazy_property
     def _frameworks(self):
         frameworks_file = self.config.frameworks.definition_file
-        return load_framework_definitions(frameworks_file, self)
+        return load_framework_definitions(frameworks_file, self.config)
 
     @memoize
     def constraint_definition(self, name):

--- a/amlb/results.py
+++ b/amlb/results.py
@@ -3,6 +3,7 @@
 as well as logic to compute, format, save, read and merge scores obtained from those predictions (cf. ``Result`` and ``Scoreboard``).
 """
 from functools import partial
+import collections
 import io
 import logging
 import math
@@ -39,16 +40,17 @@ class Scoreboard:
 
     @classmethod
     def from_file(cls, path):
+        sep = rconfig().token_separator
         folder, basename = os.path.split(path)
         framework_name = None
         benchmark_name = None
         task_name = None
         patterns = [
             cls.results_file,
-            r"(?P<framework>[\w\-]+)_benchmark_(?P<benchmark>[\w\-]+)\.csv",
-            r"benchmark_(?P<benchmark>[\w\-]+)\.csv",
-            r"(?P<framework>[\w\-]+)_task_(?P<task>[\w\-]+)\.csv",
-            r"task_(?P<task>[\w\-]+)\.csv",
+            rf"(?P<framework>[\w\-]+){sep}benchmark{sep}(?P<benchmark>[\w\-]+)\.csv",
+            rf"benchmark{sep}(?P<benchmark>[\w\-]+)\.csv",
+            rf"(?P<framework>[\w\-]+){sep}task{sep}(?P<task>[\w\-]+)\.csv",
+            rf"task{sep}(?P<task>[\w\-]+)\.csv",
             r"(?P<framework>[\w\-]+)\.csv",
         ]
         found = False
@@ -102,16 +104,16 @@ class Scoreboard:
         self.framework_name = framework_name
         self.benchmark_name = benchmark_name
         self.task_name = task_name
-        self.scores_dir = scores_dir if scores_dir \
-            else output_dirs(rconfig().output_dir, rconfig().sid, ['scores']).scores
+        self.scores_dir = (scores_dir if scores_dir
+                           else output_dirs(rconfig().output_dir, rconfig().sid, ['scores']).scores)
         self.scores = scores if scores is not None else self._load()
 
     @cached
     def as_data_frame(self):
         # index = ['task', 'framework', 'fold']
         index = []
-        df = self.scores if is_data_frame(self.scores) \
-            else to_data_frame([dict(sc) for sc in self.scores])
+        df = (self.scores if is_data_frame(self.scores)
+              else to_data_frame([dict(sc) for sc in self.scores]))
         if df.empty:
             # avoid dtype conversions during reindexing on empty frame
             return df
@@ -163,18 +165,19 @@ class Scoreboard:
                           scores_dir=self.scores_dir)
 
     def _score_file(self):
+        sep = rconfig().token_separator
         if self.framework_name:
             if self.task_name:
-                file_name = "{framework}_task_{task}.csv".format(framework=self.framework_name, task=self.task_name)
+                file_name = f"{self.framework_name}{sep}task_{self.task_name}.csv"
             elif self.benchmark_name:
-                file_name = "{framework}_benchmark_{benchmark}.csv".format(framework=self.framework_name, benchmark=self.benchmark_name)
+                file_name = f"{self.framework_name}{sep}benchmark_{self.benchmark_name}.csv"
             else:
-                file_name = "{framework}.csv".format(framework=self.framework_name)
+                file_name = f"{self.framework_name}.csv"
         else:
             if self.task_name:
-                file_name = "task_{task}.csv".format(task=self.task_name)
+                file_name = f"task_{self.task_name}.csv"
             elif self.benchmark_name:
-                file_name = "benchmark_{benchmark}.csv".format(benchmark=self.benchmark_name)
+                file_name = f"benchmark_{self.benchmark_name}.csv"
             else:
                 file_name = Scoreboard.results_file
 
@@ -288,20 +291,38 @@ class TaskResult:
 
     @classmethod
     def score_from_predictions_file(cls, path):
+        sep = rconfig().token_separator
         folder, basename = os.path.split(path)
-        pattern = r"(?P<framework>[\w\-]+?)_(?P<task>[\w\-]+)_(?P<fold>\d+)(_(?P<datetime>\d{8}T\d{6}))?.csv"
-        m = re.fullmatch(pattern, basename)
-        if not m:
+        folder_g = collections.defaultdict(lambda: None)
+        if folder:
+            folder_pat = rf"/(?P<framework>[\w\-]+?){sep}(?P<benchmark>[\w\-]+){sep}(?P<constraint>[\w\-]+){sep}(?P<mode>[\w\-]+)({sep}(?P<datetime>\d{8}T\d{6}))/"
+            folder_m = re.match(folder_pat, folder)
+            if folder_m:
+                folder_g = folder_m.groupdict()
+
+        file_pat = rf"(?P<framework>[\w\-]+?){sep}(?P<task>[\w\-]+){sep}(?P<fold>\d+)\.csv"
+        file_m = re.fullmatch(file_pat, basename)
+        if not file_m:
             log.error("Predictions file `%s` has wrong naming format.", path)
             return None
 
-        d = m.groupdict()
-        framework_name = d['framework']
-        task_name = d['task']
-        fold = int(d['fold'])
+        file_g = file_m.groupdict()
+        framework_name = file_g['framework']
+        task_name = file_g['task']
+        fold = int(file_g['fold'])
+        constraint = folder_g['constraint']
+        benchmark = folder_g['benchmark']
+        task = Namespace(name=task_name, id=task_name)
+        if benchmark:
+            try:
+                tasks, _, _ = rget().benchmark_definition(benchmark)
+                task = next(t for t in tasks if t.name==task_name)
+            except:
+                pass
+
         result = cls.load_predictions(path)
-        task_result = cls(task_name, fold, '')
-        metrics = rconfig().benchmarks.metrics.get(result.type.name)
+        task_result = cls(task, fold, constraint, '')
+        metrics = rconfig().benchmarks.metrics[result.type.name]
         return task_result.compute_scores(framework_name, metrics, result=result)
 
     def __init__(self, task_def, fold: int, constraint: str, predictions_dir=None):
@@ -348,7 +369,8 @@ class TaskResult:
         return scores
 
     def _predictions_file(self, framework_name):
-        return os.path.join(self.predictions_dir, "{framework}_{task}_{fold}.csv").format(
+        return os.path.join(self.predictions_dir, "{framework}{sep}{task}{sep}{fold}.csv").format(
+            sep=rconfig().token_separator,
             framework=framework_name.lower(),
             task=self.task.name,
             fold=self.fold
@@ -398,7 +420,7 @@ class ClassificationResult(Result):
         super().__init__(predictions_df, info)
         self.classes = self.df.columns[:-2].values.astype(str, copy=False)
         self.probabilities = self.df.iloc[:, :-2].values.astype(float, copy=False)
-        self.target = Feature(0, 'class', 'categorical', self.classes, is_target=True)
+        self.target = Feature(0, 'class', 'categorical', values=self.classes, is_target=True)
         self.type = DatasetType.binary if len(self.classes) == 2 else DatasetType.multiclass
         self.truth = self._autoencode(self.truth.astype(str, copy=False))
         self.predictions = self._autoencode(self.predictions.astype(str, copy=False))

--- a/amlb/runners/aws.py
+++ b/amlb/runners/aws.py
@@ -242,12 +242,14 @@ class AWSBenchmark(Benchmark):
                         else sum([task.max_runtime_seconds for task in self.benchmark_def]))
         timeout_secs += rconfig().aws.overhead_time_seconds
 
-        job = Job('_'.join(['aws',
-                            self.benchmark_name,
-                            self.constraint_name,
-                            '.'.join(task_names) if len(task_names) > 0 else 'all',
-                            '.'.join(folds),
-                            self.framework_name]))
+        job = Job(rconfig().token_separator.join([
+            'aws',
+            self.benchmark_name,
+            self.constraint_name,
+            ' '.join(task_names) if len(task_names) > 0 else 'all',
+            ' '.join(folds),
+            self.framework_name
+        ]))
         job.instance_id = None
 
         def _run(job_self):

--- a/amlb/runners/container.py
+++ b/amlb/runners/container.py
@@ -107,12 +107,14 @@ class ContainerBenchmark(Benchmark):
             ))
             # TODO: would be nice to reload generated scores and return them
 
-        job = Job('_'.join([self.container_name,
-                            self.benchmark_name,
-                            self.constraint_name,
-                            '.'.join(task_names) if len(task_names) > 0 else 'all',
-                            '.'.join(folds),
-                            self.framework_name]))
+        job = Job(rconfig().token_separator.join([
+            self.container_name,
+            self.benchmark_name,
+            self.constraint_name,
+            ' '.join(task_names) if len(task_names) > 0 else 'all',
+            ' '.join(folds),
+            self.framework_name
+        ]))
         job._run = _run
         return job
 

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -26,6 +26,10 @@ seed: auto  # default global seed (used if not set in task definition), can be o
             # `none`: no seed will be provided (seed left to framework's responsibility).
             # any int32 to pass a fixed seed to the jobs.
 
+token_separator: '.'    # set to '_' for backwards compatibility.
+                        # This separator is used to generate directory structure and files,
+                        # the '_' separator makes the parsing of those names more difficult as it's also used in framework names, task names...
+
 setup:
   live_output: true      # set to true to stream the output of setup commands, if false they are only printed when setup is complete.
   activity_timeout: 300  # when using live output, subprocess will be considered as hanging if nothing was printed during this activity time.
@@ -33,6 +37,7 @@ setup:
 frameworks:
   definition_file: '{root}/resources/frameworks.yaml'
   root_module: frameworks
+  allow_duplicates: false  # if true, the last definition is used.
 
 benchmarks:
   definition_dir:

--- a/runbenchmark.py
+++ b/runbenchmark.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import os
+import re
 import sys
 
 # prevent asap other modules from defining the root logger using basicConfig
@@ -64,12 +65,13 @@ extras = {t[0]: t[1] if len(t) > 1 else True for t in [x.split('=', 1) for x in 
 
 now_str = datetime_iso(date_sep='', time_sep='')
 sid = (args.session if args.session is not None
-       else "{}_{}".format('_'.join([args.framework,
-                                     os.path.splitext(os.path.basename(args.benchmark))[0],
+       else "{}.{}".format('.'.join([args.framework,
+                                     (args.benchmark if re.fullmatch(r"(openml)/[st]/\d+", args.benchmark)
+                                      else os.path.splitext(os.path.basename(args.benchmark))[0]),
                                      args.constraint,
                                      extras.get('run_mode', args.mode)])
                               .lower(),
-                           now_str))
+                           now_str)).replace("/", "_")
 log_dir = amlb.resources.output_dirs(args.outdir or os.path.join(os.getcwd(), 'logs'),
                                      session=sid,
                                      subdirs='logs' if args.outdir else '',
@@ -77,8 +79,8 @@ log_dir = amlb.resources.output_dirs(args.outdir or os.path.join(os.getcwd(), 'l
 # now_str = datetime_iso(time=False, no_sep=True)
 if args.profiling:
     logging.TRACE = logging.INFO
-amlb.logger.setup(log_file=os.path.join(log_dir, '{script}_{now}.log'.format(script=script_name, now=now_str)),
-                  root_file=os.path.join(log_dir, '{script}_{now}_full.log'.format(script=script_name, now=now_str)),
+amlb.logger.setup(log_file=os.path.join(log_dir, '{script}.{now}.log'.format(script=script_name, now=now_str)),
+                  root_file=os.path.join(log_dir, '{script}.{now}.full.log'.format(script=script_name, now=now_str)),
                   root_level='INFO', app_level='DEBUG', console_level='INFO', print_to_log=True)
 
 log.info("Running `%s` on `%s` benchmarks in `%s` mode.", args.framework, args.benchmark, args.mode)

--- a/runscores.py
+++ b/runscores.py
@@ -10,6 +10,7 @@ import amlb
 from amlb import log
 from amlb.utils import config_load
 
+root_dir = os.path.dirname(__file__)
 
 parser = argparse.ArgumentParser()
 parser.add_argument('predictions', type=str,
@@ -24,6 +25,7 @@ amlb.logger.setup(root_level='DEBUG', console_level='INFO')
 
 config = config_load("resources/config.yaml")
 config.run_mode = 'script'
+config.root_dir = root_dir
 config.script = os.path.basename(__file__)
 amlb.resources.from_config(config)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,8 @@ def simple_resource():
             ),
             frameworks=Namespace(
                 root_module="frameworks",
-                definition_file=[]
+                definition_file=[],
+                allow_duplicates=False
             )
         )
     )

--- a/tests/unit/amlb/framework_definitions/test_load_and_merge_framework_definitions.py
+++ b/tests/unit/amlb/framework_definitions/test_load_and_merge_framework_definitions.py
@@ -18,23 +18,23 @@ second_file_has_extension = [
 
 
 @pytest.mark.use_disk
-def test_loads_all_definitions():
-    definition = _load_and_merge_framework_definitions(framework_file)
+def test_loads_all_definitions(simple_resource):
+    definition = _load_and_merge_framework_definitions(framework_file, simple_resource.config)
     assert "unit_test_framework" in definition
     assert len(definition) == 5
 
 
 @pytest.mark.use_disk
-def test_merges_definitions_of_two_files():
-    definition = _load_and_merge_framework_definitions(second_file_has_extension)
+def test_merges_definitions_of_two_files(simple_resource):
+    definition = _load_and_merge_framework_definitions(second_file_has_extension, simple_resource.config)
     assert "other_test_framework_extended_other_file" in definition
     assert len(definition) == 6
 
 
 @pytest.mark.use_disk
-def test_does_not_raise_exception_if_extension_is_not_defined():
+def test_does_not_raise_exception_if_extension_is_not_defined(simple_resource):
     try:
-        _load_and_merge_framework_definitions(framework_file_with_extension_only)
+        _load_and_merge_framework_definitions(framework_file_with_extension_only, simple_resource.config)
     except Exception:
         pytest.fail(
             "Extensions should be verified when filling defaults, not on initial load."
@@ -42,6 +42,6 @@ def test_does_not_raise_exception_if_extension_is_not_defined():
 
 
 @pytest.mark.use_disk
-def test_raises_exception_on_duplicate_definition():
+def test_raises_exception_on_duplicate_definition(simple_resource):
     with pytest.raises(ValueError, match="Duplicate entry 'duplicate_entry' found."):
-        _load_and_merge_framework_definitions(second_file_has_duplicate)
+        _load_and_merge_framework_definitions(second_file_has_duplicate, simple_resource.config)


### PR DESCRIPTION
All the path/files generated by the app must have an easily parseable name to extract meta information.
Until now, tokens were separated by an underscore character.
However, framework names, benchmark names, constraint names, task names often include an underscore or a dash, making those bad delimiters.
This PR uses dot a as a delimiter, and updates the regexp used internally to fetch and extract information from those files.

a config entry `token_separator` (now defaulting to ".") was added for backwards support.