### PR TITLE
Extract prediction time and expose to results file.

### DIFF
--- a/amlb/results.py
+++ b/amlb/results.py
@@ -118,7 +118,7 @@ class Scoreboard:
             # avoid dtype conversions during reindexing on empty frame
             return df
         fixed_cols = ['id', 'task', 'framework', 'constraint', 'fold', 'result', 'metric', 'mode', 'version',
-                      'params', 'app_version', 'utc', 'duration', 'models', 'seed', 'info']
+                      'params', 'app_version', 'utc', 'training_duration', 'predict_duration',  'models_count', 'seed', 'info']
         fixed_cols = [col for col in fixed_cols if col not in index]
         dynamic_cols = [col for col in df.columns if col not in index and col not in fixed_cols]
         dynamic_cols.sort()
@@ -134,8 +134,8 @@ class Scoreboard:
 
         df = self.as_data_frame()
         force_str_cols = ['id']
-        nanable_int_cols = ['fold', 'models', 'seed']
-        low_precision_float_cols = ['duration']
+        nanable_int_cols = ['fold', 'models_count', 'seed']
+        low_precision_float_cols = ['training_duration', 'predict_duration']
         high_precision_float_cols = [col for col in df.select_dtypes(include=[np.float]).columns if col not in ([] + nanable_int_cols + low_precision_float_cols)]
         for col in force_str_cols:
             df[col] = df[col].astype(np.object).map(str_print).astype(np.str)
@@ -357,16 +357,17 @@ class TaskResult:
             app_version=rget().app_version,
             utc=datetime_iso(),
             metric=metadata.metric,
-            duration=meta_result.training_duration if 'training_duration' in meta_result else nan,
-            models=meta_result.models_count if 'models_count' in meta_result else nan,
         )
+        required_metares = ['training_duration', 'predict_duration', 'models_count']
+        for m in required_metares:
+            scores[m] = meta_result[m] if m in meta_result else nan
         result = self.get_result() if result is None else result
         for metric in metadata.metrics:
             score = result.evaluate(metric)
             scores[metric] = score
         scores.result = scores[scores.metric] if scores.metric in scores else result.evaluate(scores.metric)
         scores.info = result.info
-        scores % Namespace({k: v for k, v in meta_result if k not in ['models_count', 'training_duration']})
+        scores % Namespace({k: v for k, v in meta_result if k not in required_metares})
         log.info("Metric scores: %s", scores)
         return scores
 

--- a/amlb/results.py
+++ b/amlb/results.py
@@ -118,7 +118,7 @@ class Scoreboard:
             # avoid dtype conversions during reindexing on empty frame
             return df
         fixed_cols = ['id', 'task', 'framework', 'constraint', 'fold', 'result', 'metric', 'mode', 'version',
-                      'params', 'app_version', 'utc', 'training_duration', 'predict_duration',  'models_count', 'seed', 'info']
+                      'params', 'app_version', 'utc', 'duration', 'training_duration', 'predict_duration', 'models_count', 'seed', 'info']
         fixed_cols = [col for col in fixed_cols if col not in index]
         dynamic_cols = [col for col in df.columns if col not in index and col not in fixed_cols]
         dynamic_cols.sort()
@@ -135,7 +135,7 @@ class Scoreboard:
         df = self.as_data_frame()
         force_str_cols = ['id']
         nanable_int_cols = ['fold', 'models_count', 'seed']
-        low_precision_float_cols = ['training_duration', 'predict_duration']
+        low_precision_float_cols = ['duration', 'training_duration', 'predict_duration']
         high_precision_float_cols = [col for col in df.select_dtypes(include=[np.float]).columns if col not in ([] + nanable_int_cols + low_precision_float_cols)]
         for col in force_str_cols:
             df[col] = df[col].astype(np.object).map(str_print).astype(np.str)
@@ -357,6 +357,7 @@ class TaskResult:
             app_version=rget().app_version,
             utc=datetime_iso(),
             metric=metadata.metric,
+            duration=nan
         )
         required_metares = ['training_duration', 'predict_duration', 'models_count']
         for m in required_metares:

--- a/frameworks/DecisionTree/exec.py
+++ b/frameworks/DecisionTree/exec.py
@@ -26,7 +26,8 @@ def run(dataset: Dataset, config: TaskConfig):
 
     with Timer() as training:
         predictor.fit(X_train, y_train)
-    predictions = predictor.predict(X_test)
+    with Timer() as predict:
+        predictions = predictor.predict(X_test)
     probabilities = predictor.predict_proba(X_test) if is_classification else None
 
     save_predictions(dataset=dataset,
@@ -37,5 +38,6 @@ def run(dataset: Dataset, config: TaskConfig):
 
     return dict(
         models_count=1,
-        training_duration=training.duration
+        training_duration=training.duration,
+        predict_duration=predict.duration
     )

--- a/frameworks/GAMA/exec.py
+++ b/frameworks/GAMA/exec.py
@@ -66,7 +66,8 @@ def run(dataset, config):
         gama_automl.fit_arff(dataset.train_path, dataset.target, encoding='utf-8')
 
     log.info('Predicting on the test set.')
-    predictions = gama_automl.predict_arff(dataset.test_path, dataset.target, encoding='utf-8')
+    with utils.Timer() as predict:
+        predictions = gama_automl.predict_arff(dataset.test_path, dataset.target, encoding='utf-8')
     if is_classification is not None:
         probabilities = gama_automl.predict_proba_arff(dataset.test_path, dataset.target, encoding='utf-8')
     else:
@@ -78,7 +79,8 @@ def run(dataset, config):
         probabilities=probabilities,
         target_is_encoded=False,
         models_count=len(gama_automl._final_pop),
-        training_duration=training.duration
+        training_duration=training.duration,
+        predict_duration=predict.duration
     )
 
 

--- a/frameworks/MLPlan/exec.py
+++ b/frameworks/MLPlan/exec.py
@@ -73,7 +73,7 @@ def run(dataset, config):
             os=statistics_file,
             tmp=tmp_dir,
             **training_params
-       )
+        )
 
         cmd = cmd_root + ''.join([" -{} {}".format(k, v) for k, v in cmd_params.items()])
 

--- a/frameworks/RandomForest/exec.py
+++ b/frameworks/RandomForest/exec.py
@@ -39,7 +39,8 @@ def run(dataset, config):
     with utils.Timer() as training:
         rf.fit(X_train, y_train)
 
-    predictions = rf.predict(X_test)
+    with utils.Timer() as predict:
+        predictions = rf.predict(X_test)
     probabilities = rf.predict_proba(X_test) if is_classification else None
 
     return result(output_file=config.output_predictions_file,
@@ -48,7 +49,8 @@ def run(dataset, config):
                   probabilities=probabilities,
                   target_is_encoded=is_classification,
                   models_count=len(rf),
-                  training_duration=training.duration)
+                  training_duration=training.duration,
+                  predict_duration=predict.duration)
 
 
 if __name__ == '__main__':

--- a/frameworks/TPOT/exec.py
+++ b/frameworks/TPOT/exec.py
@@ -63,7 +63,8 @@ def run(dataset, config):
     log.info('Predicting on the test set.')
     X_test = dataset.test.X_enc
     y_test = dataset.test.y_enc
-    predictions = tpot.predict(X_test)
+    with utils.Timer() as predict:
+        predictions = tpot.predict(X_test)
     try:
         probabilities = tpot.predict_proba(X_test) if is_classification else None
     except RuntimeError:
@@ -78,7 +79,8 @@ def run(dataset, config):
                   probabilities=probabilities,
                   target_is_encoded=is_classification,
                   models_count=len(tpot.evaluated_individuals_),
-                  training_duration=training.duration)
+                  training_duration=training.duration,
+                  predict_duration=predict.duration)
 
 
 def save_artifacts(estimator, config):

--- a/frameworks/TunedRandomForest/exec.py
+++ b/frameworks/TunedRandomForest/exec.py
@@ -117,7 +117,8 @@ def run(dataset, config):
     with utils.Timer() as training:
         rf.fit(X_train, y_train)
 
-    predictions = rf.predict(X_test)
+    with utils.Timer() as predict:
+        predictions = rf.predict(X_test)
     probabilities = rf.predict_proba(X_test) if is_classification else None
 
     return result(
@@ -127,7 +128,8 @@ def run(dataset, config):
         probabilities=probabilities,
         target_is_encoded=is_classification,
         models_count=len(rf),
-        training_duration=training.duration+sum(map(lambda t: t[1], tuning_durations))
+        training_duration=training.duration+sum(map(lambda t: t[1], tuning_durations)),
+        predict_duration=predict.duration
     )
 
 

--- a/frameworks/autosklearn/exec.py
+++ b/frameworks/autosklearn/exec.py
@@ -97,7 +97,8 @@ def run(dataset, config):
     log.info("Predicting on the test set.")
     X_test = dataset.test.X_enc
     y_test = dataset.test.y_enc
-    predictions = auto_sklearn.predict(X_test)
+    with utils.Timer() as predict:
+        predictions = auto_sklearn.predict(X_test)
     probabilities = auto_sklearn.predict_proba(X_test) if is_classification else None
 
     save_artifacts(auto_sklearn, config)
@@ -108,7 +109,8 @@ def run(dataset, config):
                   probabilities=probabilities,
                   target_is_encoded=is_classification,
                   models_count=len(auto_sklearn.get_models_with_weights()),
-                  training_duration=training.duration)
+                  training_duration=training.duration,
+                  predict_duration=predict.duration)
 
 
 def save_artifacts(estimator, config):

--- a/frameworks/constantpredictor/exec.py
+++ b/frameworks/constantpredictor/exec.py
@@ -28,7 +28,8 @@ def run(dataset: Dataset, config: TaskConfig):
 
     with Timer() as training:
         predictor.fit(X_train, y_train)
-    predictions = predictor.predict(X_test)
+    with Timer() as predict:
+        predictions = predictor.predict(X_test)
     probabilities = predictor.predict_proba(X_test) if is_classification else None
 
     save_predictions(dataset=dataset,
@@ -40,5 +41,6 @@ def run(dataset: Dataset, config: TaskConfig):
 
     return dict(
         models_count=1,
-        training_duration=training.duration
+        training_duration=training.duration,
+        predict_duration=predict.duration
     )

--- a/frameworks/hyperoptsklearn/exec.py
+++ b/frameworks/hyperoptsklearn/exec.py
@@ -77,7 +77,8 @@ def run(dataset, config):
     log.info('Predicting on the test set.')
     X_test = dataset.test.X_enc
     y_test = dataset.test.y_enc
-    predictions = estimator.predict(X_test)
+    with Timer() as predict:
+        predictions = estimator.predict(X_test)
 
     if is_classification:
         probabilities = "predictions"  # encoding is handled by caller in `__init__.py`
@@ -90,7 +91,8 @@ def run(dataset, config):
                   probabilities=probabilities,
                   target_is_encoded=is_classification,
                   models_count=len(estimator.trials),
-                  training_duration=training.duration)
+                  training_duration=training.duration,
+                  predict_duration=predict.duration)
 
 
 if __name__ == '__main__':

--- a/frameworks/mljarsupervised/exec.py
+++ b/frameworks/mljarsupervised/exec.py
@@ -54,7 +54,8 @@ def run(dataset, config):
     with utils.Timer() as training:
         automl.fit(X_train, y_train)
 
-    preds = automl.predict(X_test)
+    with utils.Timer() as predict:
+        preds = automl.predict(X_test)
 
     predictions, probabilities = None, None
     if is_classification:
@@ -74,6 +75,7 @@ def run(dataset, config):
         probabilities=probabilities,
         models_count=len(automl._models),
         training_duration=training.duration,
+        predict_duration=predict.duration
     )
 
 

--- a/frameworks/oboe/exec.py
+++ b/frameworks/oboe/exec.py
@@ -46,7 +46,9 @@ def run(dataset, config):
     log.info('Predicting on the test set.')
     X_test = dataset.test.X_enc
     y_test = dataset.test.y_enc
-    predictions = aml.predict(X_test).reshape(len(X_test))
+    with utils.Timer() as predict:
+        predictions = aml.predict(X_test)
+    predictions = predictions.reshape(len(X_test))
 
     if is_classification:
         probabilities = "predictions"  # encoding is handled by caller in `__init__.py`
@@ -59,7 +61,8 @@ def run(dataset, config):
                   probabilities=probabilities,
                   target_is_encoded=is_classification,
                   models_count=len(aml_models()),
-                  training_duration=training.duration)
+                  training_duration=training.duration,
+                  predict_duration=predict.duration)
 
 
 if __name__ == '__main__':

--- a/frameworks/ranger/exec.R
+++ b/frameworks/ranger/exec.R
@@ -3,7 +3,7 @@ library(mlrCPO)
 library(farff)
 
 
-run <- function(train_file, test_file, output_predictions_file, cores) {
+run <- function(train_file, test_file, output_predictions_file, cores=1, meta_results_file=NULL) {
   train <- readARFF(train_file)
   test <- readARFF(test_file)
   colnames(train) <- make.names(colnames(train))
@@ -18,16 +18,23 @@ run <- function(train_file, test_file, output_predictions_file, cores) {
                     ) %>>%
         makeLearner("classif.ranger", num.threads = cores, predict.type = "prob")
 
-  mod <- train(lrn, train)
-  preds <- predict(mod, newdata = test)$data
+  mod <- NULL
+  preds <- NULL
+  training <- function() mod <<- train(lrn, train)
+  prediction <- function() preds <<- predict(mod, newdata = test)$data
+  train_duration <- system.time(training())[['elapsed']]
+  predict_duration <- system.time(prediction())[['elapsed']]
+
   preds <- preds[c(2:ncol(preds), 1)]
   names(preds)[names(preds) == "response"] <- "predictions"
   names(preds) <- sub("^prob.", "", names(preds))
   # FIXME: label encoding for predictions and truth?
 
-  write.table(preds, file = output_predictions_file,
-              row.names = FALSE, col.names = TRUE,
-              sep = ",", quote = FALSE)
+  write.csv(preds, file = output_predictions_file, row.names = FALSE)
+
+  meta_results <- data.frame(key=c("training_duration", "predict_duration"),
+                             value=c(train_duration, predict_duration))
+  write.csv(meta_results, file = meta_results_file, row.names = FALSE)
 }
 
 # args = commandArgs(trailingOnly=TRUE)

--- a/frameworks/ranger/exec.py
+++ b/frameworks/ranger/exec.py
@@ -3,6 +3,7 @@ import os
 
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
+from amlb.datautils import read_csv
 from amlb.utils import dir_of, run_cmd
 
 from frameworks.shared.callee import save_metadata
@@ -20,12 +21,29 @@ def run(dataset: Dataset, config: TaskConfig):
         raise ValueError('Regression is not supported.')
 
     here = dir_of(__file__)
-    run_cmd(r"""Rscript --vanilla -e "source('{script}'); run('{train}', '{test}', '{output}', {cores})" """.format(
+    meta_results_file = os.path.join(config.output_dir, "meta_results.csv")
+    run_cmd(r"""Rscript --vanilla -e "
+            source('{script}'); 
+            run('{train}', '{test}', '{output}', 
+                cores={cores}, meta_results_file='{meta_results}')
+            " """.format(
         script=os.path.join(here, 'exec.R'),
         train=dataset.train.path,
         test=dataset.test.path,
         output=config.output_predictions_file,
+        meta_results=meta_results_file,
         cores=config.cores
     ), _live_output_=True)
 
     log.info("Predictions saved to %s", config.output_predictions_file)
+
+    meta_results = read_csv(meta_results_file)
+    return dict(
+        training_duration=meta_result(meta_results, 'training_duration'),
+        predict_duration=meta_result(meta_results, 'predict_duration')
+    )
+
+
+def meta_result(df, key):
+    return df.loc[df['key'] == key, 'value'].squeeze()
+

--- a/frameworks/shared/callee.py
+++ b/frameworks/shared/callee.py
@@ -41,6 +41,7 @@ def result(output_file=None,
            error_message=None,
            models_count=None,
            training_duration=None,
+           predict_duration=None,
            **others):
     return locals()
 

--- a/frameworks/shared/caller.py
+++ b/frameworks/shared/caller.py
@@ -96,5 +96,6 @@ def run_in_venv(caller_file, script_file: str, *args,
         return dict(
             models_count=res.models_count if res.models_count is not None else 1,
             training_duration=res.training_duration if res.training_duration is not None else proc_timer.duration,
+            predict_duration=res.predict_duration,
             **res.others.__dict__
         )


### PR DESCRIPTION
https://github.com/openml/automlbenchmark/issues/162

Current issues:
- Not able to extract prediction time for frameworks that don't provide a separate  method/call to predict on a dataset:
  - MLPlan (cc: @mwever)
  - AutoWeka

- current support penalizes frameworks whose predict API loads the data from the file system, vs. those who load data separately and for which the prediction duration includes (as expected) *only* the prediction computation. Penalized frameworks:
  - GAMA (cc: @PGijsbers)
