### PR TITLE
Add support for Spot instances to AWS mode

### DIFF
--- a/amlb/datautils.py
+++ b/amlb/datautils.py
@@ -76,7 +76,7 @@ def write_csv(data, path, header=True, columns=None, index=False, append=False):
         data_frame = data
     else:
         data_frame = to_data_frame(data, columns=columns)
-        header = columns is not None
+        header = header and columns is not None
     touch(path)
     data_frame.to_csv(path,
                       header=header,

--- a/amlb/job.py
+++ b/amlb/job.py
@@ -29,11 +29,15 @@ class State(Enum):
     stopped = auto()
 
 
-class InvalidStateError(Exception):
+class JobError(Exception):
     pass
 
 
-class CancelledError(Exception):
+class InvalidStateError(JobError):
+    pass
+
+
+class CancelledError(JobError):
     pass
 
 

--- a/amlb/job.py
+++ b/amlb/job.py
@@ -58,6 +58,7 @@ class Job:
                 raise InvalidStateError("Job can't be started from state `{}`.".format(self.state))
             log.info("\n%s\n%s", '-'*len(start_msg), start_msg)
             self.state = State.running
+            self._prepare()
             with Timer() as t:
                 # don't propagate interruption error here (sig=None) so that we can collect the timeout in the result
                 with InterruptTimeout(self.timeout, sig=None):
@@ -100,8 +101,12 @@ class Job:
         self.state = state
         self.thread_id = None
 
+    def _prepare(self):
+        """hood to execute pre-run logic: this is executed in the same thread as the run logic."""
+        pass
+
     def _run(self):
-        """jobs should implement their run logic in this method"""
+        """jobs should implement their run logic in this method."""
         pass
 
     def _stop(self):
@@ -109,7 +114,7 @@ class Job:
             raise_in_thread(self.thread_id, CancelledError)
 
     def _on_done(self):
-        """hook to execute logic after job completion in a thread-safe way as this is executed in the main thread"""
+        """hook to execute logic after job completion in a thread-safe way as this is executed in the main thread."""
         pass
 
 
@@ -162,7 +167,7 @@ class JobRunner:
         if self._queue is None:
             return
         _, job = self._queue.get()
-        self._queue.task_done();
+        self._queue.task_done()
         if job is None:
             self._queue = None
             return

--- a/amlb/runners/aws.py
+++ b/amlb/runners/aws.py
@@ -224,7 +224,9 @@ class AWSBenchmark(Benchmark):
 
     def _job_reschedule(self, job):
         if not self.retry:
-            self.retry = retry(2, lambda x: x*2, max_retries=3)
+            self.retry = retry(2, lambda x: x*2, max_retries=3)  # TODO: externalize
+        # we want sth more clever: if some job, is already waiting, use the same waiting time
+        # only increase wait time if the job passed as param was previously waiting (wait_min_secs > 0)
         wait = next(self.retry, None)
         if wait is None:
             # write job state/description for later replay

--- a/amlb/runners/aws.py
+++ b/amlb/runners/aws.py
@@ -274,12 +274,14 @@ class AWSBenchmark(Benchmark):
         job.instance_id = None
         job.wait_min_secs = 0
 
+        def _prepare(job_self):
+            if job.wait_min_secs:
+                countdown(job.wait_min_secs,
+                          message=f"starting job {job_self.name}",
+                          frequency=rconfig().aws.query_frequency_seconds)
+
         def _run(job_self):
             try:
-                if job.wait_min_secs:
-                    countdown(job.wait_min_secs,
-                              message=f"starting job {job_self.name}",
-                              frequency=rconfig().aws.query_frequency_seconds)
                 resources_root = "/custom" if rconfig().aws.use_docker else "/s3bucket/user"
                 job_self.instance_id = self._start_instance(
                     instance_def,
@@ -323,6 +325,7 @@ class AWSBenchmark(Benchmark):
                                 job_self.instance_id)
                 self._stop_instance(job_self.instance_id, terminate=terminate)
 
+        job._prepare = _prepare.__get__(job)
         job._run = _run.__get__(job)
         job._on_done = _on_done.__get__(job)
         return job

--- a/amlb/utils/core.py
+++ b/amlb/utils/core.py
@@ -7,6 +7,7 @@ import json
 import logging
 import pprint
 import re
+import threading
 
 log = logging.getLogger(__name__)
 
@@ -155,6 +156,10 @@ def noop(*args, **kwargs):
     pass
 
 
+def identity(x, *args):
+    return (x,) + args if args else x
+
+
 def as_list(*args):
     if len(args) == 0:
         return list()
@@ -280,4 +285,29 @@ def json_dumps(o, style='default'):
         return json.encoder.JSONEncoder.default(None, o)
 
     return json.dumps(o, indent=indent, separators=separators, default=default_encode)
+
+
+class ThreadsafeIterator:
+    """
+    Wrapper class making an iterator threadsafe
+    """
+    def __init__(self, it):
+        self.it = it
+        self.lock = threading.Lock()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        with self.lock:
+            return next(self.it)
+
+
+def threadsafe_generator(fn):
+    """
+    Decorator making a generator thread-safe.
+    """
+    def gen(*args, **kwargs):
+        return ThreadsafeIterator(fn(*args, **kwargs))
+    return gen
 

--- a/amlb/utils/core.py
+++ b/amlb/utils/core.py
@@ -1,6 +1,6 @@
 from ast import literal_eval
 import base64
-from collections.abc import Iterable
+from collections.abc import Iterable, Sized
 from functools import reduce, wraps
 import hashlib
 import json
@@ -203,10 +203,15 @@ def str2bool(s):
         raise ValueError(s+" can't be interpreted as a boolean.")
 
 
-def str_def(s, if_none=''):
-    if s is None:
+_empty_ = "__empty__"
+
+
+def str_def(o, if_none='', if_empty=_empty_):
+    if o is None:
         return if_none
-    return str(s)
+    if if_empty != _empty_ and isinstance(o, Sized) and len(o) == 0:
+        return if_empty
+    return str(o)
 
 
 def str_sanitize(s):

--- a/amlb/utils/core.py
+++ b/amlb/utils/core.py
@@ -287,20 +287,18 @@ def json_dumps(o, style='default'):
     return json.dumps(o, indent=indent, separators=separators, default=default_encode)
 
 
-class ThreadsafeIterator:
+def threadsafe_iterator(it):
     """
-    Wrapper class making an iterator threadsafe
+    Wrapper making an iterator thread-safe.
     """
-    def __init__(self, it):
-        self.it = it
-        self.lock = threading.Lock()
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        with self.lock:
-            return next(self.it)
+    it = iter(it)
+    lock = threading.Lock()
+    while True:
+        try:
+            with lock:
+                yield next(it)
+        except StopIteration:
+            return
 
 
 def threadsafe_generator(fn):
@@ -308,6 +306,6 @@ def threadsafe_generator(fn):
     Decorator making a generator thread-safe.
     """
     def gen(*args, **kwargs):
-        return ThreadsafeIterator(fn(*args, **kwargs))
+        return threadsafe_iterator(fn(*args, **kwargs))
     return gen
 

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -158,7 +158,8 @@ aws:
       retry_policy: 'exponential:300:2:10800'  # use "constant:interval", "linear:start:increment:max" or "exponential:start:factor:max"
                                                # e.g. "linear:300:600" will first wait 5min and then add 10min to waiting time between each retry,
                                                #      "exponential:300:2:10800" with first wait 5min and then double waiting time between each retry, until the maximum of 3h then used for all retries.
-      max_retries: 10
+      max_attempts: 10
+      fallback_to_on_demand: false             # if couldn't obtain a spot instance after max retry, starts an on-demand instance.
 
   max_timeout_seconds: 21600
   overhead_time_seconds: 1800   # amount of additional time allowed for the job to complete on aws before the instance is stopped.

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -15,7 +15,7 @@ sid:        # session id: set by caller (runbenchmark.py)
 
 test_mode: False
 parallel_jobs: 1
-max_parallel_jobs: 5
+max_parallel_jobs: 10  # safety limit: increase this if you want to be able to run many jobs in parallel, especially in aws mode. Defaults to 10 to allow running the usual 10 folds in parallel with no problem.
 delay_between_jobs: 5  # delay in seconds between each parallel job start
 monitoring:
   frequency_seconds: 120  # set <= 0 to disable
@@ -155,10 +155,10 @@ aws:
       enabled: false             # if enabled, aws mode will try to obtain a spot instance instead of on-demand.
       block_enabled: false       # if enabled, and if spot is enabled, aws mode will try to use block instances (possible only if total instance runtime <= 6h, i.e. for benchmark runtime up to 4h).
       max_hourly_price: ''       # the max hourly price (in dollar) per instance to bid (defaults to on-demand price).
-      retry_policy: 'exponential:60:2'  # use "constant:interval", "linear:start:increment" or "exponential:start:factor"
-                                        # e.g. "linear:300:600" will first wait 5min and then add 10min to waiting time between each retry,
-                                        #      "exponential:300:2" with first wait 5min and then double waiting time between each retry.
-      max_retries: 3
+      retry_policy: 'exponential:300:2:10800'  # use "constant:interval", "linear:start:increment:max" or "exponential:start:factor:max"
+                                               # e.g. "linear:300:600" will first wait 5min and then add 10min to waiting time between each retry,
+                                               #      "exponential:300:2:10800" with first wait 5min and then double waiting time between each retry, until the maximum of 3h then used for all retries.
+      max_retries: 10
 
   max_timeout_seconds: 21600
   overhead_time_seconds: 1800   # amount of additional time allowed for the job to complete on aws before the instance is stopped.

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -155,6 +155,10 @@ aws:
       enabled: false             # if enabled, aws mode will try to obtain a spot instance instead of on-demand.
       block_enabled: false       # if enabled, and if spot is enabled, aws mode will try to use block instances (possible only if total instance runtime <= 6h, i.e. for benchmark runtime up to 4h).
       max_hourly_price: ''       # the max hourly price (in dollar) per instance to bid (defaults to on-demand price).
+      retry_policy: 'exponential:60:2'  # use "constant:interval", "linear:start:increment" or "exponential:start:factor"
+                                        # e.g. "linear:300:600" will first wait 5min and then add 10min to waiting time between each retry,
+                                        #      "exponential:300:2" with first wait 5min and then double waiting time between each retry.
+      max_retries: 3
 
   max_timeout_seconds: 21600
   overhead_time_seconds: 1800   # amount of additional time allowed for the job to complete on aws before the instance is stopped.

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -151,6 +151,10 @@ aws:
       eu-central-1:
         ami: ami-0bdf93799014acdc4
         description: Ubuntu Server 18.04 LTS (HVM), EBS General Purpose (SSD) VolumeType
+    spot:
+      enabled: false             # if enabled, aws mode will try to obtain a spot instance instead of on-demand.
+      block_enabled: false       # if enabled, and if spot is enabled, aws mode will try to use block instances (possible only if total instance runtime <= 6h, i.e. for benchmark runtime up to 4h).
+      max_hourly_price: ''       # the max hourly price (in dollar) per instance to bid (defaults to on-demand price).
 
   max_timeout_seconds: 21600
   overhead_time_seconds: 1800   # amount of additional time allowed for the job to complete on aws before the instance is stopped.


### PR DESCRIPTION
https://github.com/openml/automlbenchmark/issues/150

Spot usage should be activated in user's config file, here is the list of new config points:
```yaml
aws:
  ec2:
    spot:
      enabled: false             # if enabled, aws mode will try to obtain a spot instance instead of on-demand.
      block_enabled: false       # if enabled, and if spot is enabled, aws mode will try to use block instances (possible only if total instance runtime <= 6h, i.e. for benchmark runtime up to 4h).
      max_hourly_price: ''       # the max hourly price (in dollar) per instance to bid (defaults to on-demand price).
      retry_policy: 'exponential:300:2:10800'  # use "constant:interval", "linear:start:increment:max" or "exponential:start:factor:max"
                                               # e.g. "linear:300:600" will first wait 5min and then add 10min to waiting time between each retry,
                                               #      "exponential:300:2:10800" with first wait 5min and then double waiting time between each retry, until the maximum of 3h then used for all retries.
      max_attempts: 10
      fallback_to_on_demand: false             # if couldn't obtain a spot instance after max retry, starts an on-demand instance.

```