### PR TITLE
fix H2O predictions formatting for target categories with numerical values

### DIFF
--- a/frameworks/H2OAutoML/exec.py
+++ b/frameworks/H2OAutoML/exec.py
@@ -2,6 +2,7 @@ import contextlib
 import logging
 import os
 import psutil
+import re
 import shutil
 
 import h2o
@@ -194,6 +195,10 @@ def save_predictions(model, test, dataset, config, predictions_file=None, previe
     predictions = y_pred.values
     probabilities = preds.iloc[:, 1:].values
     prob_labels = h2o_preds[0][1:]
+    if all([re.fullmatch(r"p\d+", p) for p in prob_labels]):
+        # for categories represented as numerical values, h2o prefixes the probabilities columns with p
+        # in this case, we let the app setting the labels to avoid mismatch
+        prob_labels = None
     truth = y_truth.values
 
     save_predictions_to_file(dataset=dataset,


### PR DESCRIPTION
For datasets like dresses-sales (https://www.openml.org/t/125920), with numeric target classes (here: 1, 2), H2O prefixes the probabilities columns with `p` (p1, p2...) which breaks the computation of final metrics.

This didn't occur until recently as we only started to use H2O predictions columns since https://github.com/openml/automlbenchmark/pull/191