### PR TITLE
Normalize categorical values

### DIFF
--- a/amlb/data.py
+++ b/amlb/data.py
@@ -43,7 +43,7 @@ class Feature:
         self.index = index
         self.name = name
         self.data_type = data_type.lower() if data_type is not None else None
-        self.values = values
+        self.values = self.normalize(values).tolist() if values is not None else None
         self.has_missing_values = has_missing_values
         self.is_target = is_target
         # print(self)
@@ -63,7 +63,7 @@ class Feature:
                        target=self.is_target,
                        encoded_type=int if self.is_target and not self.is_numerical() else float,
                        missing_policy='mask' if self.has_missing_values else 'ignore',
-                       trim_values=True
+                       normalize_fn=self.normalize
                        ).fit(self.values)
 
     @lazy_property
@@ -72,8 +72,11 @@ class Feature:
                        target=self.is_target,
                        encoded_type=int if self.is_target and not self.is_numerical() else float,
                        missing_policy='mask' if self.has_missing_values else 'ignore',
-                       trim_values=True
+                       normalize_fn=self.normalize
                        ).fit(self.values)
+
+    def normalize(self, arr):
+        return np.char.lower(np.char.strip(np.asarray(arr).astype(str)))
 
     def __repr__(self):
         return repr_def(self)

--- a/tests/unit/amlb/datautils/test_encoder.py
+++ b/tests/unit/amlb/datautils/test_encoder.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pytest
+
+from amlb.datautils import Encoder
+
+
+@pytest.mark.parametrize(
+    ['labels', 'to_encode', 'encoded'],
+    [
+        (['c', 'a', 'b'], ['a', 'b', 'c', 'b', 'c', 'a'], [0, 1, 2, 1, 2, 0]),
+        (['a', 'b', 'c'], ['a', 'b', 'c', 'b', 'c', 'a'], [0, 1, 2, 1, 2, 0]),
+    ])
+def test_encoder_sorts_the_labels_in_lexicographic_order(labels, to_encode, encoded):
+    e = Encoder().fit(labels)
+    transformed = e.transform(to_encode)
+    assert (encoded == transformed).all()
+
+
+@pytest.mark.parametrize(
+    ['labels', 'to_encode', 'encoded'],
+    [
+        (['a', 'A'], ['A', 'a', 'a', 'A'], [0, 1, 1, 0]),
+        (['a', ' a'], [' a', 'a', ' a', 'a'], [0, 1, 0, 1]),
+        (['a', 'a '], ['a ', 'a', 'a ', 'a'], [1, 0, 1, 0]),
+        (['a', ' a '], [' a ', 'a', ' a ', 'a'], [0, 1, 0, 1]),
+    ])
+def test_encoder_does_not_modify_categorical_values_by_default(labels, to_encode, encoded):
+    e = Encoder().fit(labels)
+    transformed = e.transform(to_encode)
+    assert (encoded == transformed).all()
+
+
+@pytest.mark.parametrize(
+    ['labels', 'to_encode', 'encoded'],
+    [
+        (['a', ' a'], [' a', 'a', ' a', 'a'], [0, 0, 0, 0]),
+        (['a', 'a '], ['a ', 'a', 'a ', 'a'], [0, 0, 0, 0]),
+        (['a', ' a '], [' a ', 'a', ' a ', 'a'], [0, 0, 0, 0]),
+        (['a', 'b', ' a ', ' a', 'a '], [' a ', 'a', 'b',  'a ', ' a'], [0, 0, 1, 0, 0]),
+    ])
+def test_encoder_can_trim_categorical_values(labels, to_encode, encoded):
+    normalize = lambda v: np.char.strip(np.asarray(v).astype(str))
+    e = Encoder(normalize_fn=normalize).fit(labels)
+    transformed = e.transform(to_encode)
+    assert (encoded == transformed).all()
+
+
+@pytest.mark.parametrize(
+    ['labels', 'to_encode', 'encoded'],
+    [
+        (['a', 'A'], ['A', 'a', 'a', 'A'], [0, 0, 0, 0]),
+        (['a', 'b', 'A'], ['A', 'a', 'b', 'a', 'A'], [0, 0, 1, 0, 0]),
+    ])
+def test_encoder_can_make_categorical_values_case_insensitive(labels, to_encode, encoded):
+    normalize = lambda v: np.char.lower(np.asarray(v).astype(str))
+    e = Encoder(normalize_fn=normalize).fit(labels)
+    transformed = e.transform(to_encode)
+    assert (encoded == transformed).all()


### PR DESCRIPTION
The application was already trimming all categorical values to support datasets like https://www.openml.org/d/4535 (see https://github.com/openml/automlbenchmark/pull/191).
Now some "unclean" datasets like https://www.openml.org/d/23381 have features like:
```
@attribute V2 {bohemian,Brief,Casual,cute,fashion,Flare,Novelty,OL,party,sexy,Sexy,vintage,work}
```
with "sexy" present twice but with a different case (also in the data), whereas the openml data provide only one version, creating a discrepancy in the application logic when encoding those categoricals.

To prevent this, the app now converts categorical values to lowercase to make sure they're case insensitive.

*N.B.*, this may also create an advantage for this majority of frameworks for which the application is preparing the data compared with others like H2OAutoML, autoxgboost, or MLPlan who are able to directly consume the arff files, for those datasets that may present duplicate values, the data as processed by the app are now cleaner than the raw arff file.
