### PR TITLE
Handle datasets with '?' as categorical value

### DIFF
--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -16,6 +16,9 @@ from ..utils import lazy_property, obj_size, profile, to_mb
 
 log = logging.getLogger(__name__)
 
+# hack (only adding a ? to the regexp pattern) to ensure that '?' values remain quoted when we save dataplits in arff format.
+arff._RE_QUOTE_CHARS = re.compile(r'[?"\'\\\s%,\000-\031]', re.UNICODE)
+
 
 class OpenmlLoader:
 


### PR DESCRIPTION
An example of dataset that was not handled correctly by the app: https://www.openml.org/d/4541

Applied a hack to the arff library to quote single question marks when writing arff files.

Will also create a ticket on the liac-arff library as this a bug imo.
Scenario is:
- arff file with quoted question marks as categorical values and data: e.g. 
```@attribute feat1 {'?', 'A', 'B', 'C'}```
- `arff.load()` reads those `'?'` as strings.
- `arff.write()` then writes the `'?'` from loaded data without quotes: ```@attribute feat1 {?, A, B, C}```
- `arff.load()` the last file interpretes `?` as missing value (`None`)

