### PR TITLE
increase default activity timeout

### DIFF
--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -33,7 +33,7 @@ archive: ['logs']
 
 setup:
   live_output: true      # set to true to stream the output of setup commands, if false they are only printed when setup is complete.
-  activity_timeout: 300  # when using live output, subprocess will be considered as hanging if nothing was printed during this activity time.
+  activity_timeout: 600  # when using live output, subprocess will be considered as hanging if nothing was printed during this activity time.
 
 frameworks:
   definition_file: '{root}/resources/frameworks.yaml'


### PR DESCRIPTION
increase default activity timeout to allow installation of large libraries when building docker image