### PR TITLE
allow using pre-release versions

### DIFF
--- a/frameworks/autosklearn/exec.py
+++ b/frameworks/autosklearn/exec.py
@@ -83,12 +83,11 @@ def run(dataset, config):
             ),
             3072  # 3072 is autosklearn default and we use it as a lower bound
         )
-    if askl_version >= version.parse("0.11"):
+    if isinstance(askl_version, version.LegacyVersion) or askl_version >= version.parse("0.11"):
         log.info(
             "Using %sMB memory per job and on a total of %s jobs.",
             ml_memory_limit, n_jobs
         )
-        constr_params["memory_limit"] = ml_memory_limit
     else:
         ensemble_memory_limit = config.framework_params.get('_ensemble_memory_limit', 'auto')
         # when memory is large enough, we should have:
@@ -112,7 +111,7 @@ def run(dataset, config):
             )
         estimator = AutoSklearnRegressor
 
-    if askl_version >= version.parse("0.8"):
+    if isinstance(askl_version, version.LegacyVersion) or askl_version >= version.parse("0.8"):
         constr_params['metric'] = perf_metric
     else:
         fit_extra_params['metric'] = perf_metric


### PR DESCRIPTION
This PR adds support for pre-release versions of Auto-sklearn and works around the package `packaging` apparently not being able to parse version identifiers following [PEP440](https://www.python.org/dev/peps/pep-0440/) but instead returning incomparable objects of type `LegacyVersion`.

I've also pushed a pre-release that I'd like to be used for the benchmark (see [here](https://pypi.org/project/auto-sklearn/0.12.1rc1/)), but I don't know how to make that available.