### PR TITLE
ML-Plan: Added prediction runtime for test predictions.

### DIFF
--- a/frameworks/AutoWEKA/setup.sh
+++ b/frameworks/AutoWEKA/setup.sh
@@ -10,9 +10,9 @@ fi
 AUTOWEKA_ARCHIVE="autoweka-${VERSION}.zip"
 DOWNLOAD_DIR="$HERE/lib"
 TARGET_DIR="$DOWNLOAD_DIR/autoweka"
-if [[ ! -e "$TARGET_DIR" ]]; then
-    wget http://www.cs.ubc.ca/labs/beta/Projects/autoweka/$AUTOWEKA_ARCHIVE -P $DOWNLOAD_DIR
-    unzip $DOWNLOAD_DIR/$AUTOWEKA_ARCHIVE -d $TARGET_DIR
-fi
+rm -Rf ${TARGET_DIR}
+
+wget http://www.cs.ubc.ca/labs/beta/Projects/autoweka/$AUTOWEKA_ARCHIVE -P $DOWNLOAD_DIR
+unzip $DOWNLOAD_DIR/$AUTOWEKA_ARCHIVE -d $TARGET_DIR
 
 find $HERE/lib/autoweka*.zip | sed -e 's/.*\/autoweka-\(.*\)\.zip/\1/' >> "${HERE}/.installed"

--- a/frameworks/MLPlan/__init__.py
+++ b/frameworks/MLPlan/__init__.py
@@ -14,8 +14,8 @@ def run(dataset: Dataset, config: TaskConfig):
     train_path = dataset.train.path
     test_path = dataset.test.path
     backend = config.framework_params.get('_backend')
-    # Weka requires target as the last attribute
-    if backend == 'weka' and dataset.target.index != len(dataset.predictors):
+    # ML-Plan requires the target attribute to be the last column
+    if dataset.target.index != len(dataset.predictors):
         train_path = reorder_dataset(dataset.train.path, target_src=dataset.target.index)
         test_path = reorder_dataset(dataset.test.path, target_src=dataset.target.index)
 

--- a/frameworks/MLPlan/exec.py
+++ b/frameworks/MLPlan/exec.py
@@ -53,9 +53,9 @@ def run(dataset, config):
              backend, mode, config.max_runtime_seconds, config.cores, config.max_mem_size_mb, metric)
     log.info("Environment: %s", os.environ)
 
-    predictions_file = os.path.join(output_subdir('mlplan_out', config), 'predictions.csv')
-    statistics_file = os.path.join(output_subdir('mlplan_out', config), 'statistics.json')
-    #tmp_dir = output_subdir('mlplan_tmp', config)
+    mlplan_output_dir = output_subdir('mlplan_out', config)
+    predictions_file = os.path.join(mlplan_output_dir, 'predictions.csv')
+    statistics_file = os.path.join(mlplan_output_dir, 'statistics.json')
 
     cmd_root = f"java -jar -Xmx{mem_limit}M {jar_file}"
 

--- a/frameworks/MLPlan/exec.py
+++ b/frameworks/MLPlan/exec.py
@@ -84,7 +84,8 @@ def run(dataset, config):
 
     predictions = stats["predictions"]
     truth = stats["truth"]
-    numEvals = stats["num_evaluations"]
+    num_evals = stats["num_evaluations"]
+    predict_time = stats["final_candidate_predict_time_ms"]
 
     # only for classification tasks we have probabilities available, thus check whether the json contains the respective fields
     if "probabilities" in stats and "probabilities_labels" in stats:
@@ -101,8 +102,9 @@ def run(dataset, config):
         probabilities=probabilities,
         probabilities_labels=probabilities_labels,
         target_is_encoded=is_classification,
-        models_count=numEvals,
-        training_duration=training.duration
+        models_count=num_evals,
+        training_duration=training.duration,
+        predict_duration=predict_time
     )
 
 

--- a/frameworks/MLPlan/exec.py
+++ b/frameworks/MLPlan/exec.py
@@ -85,7 +85,10 @@ def run(dataset, config):
     predictions = stats["predictions"]
     truth = stats["truth"]
     num_evals = stats["num_evaluations"]
-    predict_time = stats["final_candidate_predict_time_ms"]
+    if "final_candidate_predict_time_ms" in stats:
+        predict_time = stats["final_candidate_predict_time_ms"]
+    else:
+        predict_time = float("NaN")
 
     # only for classification tasks we have probabilities available, thus check whether the json contains the respective fields
     if "probabilities" in stats and "probabilities_labels" in stats:
@@ -95,13 +98,18 @@ def run(dataset, config):
         probabilities = []
         probabilities_labels = []
 
+    if version == "0.2.3":
+        target_encoded = is_classification
+    else:
+        target_encoded = False
+
     return result(
         output_file=config.output_predictions_file,
         predictions=predictions,
         truth=truth,
         probabilities=probabilities,
         probabilities_labels=probabilities_labels,
-        target_is_encoded=is_classification,
+        target_is_encoded=target_encoded,
         models_count=num_evals,
         training_duration=training.duration,
         predict_duration=predict_time

--- a/frameworks/MLPlan/setup.sh
+++ b/frameworks/MLPlan/setup.sh
@@ -22,13 +22,12 @@ PIP install --no-cache-dir -r $HERE/requirements.txt
 MLPLAN_ARC="mlplan.zip"
 DOWNLOAD_DIR="$HERE/lib"
 TARGET_DIR="$DOWNLOAD_DIR/mlplan"
+rm -Rf ${TARGET_DIR}
 
-if [[ ! -e "$TARGET_DIR" ]]; then
-    mkdir -p $DOWNLOAD_DIR
-    echo "Download ML-Plan from extern"
-    wget https://download.mlplan.org/version/$VERSION -O $DOWNLOAD_DIR/$MLPLAN_ARC
-    echo "Download finished. Now unzip the downloaded file."
-    unzip $DOWNLOAD_DIR/$MLPLAN_ARC -d $TARGET_DIR
-fi
+mkdir -p $DOWNLOAD_DIR
+echo "Download ML-Plan from extern"
+wget -q https://download.mlplan.org/version/$VERSION -O $DOWNLOAD_DIR/$MLPLAN_ARC
+echo "Download finished. Now unzip the downloaded file."
+unzip $DOWNLOAD_DIR/$MLPLAN_ARC -d $TARGET_DIR
 
 find $HERE/lib/mlplan/*.jar | sed -e 's/.*\/mlplan-cli-\(.*\)\.jar/\1/' >> "${HERE}/.installed"


### PR DESCRIPTION
* Added feature for returning the time taken for making the predictions with the finally chosen candidate.

Note: ML-Plan takes the time for fitting the finally chosen solution candidate into account and tries to meet the timeout including fitting the solution. The prediction time for the test data, however, is not anticipated.

Furthermore, we just released a new version (0.2.4) with several bug fixes and a few enhancements. I did not want to mess up the frameworks.yaml files so I did not touch them. As far as I can see, except for the Q2.2020 file, the version of ML-Plan always refers to the "latest" version. If this is also the version which is benchmarked everything should be fine.