### PR TITLE
Allow exit on error of a job

### DIFF
--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -443,6 +443,8 @@ class BenchmarkTask:
             log.info("Running task %s on framework %s with config:\n%s", task_config.name, self.benchmark.framework_name, repr_def(task_config))
             meta_result = self.benchmark.framework_module.run(self._dataset, task_config)
         except Exception as e:
+            if rconfig().exit_on_error:
+                raise
             log.exception(e)
             result = ErrorResult(e)
         finally:

--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -404,7 +404,9 @@ class BenchmarkTask:
             self.task_config.name,
             str(self.fold),
             self.benchmark.framework_name
-        ]), timeout_secs=timeout_secs)  # this timeout is just to handle edge cases where framework never completes
+        ]), timeout_secs=timeout_secs,  # this timeout is just to handle edge cases where framework never completes
+            raise_exceptions=rconfig().exit_on_error,
+        )
         job._run = _run
         return job
         # return Namespace(run=lambda: self.run(framework))

--- a/amlb/job.py
+++ b/amlb/job.py
@@ -6,16 +6,14 @@
   - SimpleJobRunner runs the jobs sequentially.
   - ParallelJobRunner queues the jobs and run them in a dedicated thread
 """
-from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 from enum import Enum, auto
 import logging
-import multiprocessing
 import queue
 import signal
 import threading
 import time
 
-from .resources import config as rconfig
 from .utils import Namespace, Timer, InterruptTimeout, raise_in_thread, signal_handler
 
 log = logging.getLogger(__name__)
@@ -44,12 +42,22 @@ class CancelledError(JobError):
 
 class Job:
 
-    def __init__(self, name="", timeout_secs=None, priority=None):
+    def __init__(self, name="", timeout_secs=None, priority=None, raise_exceptions=False):
+        """
+
+        :param name:
+        :param timeout_secs:
+        :param priority:
+        :param raise_exceptions: bool (default=False)
+            If True, log and raise any Exception that caused a job failure.
+            If False, only log the exception.
+        """
         self.name = name
         self.timeout = timeout_secs
         self.priority = priority
         self.state = State.created
         self.thread_id = None
+        self.raise_exceptions = raise_exceptions
 
     def start(self):
         try:
@@ -74,7 +82,7 @@ class Job:
         except Exception as e:
             log.error("Job `%s` failed with error: %s", self.name, str(e))
             log.exception(e)
-            if rconfig().exit_on_error:
+            if self.raise_exceptions:
                 raise
             return None, -1
 

--- a/amlb/job.py
+++ b/amlb/job.py
@@ -15,6 +15,7 @@ import signal
 import threading
 import time
 
+from .resources import config as rconfig
 from .utils import Namespace, Timer, InterruptTimeout, raise_in_thread, signal_handler
 
 log = logging.getLogger(__name__)
@@ -73,6 +74,8 @@ class Job:
         except Exception as e:
             log.error("Job `%s` failed with error: %s", self.name, str(e))
             log.exception(e)
+            if rconfig().exit_on_error:
+                raise
             return None, -1
 
     def stop(self):

--- a/amlb/runners/aws.py
+++ b/amlb/runners/aws.py
@@ -80,7 +80,7 @@ class AWSBenchmark(Benchmark):
 
         def to_job(iid, inst):
             inst.instance = bench.ec2.Instance(iid)
-            job = Job(inst.key)
+            job = Job(inst.key, raise_exceptions=rconfig().exit_on_error)
             job.instance_id = iid
 
             def _run(job_self):
@@ -283,7 +283,8 @@ class AWSBenchmark(Benchmark):
             ','.join(task_names) if len(task_names) > 0 else 'all_tasks',
             ','.join(folds) if len(folds) > 0 else 'all_folds',
             self.framework_name
-        ]))
+        ]), raise_exceptions=rconfig().exit_on_error,
+        )
         job.ext = ns(
             tasks=task_names,
             folds=folds,

--- a/amlb/runners/container.py
+++ b/amlb/runners/container.py
@@ -118,7 +118,7 @@ class ContainerBenchmark(Benchmark):
             ','.join(task_names) if len(task_names) > 0 else 'all_tasks',
             ','.join(folds) if len(folds) > 0 else 'all_folds',
             self.framework_name
-        ]))
+        ]), raise_exceptions=rconfig().exit_on_error)
         job._run = _run
         return job
 

--- a/runbenchmark.py
+++ b/runbenchmark.py
@@ -47,6 +47,8 @@ parser.add_argument('-s', '--setup', choices=['auto', 'skip', 'force', 'only'], 
                          "•auto: setup is executed only if strictly necessary. •skip: setup is skipped. •force: setup is always executed before the benchmark. •only: only setup is executed (no benchmark).")
 parser.add_argument('-k', '--keep-scores', type=str2bool, metavar='true|false', nargs='?', const=True, default=True,
                     help="Set to true [default] to save/add scores in output directory.")
+parser.add_argument('-e', action='store_true', dest="exit_on_error",
+                    help="If set, *any* task that does not complete with a model will cause the script to terminate.")
 parser.add_argument('--profiling', nargs='?', const=True, default=False, help=argparse.SUPPRESS)
 parser.add_argument('--session', type=str, default=None, help=argparse.SUPPRESS)
 parser.add_argument('-X', '--extra', default=[], action='append', help=argparse.SUPPRESS)
@@ -103,6 +105,7 @@ config_args = ns.parse(
     run_mode=args.mode,
     parallel_jobs=args.parallel,
     sid=sid,
+    exit_on_error=args.exit_on_error,
 ) + ns.parse(extras)
 if args.mode != 'local':
     config_args + ns.parse({'monitoring.frequency_seconds': 0})


### PR DESCRIPTION
Add the `-e` parameter to allow an error of a job to propagate back up and terminate the execution of `runbenchmark.py`. 
Used in Github Workflow (work in progress) to correctly identify failed evaluations. Also useful if you don't want to run subsequent tasks if one fails.