### PR TITLE
Non-openML datasets: download only needed files

### DIFF
--- a/examples/custom/benchmarks/filedatasets.yaml
+++ b/examples/custom/benchmarks/filedatasets.yaml
@@ -53,4 +53,18 @@
   dataset: 'https://github.com/openml/automlbenchmark/raw/master/examples/custom/data/iris/iris_single_fold.zip'
   folds: 1
 
+- name: iris_remote_files
+  dataset:
+    train:
+      - 'https://github.com/openml/automlbenchmark/raw/master/examples/custom/data/iris/multi_folds/iris_train_0.csv'
+      - 'https://github.com/openml/automlbenchmark/raw/master/examples/custom/data/iris/multi_folds/iris_train_1.csv'
+      - 'https://github.com/openml/automlbenchmark/raw/master/examples/custom/data/iris/multi_folds/iris_train_2.csv'
+    test:
+      - 'https://github.com/openml/automlbenchmark/raw/master/examples/custom/data/iris/multi_folds/iris_test_0.csv'
+      - 'https://github.com/openml/automlbenchmark/raw/master/examples/custom/data/iris/multi_folds/iris_test_1.csv'
+      - 'https://github.com/openml/automlbenchmark/raw/master/examples/custom/data/iris/multi_folds/iris_test_2.csv'
+    target: species
+  folds: 3
+
+
 


### PR DESCRIPTION
when dataset is defined as a list of remote files, only download needed files: the previous logic was downloading all listed files even if only 1 fold was used for example.