### PR TITLE
Improve job/framework interruption after hard timeout.

### DIFF
--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -301,7 +301,6 @@ class TaskConfig:
         self.name = name
         self.fold = fold
         self.metrics = [metrics] if isinstance(metrics, str) else metrics
-        self.metric = metrics[0] if isinstance(metrics, list) else metrics
         self.seed = seed
         self.max_runtime_seconds = max_runtime_seconds
         self.cores = cores
@@ -311,6 +310,14 @@ class TaskConfig:
         self.output_dir = output_dir
         self.output_predictions_file = os.path.join(output_dir, "predictions.csv")
         self.ext = ns()  # used if frameworks require extra config points
+
+    def __setattr__(self, name, value):
+        if name == 'metrics':
+            self.metric = value[0] if isinstance(value, list) else value
+        elif name == 'max_runtime_seconds':
+            self.job_timeout_seconds = min(value * 2,
+                                           value + rconfig().benchmarks.overhead_time_seconds)
+        super().__setattr__(name, value)
 
     def __json__(self):
         return self.__dict__
@@ -395,16 +402,17 @@ class BenchmarkTask:
         def _run():
             self.load_data()
             return self.run()
-        timeout_secs = min(self.task_config.max_runtime_seconds * 2,
-                           self.task_config.max_runtime_seconds + rconfig().benchmarks.overhead_time_seconds)
         job = Job(name=rconfig().token_separator.join([
-            'local',
-            self.benchmark.benchmark_name,
-            self.benchmark.constraint_name,
-            self.task_config.name,
-            str(self.fold),
-            self.benchmark.framework_name
-        ]), timeout_secs=timeout_secs,  # this timeout is just to handle edge cases where framework never completes
+                'local',
+                self.benchmark.benchmark_name,
+                self.benchmark.constraint_name,
+                self.task_config.name,
+                str(self.fold),
+                self.benchmark.framework_name
+            ]),
+            # specifying a job timeout to handle edge cases where framework never completes or hangs
+            # (adding 1 min to let the potential subprocess handle the interruption first).
+            timeout_secs=self.task_config.job_timeout_seconds+60,
             raise_exceptions=rconfig().exit_on_error,
         )
         job._run = _run

--- a/amlb/runners/aws.py
+++ b/amlb/runners/aws.py
@@ -451,16 +451,26 @@ class AWSBenchmark(Benchmark):
             Statistics=['Average'],
             Unit='Percent'
         )
+        log.info(resp)
         return [activity['Average'] for activity in sorted(resp['Datapoints'], key=op.itemgetter('Timestamp'), reverse=True)]
 
     def _is_hanging(self, iid):
         cpu_config = rconfig().aws.ec2.monitoring.cpu
-        activity = self._get_cpu_activity(iid,
-                                          delta_minutes=cpu_config.delta_minutes,
-                                          period_minutes=cpu_config.period_minutes)
-        threshold = cpu_config.threshold
-        min_activity_len = int(cpu_config.delta_minutes / cpu_config.period_minutes)
-        return len(activity) >= min_activity_len and all([a < threshold for a in activity])
+        inst_desc = self.instances[iid]
+        try:
+            log.info("***** Check for hanging *****")
+            activity = self._get_cpu_activity(iid,
+                                              delta_minutes=cpu_config.delta_minutes,
+                                              period_minutes=cpu_config.period_minutes)
+            inst_desc.monitor_failure_start = 0
+            threshold = cpu_config.threshold
+            min_activity_len = int(cpu_config.delta_minutes / cpu_config.period_minutes)
+            return len(activity) >= min_activity_len and all([a < threshold for a in activity])
+        except Exception as e:
+            log.exception(e)
+            if inst_desc.monitor_failure_start == 0:
+                inst_desc.monitor_failure_start = time.time()
+            return time.time() - inst_desc.monitor_failure_start >= cpu_config.delta_minutes*60
 
     def _monitoring_start(self):
         if self.monitoring is not None:

--- a/amlb/runners/aws.py
+++ b/amlb/runners/aws.py
@@ -455,7 +455,6 @@ class AWSBenchmark(Benchmark):
 
     def _is_hanging(self, iid):
         cpu_config = rconfig().aws.ec2.monitoring.cpu
-        inst_desc = self.instances[iid]
         activity = self._get_cpu_activity(iid,
                                           delta_minutes=cpu_config.delta_minutes,
                                           period_minutes=cpu_config.period_minutes)

--- a/amlb/utils/process.py
+++ b/amlb/utils/process.py
@@ -334,7 +334,7 @@ class InterruptTimeout(Timeout):
                 except Exception:
                     raise
                 finally:
-                    self.interrupt_event.wait(1000)  # retry every second if interruption didn't work
+                    self.interrupt_event.wait(1)  # retry every second if interruption didn't work
 
         super().__init__(timeout_secs, on_timeout=interruption)
         if interrupt not in ['thread', 'process']:

--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -3,6 +3,7 @@
   * [Run a benchmark](#run-a-benchmark)
      * [Custom configuration](#custom-configuration)
         * [Run a framework with different (hyper-)parameters](#run-a-framework-with-different-hyper-parameters)
+     * [Advanced AWS Support](#advanced-aws-support) 
   * [Add a benchmark](#add-a-benchmark)
      * [Datasets definition](#datasets-definition)
         * [OpenML datasets](#openml-datasets)
@@ -74,6 +75,9 @@ aws:
 - `{user}`: replaced by the value of config `user_dir`. Folder containing customizations (`config.yaml`, benchmark definitions, framework definitions...). Defaults to `~/.config/automlbenchmark`, but can be overridden at the command line using `-u` or `--userdir`.
 - `{root}`: replaced by the value of config `root_dir`. The root folder of the `automlbenchmark` application: this is detected at runtime.
 
+**Note:** It is possible to have multiple configuration files: just create a folder for each `config.yaml` file and use that folder as your `user_dir` using `-u /path/to/config/folder`
+
+
 #### Run a framework with different (hyper-)parameters
 
 Framework definitions accept a `params` dictionary for pass-through parameters, i.e. parameters that are directly accessible from the `exec.py` file in the framework integration executing the AutoML training.
@@ -100,6 +104,34 @@ RandomForest_custom:
   params:
     n_estimators: 2000
     _n_jobs: 1
+```
+
+### Advanced AWS Support
+
+When using AWS mode, the application with use `on-demand` EC2 instances from the `m5` series by default.
+
+However, it is also possible to use `Spot` instances, specify a `max_hourly_price`, or customize your experience when using this mode in general.
+
+All configuration points are grouped and documented under the `aws` yaml namespace in the main [config] file.
+
+When setting  your own configuration, it is strongly recommended to first create your own `config.yaml` file as described in [Custom configuration](#custom-configuration).
+
+_Example:_
+
+A sample of a config file using Spot instances on a non-default region:
+```yaml
+
+aws:
+  region: 'us-east-1'
+  resource_files:
+    - '{user}/config.yaml'
+    - '{user}/frameworks.yaml'
+
+  ec2:
+    subnet_id: subnet-123456789   # subnet for account on us-east-1 region
+    spot:
+      enabled: true
+      max_hourly_price: 0.40  # comment out to use default
 ```
 
 ## Add a benchmark
@@ -954,3 +986,4 @@ If the setup fails on a supported environment, please try the following:
 [ARFF]: https://waikato.github.io/weka-wiki/formats_and_processing/arff_stable/
 [CSV]: https://tools.ietf.org/html/rfc4180
 [Docker]: https://docs.docker.com/
+[config]: ../resources/config.yaml

--- a/frameworks/shared/callee.py
+++ b/frameworks/shared/callee.py
@@ -82,18 +82,26 @@ def call_run(run_fn):
     config.framework_params = utils.Namespace.dict(config.framework_params)
 
     try:
-        result = run_fn(ds, config)
-        res = dict(result)
-        for name in ['predictions', 'truth', 'probabilities']:
-            arr = result[name]
-            if arr is not None:
-                res[name] = os.path.join(config.result_dir, '.'.join([name, 'npy']))
-                np.save(res[name], arr, allow_pickle=True)
+        with utils.InterruptTimeout(config.job_timeout_seconds,
+                                    sig=TimeoutError,
+                                    # interrupt='process',
+                                    # before_interrupt=lambda: utils.kill_proc_tree(include_parent=False)
+                                    ):
+            result = run_fn(ds, config)
+            res = dict(result)
+            for name in ['predictions', 'truth', 'probabilities']:
+                arr = result[name]
+                if arr is not None:
+                    res[name] = os.path.join(config.result_dir, '.'.join([name, 'npy']))
+                    np.save(res[name], arr, allow_pickle=True)
     except BaseException as e:
         log.exception(e)
         res = dict(
             error_message=str(e),
             models_count=0
         )
+    finally:
+        # ensure there's no subprocess left
+        utils.kill_proc_tree(include_parent=False)
 
     utils.json_dump(res, config.result_file, style='compact')

--- a/frameworks/shared/caller.py
+++ b/frameworks/shared/caller.py
@@ -10,7 +10,7 @@ from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
 from amlb.resources import config as rconfig
 from amlb.results import NoResultError, save_predictions
-from amlb.utils import Namespace as ns, Timer, TmpDir, dir_of, run_cmd, json_dumps, json_load, json_loads
+from amlb.utils import Namespace as ns, Timer, dir_of, run_cmd, json_dumps, json_load
 
 log = logging.getLogger(__name__)
 

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -8,12 +8,13 @@ user_dir: ~/.config/automlbenchmark   # where to override settings with a custom
 input_dir: ~/.openml/cache            # where the datasets are loaded by default.
 output_dir: results                   # where logs and results are saved by default.
 
-root_dir:   # app root dir: set by caller (runbenchamrk.py)
+root_dir:   # app root dir: set by caller (runbenchmark.py)
 script:     # calling script: set by caller (runbenchmark.py)
 run_mode:   # target run mode (local, docker, aws): set by caller (runbenchmark.py)
 sid:        # session id: set by caller (runbenchmark.py)
 
-test_mode: False
+test_mode: false
+exit_on_error: # if true, the entire run will be aborted on the first job failure (mainly used for testing) : set by caller (runbenchmark.py)
 parallel_jobs: 1
 max_parallel_jobs: 10  # safety limit: increase this if you want to be able to run many jobs in parallel, especially in aws mode. Defaults to 10 to allow running the usual 10 folds in parallel with no problem.
 delay_between_jobs: 5  # delay in seconds between each parallel job start
@@ -166,11 +167,11 @@ aws:
                                                # e.g. "linear:300:600" will first wait 5min and then add 10min to waiting time between each retry,
                                                #      "exponential:300:2:10800" with first wait 5min and then double waiting time between each retry, until the maximum of 3h then used for all retries.
       max_attempts: 10
-      fallback_to_on_demand: false             # if couldn't obtain a spot instance after max retry, starts an on-demand instance.
+      fallback_to_on_demand: false             # if couldn't obtain a spot instance after max attempts, starts an on-demand instance.
 
   max_timeout_seconds: 21600
   overhead_time_seconds: 1800   # amount of additional time allowed for the job to complete on aws before the instance is stopped.
-  query_frequency_seconds: 30
+  query_frequency_seconds: 30   # check instance state every N seconds
   resource_files: []    # additional resource files or directories that are made available to benchmark runs on ec2, from remote input or user directory.
                         # Those files are actually uploaded to s3 bucket (precisely to s3://{s3.bucket}/{s3.root_key}/user),
                         #  this folder being itself synchronized on each ec2 instance and used as user directory.

--- a/runbenchmark.py
+++ b/runbenchmark.py
@@ -93,7 +93,7 @@ log.debug("Script args: %s.", args)
 
 config = config_load(os.path.join(root_dir, "resources", "config.yaml"))
 # allowing config override from user_dir: useful to define custom benchmarks and frameworks for example.
-config_user = config_load(os.path.join(args.userdir if args.userdir is not None else config.user_dir, "config.yaml"))
+config_user = config_load(extras.get('config', os.path.join(args.userdir or config.user_dir, "config.yaml")))
 # config listing properties set by command line
 config_args = ns.parse(
     {'results.save': args.keep_scores},


### PR DESCRIPTION
The existing logic was not always able to interrupt the job, especially if the framework was running in a subprocess.
Therefore the subprocess (`callee.py`) now handles its own interruption logic, raising an error in the main thread and cleaning up the sub-subprocesses if any.
The job interruption is then delayed by 1 min to let the subprocess handle its own interruption and propagate the errors correctly and generate  an entry in the `results.csv` file.