### PR TITLE
Job Runner v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   - pip install -r dev-requirements.txt
 
 script:
-  - python -m pytest -s
+  - python -m pytest -m "not no_ci"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   - pip install -r dev-requirements.txt
 
 script:
-  - python -m pytest -v
+  - python -m pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   - pip install -r dev-requirements.txt
 
 script:
-  - python -m pytest
+  - python -m pytest -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   - pip install -r dev-requirements.txt
 
 script:
-  - python -m pytest
+  - python -m pytest -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   - pip install -r dev-requirements.txt
 
 script:
-  - python -m pytest -m "not no_ci"
+  - python -m pytest -m "not stress"

--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -183,9 +183,12 @@ class Benchmark:
             self.job_runner = SimpleJobRunner(jobs)
         else:
             # runner = ThreadPoolExecutorJobRunner(jobs, self.parallel_jobs)
+            queueing_strategy = (MultiThreadingJobRunner.QueueingStrategy.enforce_job_priority if rconfig().mode is 'aws'
+                                 else MultiThreadingJobRunner.QueueingStrategy.keep_queue_full)
             self.job_runner = MultiThreadingJobRunner(jobs, self.parallel_jobs,
                                                       delay_secs=rconfig().delay_between_jobs,
-                                                      done_async=True)
+                                                      done_async=True,
+                                                      queueing_strategy=queueing_strategy)
 
         try:
             with OSMonitoring(name=jobs[0].name if len(jobs) == 1 else None,

--- a/amlb/job.py
+++ b/amlb/job.py
@@ -167,7 +167,6 @@ class Job:
         """hook executed on the job once it's being cancelled by the runner:
         this is called only once on the job, and only if it didn't complete"""
         if self.thread_id is not None:
-
             raise_in_thread(self.thread_id, CancelledError)
 
     def _on_state(self, state: State):

--- a/amlb/job.py
+++ b/amlb/job.py
@@ -324,7 +324,6 @@ class MultiThreadingJobRunner(JobRunner):
                         result = job.start()
                         if job.state is not State.rescheduled:
                             self.results.append(result)
-                            print(len(self.results), result)
                         if self._done_async:
                             job.done()
                         self.stop_if_complete()

--- a/amlb/job.py
+++ b/amlb/job.py
@@ -324,6 +324,7 @@ class MultiThreadingJobRunner(JobRunner):
                         result = job.start()
                         if job.state is not State.rescheduled:
                             self.results.append(result)
+                            print(len(self.results), result)
                         if self._done_async:
                             job.done()
                         self.stop_if_complete()

--- a/amlb/job.py
+++ b/amlb/job.py
@@ -307,7 +307,9 @@ class MultiThreadingJobRunner(JobRunner):
         self._queueing_strategy = queueing_strategy
 
     def _run(self):
-        with signal_handler(signal.SIGINT, self.stop), signal_handler(signal.SIGTERM, self.stop):
+        def _stop(*ignored):
+            self.stop()
+        with signal_handler(signal.SIGINT, _stop), signal_handler(signal.SIGTERM, _stop):
             q = queue.Queue()
             available_workers = ThreadSafeCounter(self.parallel_jobs)
             wc = threading.Condition()

--- a/amlb/results.py
+++ b/amlb/results.py
@@ -446,7 +446,7 @@ class ErrorResult(NoResult):
     def __init__(self, error):
         msg = "{}: {}".format(type(error).__qualname__ if error is not None else "Error", error)
         max_len = rconfig().results.error_max_length
-        msg = msg if len(msg) <= max_len else (msg[:max_len - 3] + '...')
+        msg = msg if len(msg) <= max_len else (msg[:max_len - 1] + '…')
         super().__init__(msg)
 
 

--- a/amlb/runners/aws.py
+++ b/amlb/runners/aws.py
@@ -366,8 +366,11 @@ class AWSBenchmark(Benchmark):
                                 _self.ext.instance_id)
                 _self.ext.terminate = terminate
 
-            elif state == JobState.rescheduled:
+            elif state == JobState.rescheduling:
                 self._stop_instance(_self.ext.instance_id, terminate=True)
+
+            elif state == JobState.cancelling:
+                return True  # job is running remotely: no need to try to cancel what is running here, we just need to stop the instance
 
             elif state == JobState.stopping:
                 self._stop_instance(_self.ext.instance_id, terminate=_self.ext.terminate)

--- a/amlb/utils/core.py
+++ b/amlb/utils/core.py
@@ -301,6 +301,25 @@ def json_dumps(o, style='default'):
     return json.dumps(o, indent=indent, separators=separators, default=default_encode)
 
 
+#################################
+# Thread-safe utility functions #
+#################################
+
+class ThreadSafeCounter:
+
+    def __init__(self, value=0):
+        self.value = value
+        self._lock = threading.Lock()
+
+    def inc(self):
+        with self._lock:
+            self.value += 1
+
+    def dec(self):
+        with self._lock:
+            self.value -= 1
+
+
 def threadsafe_iterator(it):
     """
     Wrapper making an iterator thread-safe.

--- a/concat_csv.py
+++ b/concat_csv.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python
+
+import argparse
+
+import pandas as pd
+
+parser = argparse.ArgumentParser(
+    description="Small utility to safely concatenate multiple csv files, "
+                "especially useful here when concatenating multiple `results.csv` files.",
+    epilog="""Usage example:
+find ./results -name 'results.csv' -exec python concat_csv.py results.csv {} +
+""",
+    formatter_class=argparse.RawDescriptionHelpFormatter)
+parser.add_argument('target', type=str, help='The target file that will contain the concatenated csv files.')
+parser.add_argument('sources',  nargs='*', help='the csv files to be concatenated.')
+args = parser.parse_args()
+
+print(f"concatenating following files to `{args.target}`:\n{args.sources}")
+(pd.concat([pd.read_csv(file) for file in args.sources], ignore_index=True)
+   .drop_duplicates()
+   .to_csv(args.target, index=False))
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,5 @@
 markers =
     use_disk: access the filesystem
     use_web: access internet
+    no_ci: tests not intended to be run during continuous integration
 testpaths = tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,6 @@
 markers =
     use_disk: access the filesystem
     use_web: access internet
-    no_ci: tests not intended to be run during continuous integration
+    slow: tests taking at least a few seconds
+    stress: stress tests, not recommended to run by default
 testpaths = tests

--- a/tests/unit/amlb/job/dummy.py
+++ b/tests/unit/amlb/job/dummy.py
@@ -1,0 +1,29 @@
+import time
+
+from amlb.job import Job, State as JobState
+
+
+class DummyJob(Job):
+
+    def __init__(self, name="", timeout_secs=None, priority=None, raise_exceptions=False,
+                 duration_secs=0, result=None, steps=None, verbose=False):
+        self.steps = [] if steps is None else steps
+        self._verbose = verbose
+        self._duration_secs = duration_secs
+        self._result = result
+        super().__init__(name, timeout_secs, priority, raise_exceptions)
+
+    def _add_step(self, step):
+        self.steps.append((self.name, step))
+        if self._verbose:
+            print(f"job {self.name} in step {step}")
+
+    def _run(self):
+        super()._run()
+        if self._duration_secs > 0:
+            time.sleep(self._duration_secs)
+        return self._result
+
+    def _on_state(self, state: JobState):
+        self._add_step(state.name)
+

--- a/tests/unit/amlb/job/test_MultiThreadingJobRunner.py
+++ b/tests/unit/amlb/job/test_MultiThreadingJobRunner.py
@@ -15,7 +15,8 @@ steps_per_job = 6
 def test_run_multiple_jobs():
     seq_steps = []
     n_jobs = 10
-    jobs = [DummyJob(name=f"job_{i}", steps=seq_steps, verbose=True, duration_secs=0.1) for i in range(n_jobs)]
+    jobs = [DummyJob(name=f"job_{i}", result=i, steps=seq_steps, verbose=True, duration_secs=0.1)
+            for i in range(n_jobs)]
     assert len(seq_steps) == n_jobs
     assert all(step == 'created' for _, step in seq_steps)
 
@@ -27,7 +28,8 @@ def test_run_multiple_jobs():
 def test_run_multiple_jobs_with_delay():
     seq_steps = []
     n_jobs = 10
-    jobs = [DummyJob(name=f"job_{i}", steps=seq_steps, verbose=True, duration_secs=1) for i in range(n_jobs)]
+    jobs = [DummyJob(name=f"job_{i}", result=i, steps=seq_steps, verbose=True, duration_secs=1)
+            for i in range(n_jobs)]
 
     runner = MultiThreadingJobRunner(jobs, parallel_jobs=3, delay_secs=0.2)
     runner.start()
@@ -37,7 +39,8 @@ def test_run_multiple_jobs_with_delay():
 def test_stop_runner_during_job_run():
     seq_steps = []
     n_jobs = 10
-    jobs = [DummyJob(name=f"job_{i}", duration_secs=0.5, steps=seq_steps, verbose=True) for i in range(n_jobs)]
+    jobs = [DummyJob(name=f"job_{i}", duration_secs=0.5, result=i, steps=seq_steps, verbose=True)
+            for i in range(n_jobs)]
 
     runner = MultiThreadingJobRunner(jobs, parallel_jobs=3, delay_secs=0.2)
     with Timeout(timeout_secs=1, on_timeout=runner.stop):
@@ -48,7 +51,8 @@ def test_stop_runner_during_job_run():
 def test_reschedule_job_default():
     seq_steps = []
     n_jobs = 10
-    jobs = [DummyJob(name=f"job_{i}", duration_secs=1, result=i, steps=seq_steps, verbose=True) for i in range(n_jobs)]
+    jobs = [DummyJob(name=f"job_{i}", duration_secs=1, result=i, steps=seq_steps, verbose=True)
+            for i in range(n_jobs)]
 
     runner = MultiThreadingJobRunner(jobs, parallel_jobs=3, delay_secs=0.2)
 
@@ -84,7 +88,8 @@ def test_reschedule_job_default():
 def test_reschedule_job_enforce_job_priority():
     seq_steps = []
     n_jobs = 10
-    jobs = [DummyJob(name=f"job_{i}", duration_secs=1, result=i, steps=seq_steps, verbose=True) for i in range(n_jobs)]
+    jobs = [DummyJob(name=f"job_{i}", duration_secs=1, result=i, steps=seq_steps, verbose=True)
+            for i in range(n_jobs)]
 
     runner = MultiThreadingJobRunner(jobs, parallel_jobs=3, delay_secs=0.2,
                                      queueing_strategy=MultiThreadingJobRunner.QueueingStrategy.enforce_job_priority)
@@ -121,7 +126,9 @@ def test_reschedule_job_enforce_job_priority():
 def test_reschedule_job_high_parallelism():
     seq_steps = []
     n_jobs = 600
-    jobs = [DummyJob(name=f"job_{i}", duration_secs=random.randint(150, 250)/10, steps=seq_steps, verbose=True) for i in range(n_jobs)]
+    jobs = [DummyJob(name=f"job_{i}", duration_secs=random.randint(150, 250)/10, result=i,
+                     steps=seq_steps, verbose=True)
+            for i in range(n_jobs)]
 
     runner = MultiThreadingJobRunner(jobs, parallel_jobs=200, delay_secs=0.1,
                                      queueing_strategy=MultiThreadingJobRunner.QueueingStrategy.enforce_job_priority)

--- a/tests/unit/amlb/job/test_MultiThreadingJobRunner.py
+++ b/tests/unit/amlb/job/test_MultiThreadingJobRunner.py
@@ -2,6 +2,8 @@ import functools as ft
 import random
 from unittest.mock import patch, DEFAULT
 
+import pytest
+
 from amlb.job import MultiThreadingJobRunner
 from amlb.utils import Timeout
 
@@ -115,6 +117,7 @@ def test_reschedule_job_enforce_job_priority():
     assert seq_steps.index(('job_4', 'completing')) < seq_steps.index(('job_5', 'completing'))
 
 
+@pytest.mark.no_ci
 def test_reschedule_job_high_parallelism():
     seq_steps = []
     n_jobs = 600

--- a/tests/unit/amlb/job/test_MultiThreadingJobRunner.py
+++ b/tests/unit/amlb/job/test_MultiThreadingJobRunner.py
@@ -126,7 +126,7 @@ def test_reschedule_job_enforce_job_priority():
     assert seq_steps.index(('job_4', 'completing')) < seq_steps.index(('job_5', 'completing'))
 
 
-@pytest.mark.no_ci
+# @pytest.mark.no_ci
 def test_reschedule_job_high_parallelism():
     seq_steps = []
     n_jobs = 600

--- a/tests/unit/amlb/job/test_MultiThreadingJobRunner.py
+++ b/tests/unit/amlb/job/test_MultiThreadingJobRunner.py
@@ -12,6 +12,7 @@ from dummy import DummyJob
 steps_per_job = 6
 
 
+@pytest.mark.slow
 def test_run_multiple_jobs():
     seq_steps = []
     n_jobs = 10
@@ -25,6 +26,7 @@ def test_run_multiple_jobs():
     assert len(seq_steps) == n_jobs * steps_per_job
 
 
+@pytest.mark.slow
 def test_run_multiple_jobs_with_delay():
     seq_steps = []
     n_jobs = 10
@@ -36,6 +38,7 @@ def test_run_multiple_jobs_with_delay():
     assert len(seq_steps) == n_jobs * steps_per_job
 
 
+@pytest.mark.slow
 def test_stop_runner_during_job_run():
     seq_steps = []
     n_jobs = 10
@@ -48,6 +51,7 @@ def test_stop_runner_during_job_run():
     assert len(seq_steps) < n_jobs * steps_per_job
 
 
+@pytest.mark.slow
 def test_reschedule_job_default():
     seq_steps = []
     n_jobs = 10
@@ -85,7 +89,7 @@ def test_reschedule_job_default():
 
     assert seq_steps.index(('job_4', 'completing')) > seq_steps.index(('job_5', 'completing'))
 
-
+@pytest.mark.slow
 def test_reschedule_job_enforce_job_priority():
     seq_steps = []
     n_jobs = 10
@@ -126,7 +130,8 @@ def test_reschedule_job_enforce_job_priority():
     assert seq_steps.index(('job_4', 'completing')) < seq_steps.index(('job_5', 'completing'))
 
 
-# @pytest.mark.no_ci
+@pytest.mark.slow
+@pytest.mark.stress
 def test_reschedule_job_high_parallelism():
     seq_steps = []
     n_jobs = 600

--- a/tests/unit/amlb/job/test_MultiThreadingJobRunner.py
+++ b/tests/unit/amlb/job/test_MultiThreadingJobRunner.py
@@ -1,0 +1,62 @@
+from unittest.mock import patch, DEFAULT
+
+from amlb.job import MultiThreadingJobRunner
+from amlb.utils import Timeout
+
+from dummy import DummyJob
+
+steps_per_job = 5
+
+
+def test_run_multiple_jobs():
+    seq_steps = []
+    n_jobs = 10
+    jobs = [DummyJob(name=f"job_{i}", steps=seq_steps, verbose=True, duration_secs=0.1) for i in range(n_jobs)]
+    assert len(seq_steps) == n_jobs
+    assert all(step == 'created' for _, step in seq_steps)
+    seq_steps.clear()
+
+    runner = MultiThreadingJobRunner(jobs, parallel_jobs=3)
+    runner.start()
+    assert len(seq_steps) == n_jobs * steps_per_job
+
+
+def test_run_multiple_jobs_with_delay():
+    seq_steps = []
+    n_jobs = 10
+    jobs = [DummyJob(name=f"job_{i}", steps=seq_steps, verbose=True, duration_secs=1) for i in range(n_jobs)]
+    seq_steps.clear()
+
+    runner = MultiThreadingJobRunner(jobs, parallel_jobs=3, delay_secs=0.2)
+    runner.start()
+    assert len(seq_steps) == n_jobs * steps_per_job
+
+
+def test_stop_runner_during_job_run():
+    seq_steps = []
+    n_jobs = 10
+    jobs = [DummyJob(name=f"job_{i}", duration_secs=0.5, steps=seq_steps, verbose=True) for i in range(n_jobs)]
+    seq_steps.clear()
+
+    runner = MultiThreadingJobRunner(jobs, parallel_jobs=3, delay_secs=0.2)
+    with Timeout(timeout_secs=1, on_timeout=runner.stop):
+        runner.start()
+    assert len(seq_steps) < n_jobs * steps_per_job
+
+
+def test_reschedule_job():
+    seq_steps = []
+    n_jobs = 10
+    jobs = [DummyJob(name=f"job_{i}", duration_secs=15, steps=seq_steps, verbose=True) for i in range(n_jobs)]
+    seq_steps.clear()
+
+    runner = MultiThreadingJobRunner(jobs, parallel_jobs=3, delay_secs=1)
+    rescheduled_job = jobs[4]
+    with patch.object(rescheduled_job, "_run", wraps=rescheduled_job._run) as mock:
+        def _run():
+            if mock.call_count < 3:
+                runner.reschedule(rescheduled_job)
+            return DEFAULT # ensures that the wrapped function is called after the side effect
+        mock.side_effect = _run
+        runner.start()
+

--- a/tests/unit/amlb/job/test_MultiThreadingJobRunner.py
+++ b/tests/unit/amlb/job/test_MultiThreadingJobRunner.py
@@ -1,3 +1,5 @@
+import functools as ft
+import random
 from unittest.mock import patch, DEFAULT
 
 from amlb.job import MultiThreadingJobRunner
@@ -5,7 +7,7 @@ from amlb.utils import Timeout
 
 from dummy import DummyJob
 
-steps_per_job = 5
+steps_per_job = 6
 
 
 def test_run_multiple_jobs():
@@ -14,7 +16,6 @@ def test_run_multiple_jobs():
     jobs = [DummyJob(name=f"job_{i}", steps=seq_steps, verbose=True, duration_secs=0.1) for i in range(n_jobs)]
     assert len(seq_steps) == n_jobs
     assert all(step == 'created' for _, step in seq_steps)
-    seq_steps.clear()
 
     runner = MultiThreadingJobRunner(jobs, parallel_jobs=3)
     runner.start()
@@ -25,7 +26,6 @@ def test_run_multiple_jobs_with_delay():
     seq_steps = []
     n_jobs = 10
     jobs = [DummyJob(name=f"job_{i}", steps=seq_steps, verbose=True, duration_secs=1) for i in range(n_jobs)]
-    seq_steps.clear()
 
     runner = MultiThreadingJobRunner(jobs, parallel_jobs=3, delay_secs=0.2)
     runner.start()
@@ -36,7 +36,6 @@ def test_stop_runner_during_job_run():
     seq_steps = []
     n_jobs = 10
     jobs = [DummyJob(name=f"job_{i}", duration_secs=0.5, steps=seq_steps, verbose=True) for i in range(n_jobs)]
-    seq_steps.clear()
 
     runner = MultiThreadingJobRunner(jobs, parallel_jobs=3, delay_secs=0.2)
     with Timeout(timeout_secs=1, on_timeout=runner.stop):
@@ -44,19 +43,110 @@ def test_stop_runner_during_job_run():
     assert len(seq_steps) < n_jobs * steps_per_job
 
 
-def test_reschedule_job():
+def test_reschedule_job_default():
     seq_steps = []
     n_jobs = 10
-    jobs = [DummyJob(name=f"job_{i}", duration_secs=15, steps=seq_steps, verbose=True) for i in range(n_jobs)]
-    seq_steps.clear()
+    jobs = [DummyJob(name=f"job_{i}", duration_secs=1, result=i, steps=seq_steps, verbose=True) for i in range(n_jobs)]
 
-    runner = MultiThreadingJobRunner(jobs, parallel_jobs=3, delay_secs=1)
+    runner = MultiThreadingJobRunner(jobs, parallel_jobs=3, delay_secs=0.2)
+
+    def _run(self, mock):
+        if mock.call_count < 3:
+            runner.reschedule(self)
+            return
+        return DEFAULT  # ensures that the wrapped function is called after the side effect
+
     rescheduled_job = jobs[4]
     with patch.object(rescheduled_job, "_run", wraps=rescheduled_job._run) as mock:
-        def _run():
-            if mock.call_count < 3:
-                runner.reschedule(rescheduled_job)
-            return DEFAULT # ensures that the wrapped function is called after the side effect
-        mock.side_effect = _run
+        mock.side_effect = ft.partial(_run, rescheduled_job, mock)
         runner.start()
+
+    assert len(seq_steps) > n_jobs * steps_per_job
+    normal_job_steps = [s for n, s in seq_steps if n != rescheduled_job.name]
+    rescheduled_job_steps = [s for n, s in seq_steps if n == rescheduled_job.name]
+
+    for state in ['created', 'starting', 'running', 'completing', 'stopping', 'stopped']:
+        assert len(list(filter(lambda s: s == state, normal_job_steps))) == n_jobs - 1
+
+    assert len(list(filter(lambda s: s == 'created', rescheduled_job_steps))) == 1
+    assert len(list(filter(lambda s: s == 'starting', rescheduled_job_steps))) == 3
+    assert len(list(filter(lambda s: s == 'running', rescheduled_job_steps))) == 3
+    assert len(list(filter(lambda s: s == 'rescheduled', rescheduled_job_steps))) == 2
+    assert len(list(filter(lambda s: s == 'completing', rescheduled_job_steps))) == 1
+    assert len(list(filter(lambda s: s == 'stopping', rescheduled_job_steps))) == 1
+    assert len(list(filter(lambda s: s == 'stopped', rescheduled_job_steps))) == 1
+
+    assert seq_steps.index(('job_4', 'completing')) > seq_steps.index(('job_5', 'completing'))
+
+
+def test_reschedule_job_enforce_job_priority():
+    seq_steps = []
+    n_jobs = 10
+    jobs = [DummyJob(name=f"job_{i}", duration_secs=1, result=i, steps=seq_steps, verbose=True) for i in range(n_jobs)]
+
+    runner = MultiThreadingJobRunner(jobs, parallel_jobs=3, delay_secs=0.2,
+                                     queueing_strategy=MultiThreadingJobRunner.QueueingStrategy.enforce_job_priority)
+    def _run(self, mock):
+        if mock.call_count < 3:
+            runner.reschedule(self)
+            return
+        return DEFAULT  # ensures that the wrapped function is called after the side effect
+
+    rescheduled_job = jobs[4]
+    with patch.object(rescheduled_job, "_run", wraps=rescheduled_job._run) as mock:
+        mock.side_effect = ft.partial(_run, rescheduled_job, mock)
+        runner.start()
+
+    assert len(seq_steps) > n_jobs * steps_per_job
+    normal_job_steps = [s for n, s in seq_steps if n != rescheduled_job.name]
+    rescheduled_job_steps = [s for n, s in seq_steps if n == rescheduled_job.name]
+
+    for state in ['created', 'starting', 'running', 'completing', 'stopping', 'stopped']:
+        assert len(list(filter(lambda s: s == state, normal_job_steps))) == n_jobs - 1
+
+    assert len(list(filter(lambda s: s == 'created', rescheduled_job_steps))) == 1
+    assert len(list(filter(lambda s: s == 'starting', rescheduled_job_steps))) == 3
+    assert len(list(filter(lambda s: s == 'running', rescheduled_job_steps))) == 3
+    assert len(list(filter(lambda s: s == 'rescheduled', rescheduled_job_steps))) == 2
+    assert len(list(filter(lambda s: s == 'completing', rescheduled_job_steps))) == 1
+    assert len(list(filter(lambda s: s == 'stopping', rescheduled_job_steps))) == 1
+    assert len(list(filter(lambda s: s == 'stopped', rescheduled_job_steps))) == 1
+
+    assert seq_steps.index(('job_4', 'completing')) < seq_steps.index(('job_5', 'completing'))
+
+
+def test_reschedule_job_high_parallelism():
+    seq_steps = []
+    n_jobs = 600
+    jobs = [DummyJob(name=f"job_{i}", duration_secs=random.randint(150, 250)/10, steps=seq_steps, verbose=True) for i in range(n_jobs)]
+
+    runner = MultiThreadingJobRunner(jobs, parallel_jobs=200, delay_secs=0.1,
+                                     queueing_strategy=MultiThreadingJobRunner.QueueingStrategy.enforce_job_priority)
+
+    def _run(self, mock):
+        if mock.call_count < 3:
+            runner.reschedule(self)
+            return
+        return DEFAULT  # ensures that the wrapped function is called after the side effect
+
+    rescheduled_jobs = [j for i, j in enumerate(jobs) if i % 17 == 0]
+    for job in rescheduled_jobs:
+        mock = patch.object(job, "_run", wraps=job._run).start()
+        mock.side_effect = ft.partial(_run, job, mock)
+    runner.start()
+
+    rescheduled_job_names = [j.name for j in rescheduled_jobs]
+    normal_job_steps = [s for n, s in seq_steps if n not in rescheduled_job_names]
+    rescheduled_job_steps = [s for n, s in seq_steps if n in rescheduled_job_names]
+
+    for state in ['created', 'starting', 'running', 'completing', 'stopping', 'stopped']:
+        assert len(list(filter(lambda s: s == state, normal_job_steps))) == n_jobs - len(rescheduled_job_names)
+
+    assert len(list(filter(lambda s: s == 'created', rescheduled_job_steps))) == 1 * len(rescheduled_job_names)
+    assert len(list(filter(lambda s: s == 'starting', rescheduled_job_steps))) == 3 * len(rescheduled_job_names)
+    assert len(list(filter(lambda s: s == 'running', rescheduled_job_steps))) == 3 * len(rescheduled_job_names)
+    assert len(list(filter(lambda s: s == 'rescheduled', rescheduled_job_steps))) == 2 * len(rescheduled_job_names)
+    assert len(list(filter(lambda s: s == 'completing', rescheduled_job_steps))) == 1 * len(rescheduled_job_names)
+    assert len(list(filter(lambda s: s == 'stopping', rescheduled_job_steps))) == 1 * len(rescheduled_job_names)
+    assert len(list(filter(lambda s: s == 'stopped', rescheduled_job_steps))) == 1 * len(rescheduled_job_names)
 

--- a/tests/unit/amlb/job/test_SimpleJobRunner.py
+++ b/tests/unit/amlb/job/test_SimpleJobRunner.py
@@ -1,6 +1,8 @@
 import functools as ft
 from unittest.mock import patch, DEFAULT
 
+import pytest
+
 from amlb.job import SimpleJobRunner
 from amlb.utils import Timeout
 
@@ -9,6 +11,7 @@ from dummy import DummyJob
 steps_per_job = 6
 
 
+@pytest.mark.slow
 def test_run_multiple_jobs():
     seq_steps = []
     n_jobs = 10
@@ -31,6 +34,7 @@ def test_run_multiple_jobs():
     assert [r.result for r in results] == list(range(n_jobs))
 
 
+@pytest.mark.slow
 def test_stop_runner_during_job_run():
     seq_steps = []
     n_jobs = 10
@@ -45,6 +49,7 @@ def test_stop_runner_during_job_run():
     # assert results only for started jobs
 
 
+@pytest.mark.slow
 def test_reschedule_job():
     seq_steps = []
     n_jobs = 10

--- a/tests/unit/amlb/job/test_SimpleJobRunner.py
+++ b/tests/unit/amlb/job/test_SimpleJobRunner.py
@@ -1,0 +1,60 @@
+from unittest.mock import patch, DEFAULT
+
+from amlb.job import SimpleJobRunner
+from amlb.utils import Timeout
+
+from dummy import DummyJob
+
+steps_per_job = 5
+
+
+def test_run_multiple_jobs():
+    seq_steps = []
+    n_jobs = 10
+    jobs = [DummyJob(name=f"job_{i}", result=i, steps=seq_steps, verbose=True) for i in range(n_jobs)]
+    assert len(seq_steps) == n_jobs
+    assert all(step == 'created' for _, step in seq_steps)
+    seq_steps.clear()
+
+    runner = SimpleJobRunner(jobs)
+    results = runner.start()
+    print(results)
+    assert len(seq_steps) == n_jobs * steps_per_job
+    for i in range(n_jobs):
+        job_steps = seq_steps[steps_per_job*i : steps_per_job*(i+1)]
+        assert all(job == f"job_{i}" for job, _ in job_steps)
+        assert ['starting', 'running', 'completing', 'stopping', 'stopped'] == [step for _, step in job_steps]
+    assert len(results) == n_jobs
+    assert [r.result for r in results] == list(range(n_jobs))
+
+
+def test_stop_runner_during_job_run():
+    seq_steps = []
+    n_jobs = 10
+    jobs = [DummyJob(name=f"job_{i}", duration_secs=0.5, result=i, steps=seq_steps, verbose=True) for i in range(n_jobs)]
+    seq_steps.clear()
+
+    runner = SimpleJobRunner(jobs)
+    with Timeout(timeout_secs=2, on_timeout=runner.stop):
+        results = runner.start()
+    print(results)
+    assert len(seq_steps) < n_jobs * steps_per_job
+    # assert results only for started jobs
+
+
+def test_reschedule_job():
+    seq_steps = []
+    n_jobs = 10
+    jobs = [DummyJob(name=f"job_{i}", duration_secs=0.5, steps=seq_steps, verbose=True) for i in range(n_jobs)]
+    seq_steps.clear()
+
+    runner = SimpleJobRunner(jobs)
+    rescheduled_job = jobs[4]
+    with patch.object(rescheduled_job, "_run", wraps=rescheduled_job._run) as mock:
+        def _run():
+            if mock.call_count < 3:
+                runner.reschedule(rescheduled_job)
+            return DEFAULT # ensures that the wrapped function is called after the side effect
+        mock.side_effect = _run
+        runner.start()
+

--- a/tests/unit/amlb/job/test_SimpleJobRunner.py
+++ b/tests/unit/amlb/job/test_SimpleJobRunner.py
@@ -53,15 +53,16 @@ def test_reschedule_job():
 
     runner = SimpleJobRunner(jobs)
 
-    def _run(self, mock):
+    def _run(self, mock, ori):
         if mock.call_count < 3:
             runner.reschedule(self)
             return
-        return DEFAULT  # ensures that the wrapped function is called after the side effect
+        return ori()
 
     rescheduled_job = jobs[4]
-    with patch.object(rescheduled_job, "_run", wraps=rescheduled_job._run) as mock:
-        mock.side_effect = ft.partial(_run, rescheduled_job, mock)
+    ori = rescheduled_job._run
+    with patch.object(rescheduled_job, "_run") as mock:
+        mock.side_effect = ft.partial(_run, rescheduled_job, mock, ori)
         runner.start()
 
     assert len(seq_steps) > n_jobs * steps_per_job

--- a/tests/unit/amlb/job/test_SimpleJobRunner.py
+++ b/tests/unit/amlb/job/test_SimpleJobRunner.py
@@ -12,7 +12,8 @@ steps_per_job = 6
 def test_run_multiple_jobs():
     seq_steps = []
     n_jobs = 10
-    jobs = [DummyJob(name=f"job_{i}", result=i, steps=seq_steps, verbose=True) for i in range(n_jobs)]
+    jobs = [DummyJob(name=f"job_{i}", result=i, steps=seq_steps, verbose=True)
+            for i in range(n_jobs)]
     assert len(seq_steps) == n_jobs
     assert all(step == 'created' for _, step in seq_steps)
 
@@ -33,7 +34,8 @@ def test_run_multiple_jobs():
 def test_stop_runner_during_job_run():
     seq_steps = []
     n_jobs = 10
-    jobs = [DummyJob(name=f"job_{i}", duration_secs=0.5, result=i, steps=seq_steps, verbose=True) for i in range(n_jobs)]
+    jobs = [DummyJob(name=f"job_{i}", duration_secs=0.5, result=i, steps=seq_steps, verbose=True)
+            for i in range(n_jobs)]
 
     runner = SimpleJobRunner(jobs)
     with Timeout(timeout_secs=2, on_timeout=runner.stop):
@@ -46,7 +48,8 @@ def test_stop_runner_during_job_run():
 def test_reschedule_job():
     seq_steps = []
     n_jobs = 10
-    jobs = [DummyJob(name=f"job_{i}", duration_secs=0.5, steps=seq_steps, verbose=True) for i in range(n_jobs)]
+    jobs = [DummyJob(name=f"job_{i}", duration_secs=0.5, result=i, steps=seq_steps, verbose=True)
+            for i in range(n_jobs)]
 
     runner = SimpleJobRunner(jobs)
 

--- a/tests/unit/amlb/utils/process/test_InterruptTimeout.py
+++ b/tests/unit/amlb/utils/process/test_InterruptTimeout.py
@@ -52,7 +52,7 @@ def test_interruption_with_sig_as_error_instance():
 
 
 def test_interruption_with_sig_as_signal():
-    def _handler(*ignored):
+    def _handler(*_):
         raise TimeoutError("from handler")
     with signal_handler(signal.SIGTERM, _handler):
         timeout = 1
@@ -75,7 +75,7 @@ def test_before_interrupt_hook():
 
 
 def test_interruptions_escalation():
-    def _handler(*ignored):
+    def _handler(*_):
         raise TimeoutError("from handler")
     with signal_handler(signal.SIGINT, lambda *_: 0), signal_handler(signal.SIGTERM, _handler):
         before = Mock()
@@ -97,7 +97,7 @@ def test_interruptions_escalation():
 
 
 def test_wait_retry_in_interruptions_escalation():
-    def _handler(*ignored):
+    def _handler(*_):
         raise TimeoutError("from handler")
     with signal_handler(signal.SIGINT, lambda *_: 0), signal_handler(signal.SIGTERM, _handler):
         timeout = 1

--- a/tests/unit/amlb/utils/process/test_InterruptTimeout.py
+++ b/tests/unit/amlb/utils/process/test_InterruptTimeout.py
@@ -52,17 +52,17 @@ def test_interruption_with_sig_as_error_instance():
 
 
 def test_interruption_with_sig_as_signal():
-    def _handler():
+    def _handler(*ignored):
         raise TimeoutError("from handler")
-    signal_handler(signal.SIGTERM, _handler)
-    timeout = 1
-    with Timer() as t:
-        with pytest.raises(TimeoutError, match=r"from handler"):
-            with InterruptTimeout(timeout_secs=timeout, sig=signal.SIGTERM):
-                for i in range(100):
-                    time.sleep(.1)
-    assert t.duration - timeout < 1
-    assert i < 11
+    with signal_handler(signal.SIGTERM, _handler):
+        timeout = 1
+        with Timer() as t:
+            with pytest.raises(TimeoutError, match=r"from handler"):
+                with InterruptTimeout(timeout_secs=timeout, sig=signal.SIGTERM):
+                    for i in range(100):
+                        time.sleep(.1)
+        assert t.duration - timeout < 1
+        assert i < 11
 
 
 def test_before_interrupt_hook():
@@ -75,45 +75,42 @@ def test_before_interrupt_hook():
 
 
 def test_interruptions_escalation():
-    def _handler():
+    def _handler(*ignored):
         raise TimeoutError("from handler")
-    signal_handler(signal.SIGINT, lambda: 0)  # shouldn't interrupt anything
-    signal_handler(signal.SIGTERM, _handler)
-    before = Mock()
+    with signal_handler(signal.SIGINT, lambda *_: 0), signal_handler(signal.SIGTERM, _handler):
+        before = Mock()
 
-    timeout = 1
-    with Timer() as t:
-        with pytest.raises(TimeoutError, match=r"from handler"):
-            with InterruptTimeout(timeout_secs=timeout,
-                                  interruptions=[
-                                      dict(sig=signal.SIGINT),
-                                      dict(sig=signal.SIGTERM)
-                                  ],
-                                  before_interrupt=before):
-                for i in range(100):
-                    time.sleep(.1)
-    assert t.duration - timeout < 2  # default wait_retry_secs is 1s
-    assert 15 < i < 25
-    assert before.call_count == 2
+        timeout = 1
+        with Timer() as t:
+            with pytest.raises(TimeoutError, match=r"from handler"):
+                with InterruptTimeout(timeout_secs=timeout,
+                                      interruptions=[
+                                          dict(sig=signal.SIGINT),
+                                          dict(sig=signal.SIGTERM)
+                                      ],
+                                      before_interrupt=before):
+                    for i in range(100):
+                        time.sleep(.1)
+        assert t.duration - timeout < 2  # default wait_retry_secs is 1s
+        assert 15 < i < 25
+        assert before.call_count == 2
 
 
 def test_wait_retry_in_interruptions_escalation():
-    def _handler():
+    def _handler(*ignored):
         raise TimeoutError("from handler")
-    signal_handler(signal.SIGINT, lambda: 0)  # shouldn't interrupt anything
-    signal_handler(signal.SIGTERM, _handler)
-
-    timeout = 1
-    with Timer() as t:
-        with pytest.raises(TimeoutError, match=r"from handler"):
-            with InterruptTimeout(timeout_secs=timeout,
-                                  interruptions=[
-                                      dict(sig=signal.SIGINT),
-                                      dict(sig=signal.SIGTERM)
-                                  ],
-                                  wait_retry_secs=0.3):
-                for i in range(100):
-                    time.sleep(.1)
-    assert t.duration - timeout < 1
-    assert 10 < i < 15
+    with signal_handler(signal.SIGINT, lambda *_: 0), signal_handler(signal.SIGTERM, _handler):
+        timeout = 1
+        with Timer() as t:
+            with pytest.raises(TimeoutError, match=r"from handler"):
+                with InterruptTimeout(timeout_secs=timeout,
+                                      interruptions=[
+                                          dict(sig=signal.SIGINT),
+                                          dict(sig=signal.SIGTERM)
+                                      ],
+                                      wait_retry_secs=0.3):
+                    for i in range(100):
+                        time.sleep(.1)
+        assert t.duration - timeout < 1
+        assert 10 < i < 15
 


### PR DESCRIPTION
Fixed race condition when multiple jobs terminate at the same time: common with high parallelism.

Partially rewrote the job runner to be more robust and predictable, especially when using Spot instances where job rescheduling is sometimes required.
- now using a proper state machine.
- generic hooks when the job change state.
- job state change hooks used in aws mode to trigger cleanup logic, rescheduling, …

Added test suites for job runners and rescheduling mechanism.