### PR TITLE
Show constant columns separately from the results

### DIFF
--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -265,7 +265,15 @@ class Benchmark:
         if rconfig().results.save:
             self._save(board)
 
-        log.info("Summing up scores for current run:\n%s", board.as_printable_data_frame().dropna(how='all', axis='columns').to_string())
+        df = board.as_printable_data_frame().dropna(how='all', axis='columns')
+        show_in_table = [
+            'result', 'duration', 'training_duration', 'predict_duration',
+            'models_count', "acc", "auc", "balacc", "logloss", "mae", "r2", "rmse"
+        ]
+        constants = [c for c in df.columns[df.nunique() == 1] if c not in show_in_table]
+        log.info("\nSumming up scores for current run:")
+        log.info(''.join(f"{c}: {df[c].iloc[0]}\n" for c in constants))
+        log.info(df[(c for c in df.columns if c not in constants)].to_string())
         return board.as_data_frame()
 
     def _save(self, board):


### PR DESCRIPTION
With more columns added over time to the results table, the printed table would generally wrap long lines. This makes the table very hard to read. At the same time a lot of the information is redundant. This table separately prints some constant information so the variable data in the table can be displayed neatly on more screens.

This takes the output from:
![image](https://user-images.githubusercontent.com/15890747/110794969-96a3c880-8276-11eb-9ffc-a146395997e7.png)

to:

![image](https://user-images.githubusercontent.com/15890747/110794930-8b509d00-8276-11eb-8cbc-dc80e0d6a945.png)

I would also consider the following changes:
 - don't show the result for each metric but only the one optimized for (or otherwise print them with lower precision),
 - rename some columns for brevity, e.g. `duration` columns to `time (s)` `train (s)` and `predict (s)`
 - drop `seed`
 
 None of these changes would affect the stored data. 