### PR TITLE
Docker for Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/amlb/resources.py
+++ b/amlb/resources.py
@@ -8,6 +8,7 @@ import os
 import random
 import re
 import sys
+import warnings
 
 from amlb.benchmarks.parser import benchmark_load
 from amlb.frameworks import default_tag, load_framework_definitions
@@ -72,9 +73,21 @@ class Resources:
                 return defval
 
         na = "NA"
-        version = git("--version")
-        is_git_repo = version and git("rev-parse --git-dir 2> /dev/null")
-        if is_git_repo:
+        git_version = git("--version")
+        if git_version is None:
+            warnings.warn(
+                "Cannot identify git version. Is git in path?",
+                RuntimeWarning
+            )
+
+        is_repo = git("rev-parse") is not None
+        if not is_repo:
+            warnings.warn(
+                "Directory '{}' is not a git repository.".format(os.getcwd()),
+                RuntimeWarning
+            )
+
+        if git_version and is_repo:
             repo = git("remote get-url origin", na)
             branch = git("rev-parse --abbrev-ref HEAD", na)
             commit = git("rev-parse HEAD", na)

--- a/amlb/resources.py
+++ b/amlb/resources.py
@@ -74,18 +74,7 @@ class Resources:
 
         na = "NA"
         git_version = git("--version")
-        if git_version is None:
-            warnings.warn(
-                "Cannot identify git version. Is git in path?",
-                RuntimeWarning
-            )
-
         is_repo = git("rev-parse") is not None
-        if not is_repo:
-            warnings.warn(
-                "Directory '{}' is not a git repository.".format(os.getcwd()),
-                RuntimeWarning
-            )
 
         if git_version and is_repo:
             repo = git("remote get-url origin", na)

--- a/amlb/resources.py
+++ b/amlb/resources.py
@@ -8,7 +8,6 @@ import os
 import random
 import re
 import sys
-import warnings
 
 from amlb.benchmarks.parser import benchmark_load
 from amlb.frameworks import default_tag, load_framework_definitions

--- a/amlb/utils/process.py
+++ b/amlb/utils/process.py
@@ -86,20 +86,14 @@ def as_cmd_args(*args, **kwargs):
 
 def live_output_windows(process: subprocess.Popen, timeout, **ignored) -> Tuple[str, str]:
     """ Custom output forwarder, because select.select is not Windows compatible. """
-    def wrap_if_needed(s):
-        """ Wrap the stream in TextIO if stream produces bytes. """
-        if hasattr(process, "text_mode") and process.text_mode:
-            return s
-        return io.TextIOWrapper(s, encoding="utf-8")
-
     outputs = dict(
         out=dict(
-            stream=wrap_if_needed(process.stdout),
+            stream=process.stdout,
             queue=queue.Queue(),
             lines=[],
         ),
         err=dict(
-            stream=wrap_if_needed(process.stderr),
+            stream=process.stderr,
             queue=queue.Queue(),
             lines=[],
         ),

--- a/amlb/utils/process.py
+++ b/amlb/utils/process.py
@@ -110,12 +110,13 @@ def live_output_windows(process: subprocess.Popen, timeout, **ignored) -> Tuple[
 
     while process.poll() is None:
         for output in outputs.values():
-            try:
-                line = output["queue"].get(timeout=timeout)
-                output["lines"].append(line)
-                print(line.rstrip())
-            except queue.Empty:
-                pass
+            while True:
+                try:
+                    line = output["queue"].get(timeout=0.5)
+                    output["lines"].append(line)
+                    print(line.rstrip())
+                except queue.Empty:
+                    break
     return ''.join(outputs["out"]["lines"]), ''.join(outputs["err"]["lines"])
 
 

--- a/amlb/utils/process.py
+++ b/amlb/utils/process.py
@@ -185,7 +185,7 @@ def run_cmd(cmd, *args, **kwargs):
     if platform.system() == "Windows":
         live_output = partial(live_output_windows, timeout=params.activity_timeout)
     else:
-        live_output = partial(live_output_unix, timeout=params.activity_timeout)
+        live_output = partial(live_output_unix, mode=params.live_output, activity_timeout=params.activity_timeout)
 
     try:
         completed = run_subprocess(str_cmd if params.shell else full_cmd,
@@ -631,6 +631,5 @@ def profile(logger=log, log_level=None, duration=True, memory=True):
         return profiler
 
     return decorator
-
 
 


### PR DESCRIPTION
There were a few issues with using docker mode `-m docker` in Windows.
The main pitfalls were:
 - default git behavior checking out `.sh` files locally with `crlf` ending, which can't be executed by a bash shell.
 - live output monitoring using `select` which is not supported for file descriptors in Windows.
 
 I could not find a proper supported way to monitor process output non-blocking in Windows (without resorting to a new package), so I made a custom function based on various solutions proposed on StackOverflow.

Also fixes a bug where `git` was not detected due to `2>/dev/null` in a command, which does not work on Windows.
If that error ignoring was desirable, I can make it platform specific (I think my fix preserves the intended functionality, but I might have missed the point).

Tested with `python runbenchmark.py h2oautoml openml/t/59 -f 0 -m docker -s force ` in Windows (it would be appreciated if you could run it on a non-Windows platform to make sure I did not break anything, @sebhrusen).