### PR TITLE
Add failures entry on missing result

### DIFF
--- a/amlb/results.py
+++ b/amlb/results.py
@@ -33,6 +33,7 @@ class ResultError(Exception):
 # TODO: reconsider organisation of output files:
 #   predictions: add framework version to name, timestamp? group into subdirs?
 
+
 class Scoreboard:
 
     results_file = 'results.csv'

--- a/amlb/utils/core.py
+++ b/amlb/utils/core.py
@@ -223,6 +223,10 @@ def str_def(o, if_none='', if_empty=_empty_):
     return str(o)
 
 
+def str_iter(col, sep=", "):
+    return sep.join(map(str, col))
+
+
 def str_sanitize(s):
     return re.sub(r"[^\w-]", "_", s)
 


### PR DESCRIPTION
Ensure that there is an entry in the failures file for each job for which we can't obtain a `results.csv` file.

Frameworks errors should be handled by the job on the remote instance and always produce an entry in the `results.csv` including a short description of the error.
Which means that if there's no  `results.csv` available, then the job failed for unkown reason and it's reasonable to consider that it could  be rerun later once we have a mechanism to load the `failures.csv` file for such reruns.