### PR TITLE
Add the possibility to declare a framework as abstract

### DIFF
--- a/amlb/frameworks/definitions.py
+++ b/amlb/frameworks/definitions.py
@@ -59,9 +59,8 @@ def _sanitize_and_add_defaults(frameworks, config):
     # based on the parent. For that reason we add it before
     # we update children with their parent fields.
     for _, framework in frameworks:
-        if "extends" in framework:
-            _add_default_abstract(framework, config)
-        else:
+        _add_default_abstract(framework, config)
+        if "extends" not in framework:
             _add_default_module(framework, config)
             _add_default_image(framework, config, props=['image'])
     _update_frameworks_with_parent_definitions(frameworks)

--- a/amlb/frameworks/definitions.py
+++ b/amlb/frameworks/definitions.py
@@ -59,7 +59,9 @@ def _sanitize_and_add_defaults(frameworks, config):
     # based on the parent. For that reason we add it before
     # we update children with their parent fields.
     for _, framework in frameworks:
-        if "extends" not in framework:
+        if "extends" in framework:
+            _add_default_abstract(framework, config)
+        else:
             _add_default_module(framework, config)
             _add_default_image(framework, config, props=['image'])
     _update_frameworks_with_parent_definitions(frameworks)
@@ -83,6 +85,11 @@ def _add_framework_name(frameworks: Namespace):
 def _add_default_module(framework, config):
     if "module" not in framework:
         framework.module = f"{config.frameworks.root_module}.{framework.name}"
+
+
+def _add_default_abstract(framework, config):
+    if 'abstract' not in framework:
+        framework.abstract = False
 
 
 def _add_default_version(framework):

--- a/amlb/resources.py
+++ b/amlb/resources.py
@@ -134,8 +134,8 @@ class Resources:
         framework = next((f for n, f in frameworks if n.lower() == lname), None)
         if not framework:
             raise ValueError("Incorrect framework `{}`: not listed in {}.".format(name, self.config.frameworks.definition_file))
-        if framework.abstract:
-            raise ValueError("Framework definition `{}` is abstract and can't be run directly.".format(name))
+        if framework['abstract']:
+            raise ValueError("Framework definition `{}` is abstract and cannot be run directly.".format(name))
         return framework, framework.name
 
     @lazy_property

--- a/amlb/resources.py
+++ b/amlb/resources.py
@@ -134,6 +134,8 @@ class Resources:
         framework = next((f for n, f in frameworks if n.lower() == lname), None)
         if not framework:
             raise ValueError("Incorrect framework `{}`: not listed in {}.".format(name, self.config.frameworks.definition_file))
+        if framework.abstract:
+            raise ValueError("Framework definition `{}` is abstract and can't be run directly.".format(name))
         return framework, framework.name
 
     @lazy_property

--- a/resources/frameworks.yaml
+++ b/resources/frameworks.yaml
@@ -116,6 +116,7 @@ mljarsupervised_compete:
 
 MLPlan:
   version: 'stable'
+  abstract: true
   description: |
     ML-Plan is an approach to AutoML based on hierarchical task networks (HTNs).
   project: http://mlplan.org

--- a/resources/frameworks_2020Q2.yaml
+++ b/resources/frameworks_2020Q2.yaml
@@ -42,6 +42,7 @@ mljarsupervised_compete:
     mode: Compete   # set mode for Compete, default mode is Explain
 
 MLPlan:
+  abstract: true
   version: '0.2.3'
 
 MLPlanSKLearn:

--- a/resources/frameworks_latest.yaml
+++ b/resources/frameworks_latest.yaml
@@ -51,6 +51,7 @@ mljarsupervised_compete:
     mode: Compete   # set mode for Compete, default mode is Explain
 
 MLPlan:
+  abstract: true
   version: 'latest'
 
 MLPlanSKLearn:

--- a/resources/frameworks_stable.yaml
+++ b/resources/frameworks_stable.yaml
@@ -47,6 +47,7 @@ mljarsupervised_compete:
     mode: Compete   # set mode for Compete, default mode is Explain
 
 MLPlan:
+  abstract: true
   version: 'stable'
 
 MLPlanSKLearn:

--- a/tests/unit/amlb/frameworks/definitions/resources/frameworks_inheritance.yaml
+++ b/tests/unit/amlb/frameworks/definitions/resources/frameworks_inheritance.yaml
@@ -1,5 +1,6 @@
 ---
 framework:
+  abstract: true
   version: 'latest'
   project: https://some.url
 

--- a/tests/unit/amlb/frameworks/definitions/test_load_framework_definitions.py
+++ b/tests/unit/amlb/frameworks/definitions/test_load_framework_definitions.py
@@ -27,6 +27,10 @@ def test_version_inheritance(simple_resource):
     assert child2.version == 'child2'
     assert grandchild2.version == 'child2'
 
+    assert parent.abstract
+    for f in [child1, child2, grandchild1, grandchild2]:
+        assert not f.abstract, f"{f.name} unexpectedly abstract"
+
 
 @pytest.mark.use_disk
 def test_docker_image_inheritance(simple_resource):

--- a/tests/unit/amlb/resources/test_framework_definition.py
+++ b/tests/unit/amlb/resources/test_framework_definition.py
@@ -1,29 +1,30 @@
 import pytest
+
 from amlb.frameworks import default_tag
 from amlb.resources import Resources
-from amlb.utils import Namespace as NS
+from amlb.utils import Namespace as ns
 
 
 @pytest.mark.parametrize(
     "frameworks, lookup, expected",
     [
-        (NS(MixedCase=NS(name="MixedCase")), "MixedCase", "MixedCase"),
-        (NS(MixedCase=NS(name="MixedCase")), "mixedcase", "MixedCase"),
-        (NS(MixedCase=NS(name="MixedCase")), "MIXEDCASE", "MixedCase"),
-        (NS(MixedCase=NS(name="MixedCase")), "mIxEdCasE", "MixedCase"),
+        (ns(MixedCase=ns(name="MixedCase")), "MixedCase", "MixedCase"),
+        (ns(MixedCase=ns(name="MixedCase")), "mixedcase", "MixedCase"),
+        (ns(MixedCase=ns(name="MixedCase")), "MIXEDCASE", "MixedCase"),
+        (ns(MixedCase=ns(name="MixedCase")), "mIxEdCasE", "MixedCase"),
     ]
 )
 def test_framework_definition_lookup_is_case_insensitive(frameworks, lookup, expected):
-    res = NS(_frameworks={default_tag: frameworks})
+    res = ns(_frameworks={default_tag: frameworks})
     # binding `framework_definition` method to our resource mock: use pytest-mock instead?
     res.framework_definition = Resources.framework_definition.__get__(res)
     assert res.framework_definition(lookup) == (frameworks[expected], frameworks[expected].name)
 
 
 def test_framework_definition_raises_error_if_no_matching_framework():
-    res = NS(
-        config=NS(frameworks=NS(definition_file="none")),
-        _frameworks={default_tag: NS(present=NS(name="present"))}
+    res = ns(
+        config=ns(frameworks=ns(definition_file="none")),
+        _frameworks={default_tag: ns(present=ns(name="present"))}
     )
     # binding `framework_definition` method to our resource mock: use pytest-mock instead?
     res.framework_definition = Resources.framework_definition.__get__(res)
@@ -31,3 +32,13 @@ def test_framework_definition_raises_error_if_no_matching_framework():
     with pytest.raises(ValueError, match=r"Incorrect framework `missing`"):
         res.framework_definition("missing")
 
+
+def test_framework_definition_raises_error_if_the_framework_is_abstract():
+    res = ns(
+        config=ns(frameworks=ns(definition_file="none")),
+        _frameworks={default_tag: ns(present=ns(name="present", abstract=True))}
+    )
+    # binding `framework_definition` method to our resource mock: use pytest-mock instead?
+    res.framework_definition = Resources.framework_definition.__get__(res)
+    with pytest.raises(ValueError, match=r"Framework definition `present` is abstract and cannot be run directly"):
+        res.framework_definition("present")


### PR DESCRIPTION
This is mainly useful to define a "template" framework from which children could extend to inherit all its properties without wanting to be able to run the template itself.

A typical use-case is MLPLan that comes with 2 training engines.