### PR TITLE
Unable to build docker image for any of the R framework

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,9 +8,11 @@ results
 **/models
 **/predictions
 **/scores
-**/lib
-**/.marker*
+**/.installed
+**/.setup_env
 **/__pycache__
+**/lib
+**/setup
 **/venv
 
 # editors/IDEs

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 Dockerfile
 .marker*
 .installed
+.setup_env
 my_*
 
 # python env

--- a/amlb/results.py
+++ b/amlb/results.py
@@ -380,7 +380,7 @@ class TaskResult:
             type=metadata.type_,
             constraint=self.constraint,
             framework=metadata.framework,
-            version=metadata.version if 'version' in metadata else metadata.framework_version,
+            version=metadata.framework_version,
             params=repr(metadata.framework_params) if metadata.framework_params else '',
             fold=self.fold,
             mode=rconfig().run_mode,

--- a/amlb/runners/aws.py
+++ b/amlb/runners/aws.py
@@ -1124,7 +1124,7 @@ runcmd:
   - mkdir /repo
   - cd /repo
   - git clone --depth 1 --single-branch --branch {branch} {repo} .
-  - python{pyv} install -U pip wheel awscli
+  - python{pyv} -m pip install -U pip wheel awscli
   - python{pyv} -m venv venv
   - alias PIP='/repo/venv/bin/python3 -m pip'
   - alias PY='/repo/venv/bin/python3 -W ignore'
@@ -1199,7 +1199,7 @@ mkdir /repo
 cd /repo
 git clone --depth 1 --single-branch --branch {branch} {repo} .
 
-python{pyv} install -U pip wheel awscli
+python{pyv} -m pip install -U pip wheel awscli
 python{pyv} -m venv venv
 alias PIP='/repo/venv/bin/python3 -m pip'
 alias PY='/repo/venv/bin/python3 -W ignore'

--- a/amlb/runners/aws.py
+++ b/amlb/runners/aws.py
@@ -1116,16 +1116,16 @@ runcmd:
   - systemctl daemon-reload
   - add-apt-repository -y ppa:deadsnakes/ppa
   - apt-get update
-  - apt-get -y install python{pyv} python{pyv}-venv python{pyv}-dev python3-pip
-  - update-alternatives --install /usr/bin/python3 python3 $(which python{pyv}) 1
-  - pip3 install -U pip wheel awscli
+  - apt-get -y install python{pyv} python{pyv}-venv python{pyv}-dev python3-pip python3-apt
+#  - update-alternatives --install /usr/bin/python3 python3 $(which python{pyv}) 1
   - mkdir -p /s3bucket/input
   - mkdir -p /s3bucket/output
   - mkdir -p /s3bucket/user
   - mkdir /repo
   - cd /repo
   - git clone --depth 1 --single-branch --branch {branch} {repo} .
-  - python3 -m venv venv
+  - python{pyv} install -U pip wheel awscli
+  - python{pyv} -m venv venv
   - alias PIP='/repo/venv/bin/python3 -m pip'
   - alias PY='/repo/venv/bin/python3 -W ignore'
   - alias PIP_REQ='xargs -L 1 /repo/venv/bin/python3 -m pip install --no-cache-dir'
@@ -1189,9 +1189,8 @@ apt-get -y install curl wget unzip git
 apt-get -y install software-properties-common
 add-apt-repository -y ppa:deadsnakes/ppa
 apt-get update
-apt-get -y install python{pyv} python{pyv}-venv python{pyv}-dev python3-pip
-update-alternatives --install /usr/bin/python3 python3 $(which python{pyv}) 1
-pip3 install -U pip wheel awscli
+apt-get -y install python{pyv} python{pyv}-venv python{pyv}-dev python3-pip python3-apt
+#update-alternatives --install /usr/bin/python3 python3 $(which python{pyv}) 1
 
 mkdir -p /s3bucket/input
 mkdir -p /s3bucket/output
@@ -1200,7 +1199,8 @@ mkdir /repo
 cd /repo
 git clone --depth 1 --single-branch --branch {branch} {repo} .
 
-python3 -m venv venv
+python{pyv} install -U pip wheel awscli
+python{pyv} -m venv venv
 alias PIP='/repo/venv/bin/python3 -m pip'
 alias PY='/repo/venv/bin/python3 -W ignore'
 #PIP install -U pip=={pipv}

--- a/amlb/runners/docker.py
+++ b/amlb/runners/docker.py
@@ -118,12 +118,11 @@ RUN apt-get -y install software-properties-common
 RUN add-apt-repository -y ppa:deadsnakes/ppa
 RUN apt-get update
 RUN apt-get -y install python{pyv} python{pyv}-venv python{pyv}-dev python3-pip
-RUN update-alternatives --install /usr/bin/python3 python3 $(which python{pyv}) 1
-RUN pip3 install -U pip wheel
+#RUN update-alternatives --install /usr/bin/python3 python3 $(which python{pyv}) 1
 
 # aliases for the python system
-ENV SPIP python3 -m pip
-ENV SPY python3
+ENV SPIP python{pyv} -m pip
+ENV SPY python{pyv}
 
 # Enforce UTF-8 encoding
 ENV PYTHONUTF8 1
@@ -136,6 +135,7 @@ WORKDIR /bench
 
 # We create a virtual environment so that AutoML systems may use their preferred versions of
 # packages that we need to data pre- and postprocessing without breaking it.
+RUN $SPIP install -U pip wheel
 RUN $SPY -m venv venv
 ENV PIP /bench/venv/bin/python3 -m pip
 ENV PY /bench/venv/bin/python3 -W ignore

--- a/amlb/runners/singularity.py
+++ b/amlb/runners/singularity.py
@@ -167,12 +167,12 @@ apt-get -y install software-properties-common
 add-apt-repository -y ppa:deadsnakes/ppa
 apt-get update
 apt-get -y install python{pyv} python{pyv}-venv python{pyv}-dev python3-pip
-update-alternatives --install /usr/bin/python3 python3 $(which python{pyv}) 1
+#update-alternatives --install /usr/bin/python3 python3 $(which python{pyv}) 1
 pip3 install -U pip wheel
 
 # aliases for the python system
-SPIP=python3 -m pip
-SPY=python3
+SPIP=python{pyv} -m pip
+SPY=python{pyv}
 
 # Enforce UTF-8 encoding
 PYTHONUTF8=1
@@ -185,6 +185,7 @@ cd /bench
 
 # We create a virtual environment so that AutoML systems may use their preferred versions of
 # packages that we need to data pre- and postprocessing without breaking it.
+$SPIP install -U pip wheel
 $SPY -m venv venv
 PIP=/bench/venv/bin/python3 -m pip
 PY=/bench/venv/bin/python3

--- a/examples/custom/extensions/GradientBoosting/__init__.py
+++ b/examples/custom/extensions/GradientBoosting/__init__.py
@@ -1,3 +1,13 @@
+import os
+from amlb.benchmark import __installed_file__
+from amlb.utils import dir_of
+
+
+def setup(*args, **kwargs):
+    from sklearn import __version__
+    with open(os.path.join(dir_of(__file__), __installed_file__), 'w') as f:
+        f.write('\n'.join([__version__, ""]))
+
 
 def run(*args, **kwargs):
     from .exec import run

--- a/examples/custom/extensions/GradientBoosting/exec.py
+++ b/examples/custom/extensions/GradientBoosting/exec.py
@@ -9,14 +9,11 @@ from amlb.datautils import impute
 from amlb.results import save_predictions
 from amlb.utils import Timer
 
-from frameworks.shared.callee import save_metadata
-
 log = logging.getLogger(__name__)
 
 
 def run(dataset: Dataset, config: TaskConfig):
     log.info(f"\n**** Gradient Boosting [sklearn v{sklearn.__version__}] ****\n")
-    save_metadata(config, version=sklearn.__version__)
 
     is_classification = config.type == 'classification'
 

--- a/examples/custom/extensions/Stacking/__init__.py
+++ b/examples/custom/extensions/Stacking/__init__.py
@@ -1,11 +1,10 @@
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
-from amlb.resources import config as rconfig
 from amlb.utils import call_script_in_same_dir
 
 
 def setup(*args, **kwargs):
-    call_script_in_same_dir(__file__, "setup.sh", rconfig().root_dir, *args, **kwargs)
+    call_script_in_same_dir(__file__, "setup.sh", *args, **kwargs)
 
 
 def run(dataset: Dataset, config: TaskConfig):

--- a/examples/custom/extensions/Stacking/exec.py
+++ b/examples/custom/extensions/Stacking/exec.py
@@ -14,14 +14,13 @@ from sklearn.ensemble import StackingClassifier, StackingRegressor
 from sklearn.linear_model import LinearRegression, LogisticRegression, SGDClassifier, SGDRegressor
 from sklearn.svm import LinearSVC, LinearSVR
 
-from frameworks.shared.callee import call_run, result, save_metadata, utils
+from frameworks.shared.callee import call_run, result, utils
 
 log = logging.getLogger(os.path.basename(__file__))
 
 
 def run(dataset, config):
     log.info(f"\n**** Stacking Ensemble [sklearn v{sklearn.__version__}] ****\n")
-    save_metadata(config, version=sklearn.__version__)
 
     is_classification = config.type == 'classification'
 

--- a/examples/custom/extensions/Stacking/setup.sh
+++ b/examples/custom/extensions/Stacking/setup.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 shopt -s expand_aliases
 HERE=$(dirname "$0")
-AMLB_DIR="$1"
-# by passing the module directory to `setup.sh`, it tells it to automatically create a virtual env under the current module.
-# this virtual env is then used to run the exec.py only, and can be configured here using `PIP` and `PY` commands.
-. $AMLB_DIR/frameworks/shared/setup.sh $HERE
-PIP install -r $HERE/requirements.txt
+
+. "$HERE/.setup_env"
+. "$AMLB_ROOT/frameworks/shared/setup.sh" "$HERE" true
+PIP install -r "$HERE/requirements.txt"

--- a/examples/custom/extensions/Stacking/setup.sh
+++ b/examples/custom/extensions/Stacking/setup.sh
@@ -5,3 +5,5 @@ HERE=$(dirname "$0")
 . "$HERE/.setup_env"
 . "$AMLB_ROOT/frameworks/shared/setup.sh" "$HERE" true
 PIP install -r "$HERE/requirements.txt"
+
+PY -c "from sklearn import __version__; print(__version__)" >> "${HERE}/.installed"

--- a/frameworks/AutoGluon/__init__.py
+++ b/frameworks/AutoGluon/__init__.py
@@ -1,11 +1,10 @@
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
-from amlb.resources import config as rconfig
 from amlb.utils import call_script_in_same_dir
 
 
 def setup(*args, **kwargs):
-    call_script_in_same_dir(__file__, "setup.sh", rconfig().root_dir, *args, **kwargs)
+    call_script_in_same_dir(__file__, "setup.sh", *args, **kwargs)
 
 
 def run(dataset: Dataset, config: TaskConfig):

--- a/frameworks/AutoGluon/exec.py
+++ b/frameworks/AutoGluon/exec.py
@@ -16,14 +16,13 @@ from autogluon.core.utils.savers import save_pd, save_pkl
 import autogluon.core.metrics as metrics
 from autogluon.tabular.version import __version__
 
-from frameworks.shared.callee import call_run, result, output_subdir, utils, save_metadata
+from frameworks.shared.callee import call_run, result, output_subdir, utils
 
 log = logging.getLogger(__name__)
 
 
 def run(dataset, config):
     log.info(f"\n**** AutoGluon [v{__version__}] ****\n")
-    save_metadata(config, version=__version__)
 
     metrics_mapping = dict(
         acc=metrics.accuracy,

--- a/frameworks/AutoGluon/setup.sh
+++ b/frameworks/AutoGluon/setup.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 HERE=$(dirname "$0")
-AMLB_DIR="$1"
-VERSION=${2:-"stable"}
-REPO=${3:-"https://github.com/awslabs/autogluon.git"}
-PKG=${4:-"autogluon"}
+VERSION=${1:-"stable"}
+REPO=${2:-"https://github.com/awslabs/autogluon.git"}
+PKG=${3:-"autogluon"}
 if [[ "$VERSION" == "latest" ]]; then
     VERSION="master"
 fi
 
 # creating local venv
-. ${HERE}/../shared/setup.sh ${HERE}
+. ${HERE}/../shared/setup.sh ${HERE} true
 #if [[ -x "$(command -v apt-get)" ]]; then
 #    SUDO apt-get install -y libomp-dev
 if [[ -x "$(command -v brew)" ]]; then
@@ -38,3 +37,5 @@ else
     PIP install -e vision/
     PIP install -e autogluon/
 fi
+
+PY -c "from autogluon.tabular.version import __version__; print(__version__)" >> "${HERE}/.installed"

--- a/frameworks/AutoWEKA/exec.py
+++ b/frameworks/AutoWEKA/exec.py
@@ -8,14 +8,11 @@ from amlb.datautils import reorder_dataset
 from amlb.results import NoResultError, save_predictions
 from amlb.utils import dir_of, path_from_split, run_cmd, split_path, Timer
 
-from frameworks.shared.callee import save_metadata
-
 log = logging.getLogger(__name__)
 
 
 def run(dataset: Dataset, config: TaskConfig):
     log.info(f"\n**** AutoWEKA [v{config.framework_version}]****\n")
-    save_metadata(config)
 
     is_classification = config.type == 'classification'
     if not is_classification:

--- a/frameworks/AutoWEKA/setup.sh
+++ b/frameworks/AutoWEKA/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 HERE=$(dirname "$0")
 VERSION=${1:-"stable"}
-. ${HERE}/../shared/setup.sh ""
+. ${HERE}/../shared/setup.sh "${HERE}"
 if [[ -x "$(command -v apt-get)" ]]; then
     SUDO apt-get update
     SUDO apt-get install -y wget unzip openjdk-8-jdk
@@ -14,3 +14,5 @@ if [[ ! -e "$TARGET_DIR" ]]; then
     wget http://www.cs.ubc.ca/labs/beta/Projects/autoweka/$AUTOWEKA_ARCHIVE -P $DOWNLOAD_DIR
     unzip $DOWNLOAD_DIR/$AUTOWEKA_ARCHIVE -d $TARGET_DIR
 fi
+
+find $HERE/lib/autoweka*.zip | sed -e 's/.*\/autoweka-\(.*\)\.zip/\1/' >> "${HERE}/.installed"

--- a/frameworks/DecisionTree/__init__.py
+++ b/frameworks/DecisionTree/__init__.py
@@ -1,3 +1,13 @@
+import os
+from amlb.benchmark import __installed_file__
+from amlb.utils import dir_of
+
+
+def setup(*args, **kwargs):
+    from sklearn import __version__
+    with open(os.path.join(dir_of(__file__), __installed_file__), 'w') as f:
+        f.write('\n'.join([__version__, ""]))
+
 
 def run(*args, **kwargs):
     from .exec import run

--- a/frameworks/DecisionTree/exec.py
+++ b/frameworks/DecisionTree/exec.py
@@ -9,14 +9,11 @@ from amlb.datautils import impute
 from amlb.results import save_predictions
 from amlb.utils import Timer
 
-from frameworks.shared.callee import save_metadata
-
 log = logging.getLogger(__name__)
 
 
 def run(dataset: Dataset, config: TaskConfig):
     log.info(f"\n**** Decision Tree [sklearn v{sklearn.__version__}] ****\n")
-    save_metadata(config, version=sklearn.__version__)
 
     is_classification = config.type == 'classification'
 

--- a/frameworks/GAMA/__init__.py
+++ b/frameworks/GAMA/__init__.py
@@ -1,11 +1,10 @@
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
-from amlb.resources import config as rconfig
 from amlb.utils import call_script_in_same_dir
 
 
 def setup(*args, **kwargs):
-    call_script_in_same_dir(__file__, "setup.sh", rconfig().root_dir, *args, **kwargs)
+    call_script_in_same_dir(__file__, "setup.sh", *args, **kwargs)
 
 
 def run(dataset: Dataset, config: TaskConfig):

--- a/frameworks/GAMA/exec.py
+++ b/frameworks/GAMA/exec.py
@@ -24,7 +24,6 @@ def run(dataset, config):
     log.info("\n**** GAMA [v%s] ****", __version__)
     log.info("sklearn == %s", sklearn.__version__)
     log.info("category_encoders == %s", category_encoders.__version__)
-    save_metadata(config, version=__version__)
 
     is_classification = (config.type == 'classification')
     # Mapping of benchmark metrics to GAMA metrics

--- a/frameworks/GAMA/setup.sh
+++ b/frameworks/GAMA/setup.sh
@@ -1,16 +1,14 @@
 #!/usr/bin/env bash
 HERE=$(dirname "$0")
-AMLB_DIR="$1"
-VERSION=${2:-"stable"}
-REPO=${3:-"https://github.com/PGijsbers/gama"}
-PKG=${4:-"gama"}
+VERSION=${1:-"stable"}
+REPO=${2:-"https://github.com/PGijsbers/gama"}
+PKG=${3:-"gama"}
 if [[ "$VERSION" == "latest" ]]; then
     VERSION="master"
 fi
 
 #create local venv
-. ${HERE}/../shared/setup.sh ${HERE}
-#. ${AMLB_DIR}/frameworks/shared/setup.sh ${HERE}
+. ${HERE}/../shared/setup.sh ${HERE} true
 
 PIP install -r ${HERE}/requirements.txt
 if [[ "$VERSION" == "stable" ]]; then
@@ -24,3 +22,5 @@ else
     git clone --depth 1 --single-branch --branch ${VERSION} --recurse-submodules ${REPO} ${TARGET_DIR}
     PIP install -U -e ${TARGET_DIR}
 fi
+
+PY -c "from gama import __version__; print(__version__)" >> "${HERE}/.installed"

--- a/frameworks/H2OAutoML/__init__.py
+++ b/frameworks/H2OAutoML/__init__.py
@@ -1,7 +1,7 @@
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
 from amlb.resources import config as rconfig
-from amlb.utils import call_script_in_same_dir, Namespace
+from amlb.utils import call_script_in_same_dir
 
 
 def setup(*args, **kwargs):

--- a/frameworks/H2OAutoML/exec.py
+++ b/frameworks/H2OAutoML/exec.py
@@ -32,7 +32,6 @@ class BackendMemoryMonitoring(utils.Monitoring):
 
 def run(dataset, config):
     log.info(f"\n**** H2O AutoML [v{h2o.__version__}] ****\n")
-    save_metadata(config, version=h2o.__version__)
     # Mapping of benchmark metrics to H2O metrics
     metrics_mapping = dict(
         acc='mean_per_class_error',

--- a/frameworks/H2OAutoML/setup.sh
+++ b/frameworks/H2OAutoML/setup.sh
@@ -4,7 +4,7 @@ VERSION=${1:-"stable"}
 H2O_REPO=${2:-"https://h2o-release.s3.amazonaws.com/h2o"}
 echo "setting up H2O version $VERSION"
 
-. ${HERE}/../shared/setup.sh ${HERE}
+. ${HERE}/../shared/setup.sh ${HERE} true
 if [[ -x "$(command -v apt-get)" ]]; then
     SUDO apt-get update
     SUDO apt-get install -y openjdk-8-jdk
@@ -43,4 +43,6 @@ if [[ -n "$h2o_package" ]]; then
 else
     echo "not installing any H2O release version"
 fi
+
+PY -c "from h2o import __version__; print(__version__)" >> "${HERE}/.installed"
 

--- a/frameworks/MLNet/__init__.py
+++ b/frameworks/MLNet/__init__.py
@@ -1,12 +1,10 @@
 from amlb.utils import call_script_in_same_dir
-import os
+
 
 def setup(*args, **kwargs):
     call_script_in_same_dir(__file__, "setup.sh", *args, **kwargs)
 
 
-
 def run(dataset, config):
     from .exec import run
-
     return run(dataset, config)

--- a/frameworks/MLNet/exec.py
+++ b/frameworks/MLNet/exec.py
@@ -3,6 +3,7 @@ import logging
 import json
 import os
 import psutil
+import shutil
 import tempfile
 
 # import 3rd_parties
@@ -12,7 +13,7 @@ import pandas as pd
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
 from amlb.results import NoResultError, save_predictions
-from amlb.utils import run_cmd, Timer
+from amlb.utils import clean_dir, run_cmd, zip_path, Timer
 from frameworks.shared.callee import output_subdir
 
 log = logging.getLogger(__name__)
@@ -38,80 +39,93 @@ def run(dataset: Dataset, config: TaskConfig):
     # set up MODELBUILDER_AUTOML
     MODELBUILDER_AUTOML = config.framework_params.get('automl_type', 'NNI')
     os.environ['MODELBUILDER_AUTOML'] = MODELBUILDER_AUTOML
-    is_save_artifacts = config.framework_params.get('_save_artifacts', False)
+
+    artifacts = config.framework_params.get('_save_artifacts', [])
     tmpdir = tempfile.mkdtemp()
-    if is_save_artifacts:
-        tmpdir = output_subdir('artifacts', config=config)
+    tmp_output_folder = os.path.join(tmpdir, str(config.fold))
+    output_dir = output_subdir('models', config=config) if 'models' in artifacts else tmp_output_folder
+    log_dir = output_subdir('logs', config=config) if 'logs' in artifacts else tmp_output_folder
+    log_path = os.path.join(log_dir, 'log.txt')
 
-    train_dataset_path: str
-    test_dataset_path: str
-    label: str = 'label'
-    temp_output_folder = os.path.join(tmpdir, str(config.fold))
-    log_path = os.path.join(temp_output_folder, 'log.txt')
-    label = dataset.target.index
+    try:
+        label = dataset.target.index
+        train_dataset_path: str
+        test_dataset_path: str
 
-    if dataset.train.format == 'csv':
-        train_dataset_path = dataset.train.path
-        test_dataset_path = dataset.test.path
-    else:
-        # .arff
-        train_dataset_path = os.path.join(tmpdir, f'train.csv')
-        test_dataset_path = os.path.join(tmpdir, f'test.csv')
-        columns = [f'col_{i}' for i in range(dataset.train.data.shape[-1])]
-        columns[label] = 'label'
+        if dataset.train.format == 'csv':
+            train_dataset_path = dataset.train.path
+            test_dataset_path = dataset.test.path
+        else:
+            # .arff
+            train_dataset_path = os.path.join(tmpdir, f'train.csv')
+            test_dataset_path = os.path.join(tmpdir, f'test.csv')
+            columns = [f'col_{i}' for i in range(dataset.train.data.shape[-1])]
+            columns[label] = 'label'
 
-        # might use a bit extra memory, but it's faster
-        pd.DataFrame(dataset.train.data, columns=columns).to_csv(train_dataset_path, index=None)
-        pd.DataFrame(dataset.test.data, columns=columns).to_csv(test_dataset_path, index=None)
+            # might use a bit extra memory, but it's faster
+            pd.DataFrame(dataset.train.data, columns=columns).to_csv(train_dataset_path, index=None)
+            pd.DataFrame(dataset.test.data, columns=columns).to_csv(test_dataset_path, index=None)
 
-    log.info(f'train dataset: {train_dataset_path}')
-    log.info(f'test dataset: {test_dataset_path}')
-    
-    cmd =   f"{mlnet} {sub_command}"\
-            f" --dataset {train_dataset_path} --test-dataset {test_dataset_path} --train-time {train_time_in_seconds}"\
-            f" --label-col {label} --output {os.path.dirname(temp_output_folder)} --name {config.fold}"\
-            f" --verbosity q --log-file-path {log_path}"
-    
-    with Timer() as training:
-        run_cmd(cmd)
+        log.info(f'train dataset: {train_dataset_path}')
+        log.info(f'test dataset: {test_dataset_path}')
 
-    train_result_json = os.path.join(temp_output_folder, '{}.mbconfig'.format(config.fold))
-    if not os.path.exists(train_result_json):
-        raise NoResultError("MLNet failed producing any prediction.")
-    
-    with open(train_result_json, 'r') as f:
-        json_str = f.read()
-        mb_config = json.loads(json_str)
-        model_path = mb_config['Artifact']['MLNetModelPath']
-        output_prediction_txt = os.path.join(tmpdir, "prediction.txt")
-        models_count = len(mb_config['RunHistory']['Trials'])
-        # predict
-        predict_cmd =   f"{mlnet} predict --task-type {config.type}" \
-                        f" --model {model_path} --dataset {test_dataset_path} > {output_prediction_txt}"
-        with Timer() as prediction:
-            run_cmd(predict_cmd)
-        if config.type == 'classification':
-            prediction_df = pd.read_csv(output_prediction_txt, dtype={'PredictedLabel':'object'})
-            save_predictions(
-                dataset=dataset,
-                output_file=config.output_predictions_file,
-                predictions=prediction_df['PredictedLabel'].values,
-                truth=dataset.test.y,
-                probabilities=prediction_df.values[:,:-1],
-                probabilities_labels=list(prediction_df.columns.values[:-1]),
-            )
-    
-        if config.type == 'regression':
-            prediction_df = pd.read_csv(output_prediction_txt)
-            save_predictions(
-                dataset=dataset,
-                output_file=config.output_predictions_file,
-                predictions=prediction_df['Score'].values,
-                truth=dataset.test.y,
-            )
+        cmd = (f"{mlnet} {sub_command}"
+               f" --dataset {train_dataset_path} --test-dataset {test_dataset_path} --train-time {train_time_in_seconds}"
+               f" --label-col {label} --output {os.path.dirname(output_dir)} --name {config.fold}"
+               f" --verbosity q --log-file-path {log_path}")
 
-        return dict(
-                models_count = models_count,
-                training_duration=training.duration,
-                predict_duration=prediction.duration,
-            )
+        with Timer() as training:
+            run_cmd(cmd)
+
+        train_result_json = os.path.join(output_dir, '{}.mbconfig'.format(config.fold))
+        if not os.path.exists(train_result_json):
+            raise NoResultError("MLNet failed producing any prediction.")
+
+        with open(train_result_json, 'r') as f:
+            json_str = f.read()
+            mb_config = json.loads(json_str)
+            model_path = mb_config['Artifact']['MLNetModelPath']
+            output_prediction_path = os.path.join(log_dir, "prediction.txt")  # keeping this in log dir as it contains useful error when prediction fails
+            models_count = len(mb_config['RunHistory']['Trials'])
+            # predict
+            predict_cmd = (f"{mlnet} predict --task-type {config.type}"
+                           f" --model {model_path} --dataset {test_dataset_path} > {output_prediction_path}")
+            with Timer() as prediction:
+                run_cmd(predict_cmd)
+            if config.type == 'classification':
+                prediction_df = pd.read_csv(output_prediction_path, dtype={'PredictedLabel': 'object'})
+
+                save_predictions(
+                    dataset=dataset,
+                    output_file=config.output_predictions_file,
+                    predictions=prediction_df['PredictedLabel'].values,
+                    truth=dataset.test.y,
+                    probabilities=prediction_df.values[:,:-1],
+                    probabilities_labels=list(prediction_df.columns.values[:-1]),
+                )
+
+            if config.type == 'regression':
+                prediction_df = pd.read_csv(output_prediction_path)
+                save_predictions(
+                    dataset=dataset,
+                    output_file=config.output_predictions_file,
+                    predictions=prediction_df['Score'].values,
+                    truth=dataset.test.y,
+                )
+
+            return dict(
+                    models_count=models_count,
+                    training_duration=training.duration,
+                    predict_duration=prediction.duration,
+                )
+    finally:
+        if 'logs' in artifacts:
+            logs_zip = os.path.join(log_dir, "logs.zip")
+            zip_path(log_dir, logs_zip)
+            clean_dir(log_dir, filtr=lambda p: p != logs_zip)
+        if 'models' in artifacts:
+            models_zip = os.path.join(output_dir, "models.zip")
+            zip_path(output_dir, models_zip)
+            clean_dir(output_dir, filtr=lambda p: p != models_zip)
+
+        shutil.rmtree(tmpdir, ignore_errors=True)

--- a/frameworks/MLNet/exec.py
+++ b/frameworks/MLNet/exec.py
@@ -1,9 +1,9 @@
 # import standard_lib
-import tempfile
-import os
 import logging
-import psutil
 import json
+import os
+import psutil
+import tempfile
 
 # import 3rd_parties
 import pandas as pd
@@ -13,13 +13,13 @@ from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
 from amlb.results import NoResultError, save_predictions
 from amlb.utils import run_cmd, Timer
-from frameworks.shared.callee import output_subdir, save_metadata
+from frameworks.shared.callee import output_subdir
 
 log = logging.getLogger(__name__)
 
+
 def run(dataset: Dataset, config: TaskConfig):
     log.info(f"\n**** MLNet [v{config.framework_version}] ****\n")
-    save_metadata(config)
 
     avaible_task_list = ['classification', 'regression']
     if config.type not in avaible_task_list:

--- a/frameworks/MLNet/setup.sh
+++ b/frameworks/MLNet/setup.sh
@@ -28,4 +28,5 @@ $DOTNET tool update mlnet --add-source "$SOURCE" --version "$VERSION" --tool-pat
 fi
 
 export DOTNET_ROOT="$DOTNET_INSTALL_DIR"
-$MLNET --version
+
+$MLNET --version >> "${HERE}/.installed"

--- a/frameworks/MLNet/setup.sh
+++ b/frameworks/MLNet/setup.sh
@@ -28,5 +28,6 @@ $DOTNET tool update mlnet --add-source "$SOURCE" --version "$VERSION" --tool-pat
 fi
 
 export DOTNET_ROOT="$DOTNET_INSTALL_DIR"
+export MLNET_CLI_HOME="$DOTNET_INSTALL_DIR"
 
-$MLNET --version >> "${HERE}/.installed"
+$MLNET --version | sed -e "s/\(.?*\)\+.*/\1/" >> "${HERE}/.installed"

--- a/frameworks/MLPlan/__init__.py
+++ b/frameworks/MLPlan/__init__.py
@@ -1,12 +1,11 @@
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
-from amlb.resources import config as rconfig
 from amlb.datautils import reorder_dataset
 from amlb.utils import call_script_in_same_dir
 
 
 def setup(*args, **kwargs):
-    call_script_in_same_dir(__file__, "setup.sh", rconfig().root_dir, *args, **kwargs)
+    call_script_in_same_dir(__file__, "setup.sh", *args, **kwargs)
 
 
 def run(dataset: Dataset, config: TaskConfig):

--- a/frameworks/MLPlan/exec.py
+++ b/frameworks/MLPlan/exec.py
@@ -1,20 +1,15 @@
-import glob
 import logging
 import os
 import json
-import re
 import tempfile
 
-from frameworks.shared.callee import call_run, result, output_subdir, save_metadata, utils
+from frameworks.shared.callee import call_run, result, output_subdir, utils
 
 log = logging.getLogger(__name__)
 
 
 def run(dataset, config):
-    jar_file = glob.glob("{here}/lib/mlplan/mlplan-cli*.jar".format(here=os.path.dirname(__file__)))[0]
-    version = re.match(r".*/mlplan-cli-(.*).jar", jar_file)[1]
-    log.info(f"\n**** ML-Plan [v{version}] ****\n")
-    save_metadata(config, version=version)
+    log.info(f"\n**** ML-Plan [v{config.framework_version}] ****\n")
 
     is_classification = config.type == 'classification'
     

--- a/frameworks/MLPlan/exec.py
+++ b/frameworks/MLPlan/exec.py
@@ -1,6 +1,8 @@
+import glob
 import logging
 import os
 import json
+import re
 import tempfile
 
 from frameworks.shared.callee import call_run, result, output_subdir, utils
@@ -9,7 +11,9 @@ log = logging.getLogger(__name__)
 
 
 def run(dataset, config):
-    log.info(f"\n**** ML-Plan [v{config.framework_version}] ****\n")
+    jar_file = glob.glob("{here}/lib/mlplan/mlplan-cli*.jar".format(here=os.path.dirname(__file__)))[0]
+    version = re.match(r".*/mlplan-cli-(.*).jar", jar_file)[1]
+    log.info(f"\n**** ML-Plan [v{version}] ****\n")
 
     is_classification = config.type == 'classification'
     

--- a/frameworks/MLPlan/setup.sh
+++ b/frameworks/MLPlan/setup.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 HERE=$(dirname "$0")
-AMLB_DIR="$1"
-VERSION=${2:-"stable"}
+VERSION=${1:-"stable"}
 if [[ "$VERSION" == "stable" ]]; then
     VERSION="latest"
 fi
@@ -9,7 +8,7 @@ fi
 echo "Setup ML-Plan for version $VERSION"
 
 # creating local venv
-. ${HERE}/../shared/setup.sh ${HERE}
+. ${HERE}/../shared/setup.sh ${HERE} true
 
 if [[ -x "$(command -v apt-get)" ]]; then
     echo "setup system packages"
@@ -31,3 +30,5 @@ if [[ ! -e "$TARGET_DIR" ]]; then
     echo "Download finished. Now unzip the downloaded file."
     unzip $DOWNLOAD_DIR/$MLPLAN_ARC -d $TARGET_DIR
 fi
+
+find $HERE/lib/mlplan/*.jar | sed -e 's/.*\/mlplan-cli-\(.*\)\.jar/\1/' >> "${HERE}/.installed"

--- a/frameworks/RandomForest/__init__.py
+++ b/frameworks/RandomForest/__init__.py
@@ -1,11 +1,10 @@
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
-from amlb.resources import config as rconfig
 from amlb.utils import call_script_in_same_dir
 
 
 def setup(*args, **kwargs):
-    call_script_in_same_dir(__file__, "setup.sh", rconfig().root_dir, *args, **kwargs)
+    call_script_in_same_dir(__file__, "setup.sh", *args, **kwargs)
 
 
 def run(dataset: Dataset, config: TaskConfig):

--- a/frameworks/RandomForest/exec.py
+++ b/frameworks/RandomForest/exec.py
@@ -10,14 +10,13 @@ os.environ['MKL_NUM_THREADS'] = '1'
 import sklearn
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 
-from frameworks.shared.callee import call_run, result, save_metadata, utils
+from frameworks.shared.callee import call_run, result, utils
 
 log = logging.getLogger(os.path.basename(__file__))
 
 
 def run(dataset, config):
     log.info(f"\n**** Random Forest [sklearn v{sklearn.__version__}] ****\n")
-    save_metadata(config, version=sklearn.__version__)
 
     is_classification = config.type == 'classification'
 

--- a/frameworks/RandomForest/setup.sh
+++ b/frameworks/RandomForest/setup.sh
@@ -1,17 +1,13 @@
 #!/usr/bin/env bash
 HERE=$(dirname "$0")
-AMLB_DIR="$1"
-VERSION=${2:-"stable"}
-REPO=${3:-"https://github.com/scikit-learn/scikit-learn.git"}
-PKG=${4:-"scikit-learn"}
+VERSION=${1:-"stable"}
+REPO=${2:-"https://github.com/scikit-learn/scikit-learn.git"}
+PKG=${3:-"scikit-learn"}
 if [[ "$VERSION" == "latest" ]]; then
     VERSION="master"
 fi
 
-# by passing the module directory to `setup.sh`, it tells it to automatically create a virtual env under the current module.
-# this virtual env is then used to run the exec.py only, and can be configured here using `PIP` and `PY` commands.
-. ${HERE}/../shared/setup.sh ${HERE}
-#. ${AMLB_DIR}/frameworks/shared/setup.sh ${HERE}
+. "${HERE}/../shared/setup.sh" "${HERE}" true
 
 if [[ "$VERSION" == "stable" ]]; then
     PIP install --no-cache-dir -U ${PKG}
@@ -24,3 +20,5 @@ else
     git clone --depth 1 --single-branch --branch ${VERSION} --recurse-submodules ${REPO} ${TARGET_DIR}
     PIP install -U -e ${TARGET_DIR}
 fi
+
+PY -c "from sklearn import __version__; print(__version__)" >> "${HERE}/.installed"

--- a/frameworks/TPOT/__init__.py
+++ b/frameworks/TPOT/__init__.py
@@ -1,12 +1,11 @@
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
 from amlb.datautils import Encoder, impute
-from amlb.resources import config as rconfig
 from amlb.utils import call_script_in_same_dir
 
 
 def setup(*args, **kwargs):
-    call_script_in_same_dir(__file__, "setup.sh", rconfig().root_dir, *args, **kwargs)
+    call_script_in_same_dir(__file__, "setup.sh", *args, **kwargs)
 
 
 def run(dataset: Dataset, config: TaskConfig):

--- a/frameworks/TPOT/exec.py
+++ b/frameworks/TPOT/exec.py
@@ -13,7 +13,7 @@ os.environ['MKL_NUM_THREADS'] = '1'
 
 from tpot import TPOTClassifier, TPOTRegressor, __version__
 
-from frameworks.shared.callee import call_run, output_subdir, result, save_metadata, utils
+from frameworks.shared.callee import call_run, output_subdir, result, utils
 
 
 log = logging.getLogger(__name__)
@@ -21,7 +21,6 @@ log = logging.getLogger(__name__)
 
 def run(dataset, config):
     log.info(f"\n**** TPOT [v{__version__}]****\n")
-    save_metadata(config, version=__version__)
 
     is_classification = config.type == 'classification'
     # Mapping of benchmark metrics to TPOT metrics

--- a/frameworks/TPOT/setup.sh
+++ b/frameworks/TPOT/setup.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 HERE=$(dirname "$0")
-AMLB_DIR="$1"
-VERSION=${2:-"stable"}
-REPO=${3:-"https://github.com/EpistasisLab/tpot"}
-PKG=${4:-"tpot[dask]"}
+VERSION=${1:-"stable"}
+REPO=${2:-"https://github.com/EpistasisLab/tpot"}
+PKG=${3:-"tpot[dask]"}
 if [[ "$VERSION" == "latest" ]]; then
     VERSION="master"
 fi
 
 # creating local venv
-. ${HERE}/../shared/setup.sh ${HERE}
+. ${HERE}/../shared/setup.sh ${HERE} true
 
 RAWREPO=$(echo ${REPO} | sed "s/github\.com/raw\.githubusercontent\.com/")
 if [[ "$VERSION" == "stable" ]]; then
@@ -28,3 +27,5 @@ else
     git clone --depth 1 --single-branch --branch ${VERSION} --recurse-submodules ${REPO} ${TARGET_DIR}
     PIP install -U -e ${HERE}/lib/${PKG}
 fi
+
+PY -c "from tpot import __version__; print(__version__)" >> "${HERE}/.installed"

--- a/frameworks/TunedRandomForest/__init__.py
+++ b/frameworks/TunedRandomForest/__init__.py
@@ -1,11 +1,10 @@
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
-from amlb.resources import config as rconfig
 from amlb.utils import call_script_in_same_dir
 
 
 def setup(*args, **kwargs):
-    call_script_in_same_dir(__file__, "setup.sh", rconfig().root_dir, *args, **kwargs)
+    call_script_in_same_dir(__file__, "setup.sh", *args, **kwargs)
 
 
 def run(dataset: Dataset, config: TaskConfig):

--- a/frameworks/TunedRandomForest/exec.py
+++ b/frameworks/TunedRandomForest/exec.py
@@ -21,7 +21,7 @@ from sklearn.impute import SimpleImputer
 from sklearn.model_selection import cross_val_score
 import stopit
 
-from frameworks.shared.callee import call_run, result, save_metadata, utils
+from frameworks.shared.callee import call_run, result, utils
 
 log = logging.getLogger(__name__)
 
@@ -34,7 +34,6 @@ def pick_values_uniform(start: int, end: int, length: int):
 
 def run(dataset, config):
     log.info(f"\n**** Tuned Random Forest [sklearn v{sklearn.__version__}] ****\n")
-    save_metadata(config, version=sklearn.__version__)
 
     is_classification = config.type == 'classification'
 

--- a/frameworks/TunedRandomForest/setup.sh
+++ b/frameworks/TunedRandomForest/setup.sh
@@ -1,17 +1,14 @@
 #!/usr/bin/env bash
 HERE=$(dirname "$0")
-AMLB_DIR="$1"
-VERSION=${2:-"stable"}
-REPO=${3:-"https://github.com/scikit-learn/scikit-learn.git"}
-PKG=${4:-"scikit-learn"}
+VERSION=${1:-"stable"}
+REPO=${2:-"https://github.com/scikit-learn/scikit-learn.git"}
+PKG=${3:-"scikit-learn"}
 if [[ "$VERSION" == "latest" ]]; then
     VERSION="master"
 fi
 
-# by passing the module directory to `setup.sh`, it tells it to automatically create a virtual env under the current module.
-# this virtual env is then used to run the exec.py only, and can be configured here using `PIP` and `PY` commands.
-. ${HERE}/../shared/setup.sh ${HERE}
-#. ${AMLB_DIR}/frameworks/shared/setup.sh ${HERE}
+# create venv
+. ${HERE}/../shared/setup.sh "${HERE}" true
 
 if [[ "$VERSION" == "stable" ]]; then
     PIP install --no-cache-dir -U ${PKG}
@@ -24,3 +21,5 @@ else
     git clone --depth 1 --single-branch --branch ${VERSION} --recurse-submodules ${REPO} ${TARGET_DIR}
     PIP install -U -e ${TARGET_DIR}
 fi
+
+PY -c "from sklearn import __version__; print(__version__)" >> "${HERE}/.installed"

--- a/frameworks/autosklearn/__init__.py
+++ b/frameworks/autosklearn/__init__.py
@@ -1,11 +1,10 @@
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
-from amlb.resources import config as rconfig
 from amlb.utils import call_script_in_same_dir
 
 
 def setup(*args, **kwargs):
-    call_script_in_same_dir(__file__, "setup.sh", rconfig().root_dir, *args, **kwargs)
+    call_script_in_same_dir(__file__, "setup.sh", *args, **kwargs)
 
 
 def run(dataset: Dataset, config: TaskConfig):

--- a/frameworks/autosklearn/exec.py
+++ b/frameworks/autosklearn/exec.py
@@ -15,7 +15,7 @@ from autosklearn.experimental.askl2 import AutoSklearn2Classifier
 import autosklearn.metrics as metrics
 from packaging import version
 
-from frameworks.shared.callee import call_run, result, output_subdir, save_metadata, utils
+from frameworks.shared.callee import call_run, result, output_subdir, utils
 
 log = logging.getLogger(__name__)
 
@@ -26,7 +26,6 @@ def run(dataset, config):
     askl_string = "Auto-sklearn2.0" if askl_method_version == 2 else "Auto-sklearn"
 
     log.info(f"\n**** {askl_string} [v{autosklearn.__version__}]****\n")
-    save_metadata(config, version=autosklearn.__version__)
     warnings.simplefilter(action='ignore', category=FutureWarning)
     warnings.simplefilter(action='ignore', category=DeprecationWarning)
 

--- a/frameworks/autosklearn/setup.sh
+++ b/frameworks/autosklearn/setup.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 HERE=$(dirname "$0")
-AMLB_DIR="$1"
-VERSION=${2:-"stable"}
-REPO=${3:-"https://github.com/automl/auto-sklearn.git"}
-PKG=${4:-"auto-sklearn"}
+VERSION=${1:-"stable"}
+REPO=${2:-"https://github.com/automl/auto-sklearn.git"}
+PKG=${3:-"auto-sklearn"}
 if [[ "$VERSION" == "latest" ]]; then
     VERSION="master"
 fi
 
 # creating local venv
-. ${HERE}/../shared/setup.sh ${HERE}
+. ${HERE}/../shared/setup.sh ${HERE} true
 
 if [[ -x "$(command -v apt-get)" ]]; then
     SUDO apt-get install -y build-essential swig
@@ -29,3 +28,4 @@ else
     PIP install -U -e ${TARGET_DIR}
 fi
 
+PY -c "from autosklearn import __version__; print(__version__)" >> "${HERE}/.installed"

--- a/frameworks/autoxgboost/exec.py
+++ b/frameworks/autoxgboost/exec.py
@@ -21,11 +21,11 @@ def run(dataset: Dataset, config: TaskConfig):
     here = dir_of(__file__)
 
     meta_results_file = os.path.join(config.output_dir, "meta_results.csv")
-    run_cmd(r"""Rscript --vanilla -e "
-            source('{script}'); 
-            run('{train}', '{test}', target.index = {target_index}, '{type}', '{output}', {cores}, 
-                time.budget = {time_budget}, meta_results_file='{meta_results}')
-            " """.format(
+    run_cmd(("Rscript --vanilla -e \""
+             "source('{script}'); "
+             "run('{train}', '{test}', target.index = {target_index}, '{type}', '{output}', {cores},"
+             " time.budget = {time_budget}, meta_results_file='{meta_results}')"
+             "\"").format(
         script=os.path.join(here, 'exec.R'),
         train=dataset.train.path,
         test=dataset.test.path,

--- a/frameworks/autoxgboost/exec.py
+++ b/frameworks/autoxgboost/exec.py
@@ -6,15 +6,12 @@ from amlb.data import Dataset
 from amlb.datautils import read_csv
 from amlb.utils import dir_of, run_cmd
 
-from frameworks.shared.callee import save_metadata
-
 log = logging.getLogger(__name__)
 
 
 def run(dataset: Dataset, config: TaskConfig):
     #TODO: use rpy2 instead? not necessary here though as the call is very simple
     log.info(f"\n**** Autoxgboost (R) [{config.framework_version}] ****\n")
-    save_metadata(config)
 
     is_classification = config.type == 'classification'
 

--- a/frameworks/autoxgboost/setup.sh
+++ b/frameworks/autoxgboost/setup.sh
@@ -9,9 +9,12 @@ fi
 . ${HERE}/../shared/setup.sh ""
 if [[ -x "$(command -v apt-get)" ]]; then
 SUDO apt-get update
-SUDO apt-get install -y software-properties-common apt-transport-https libxml2-dev
-SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 51716619E084DAB9
-SUDO add-apt-repository 'deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu bionic-cran35/'
+#SUDO apt-get install -y software-properties-common apt-transport-https libxml2-dev
+#SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 51716619E084DAB9
+#SUDO add-apt-repository 'deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu bionic-cran35/'
+SUDO apt-get install -y software-properties-common dirmngr
+SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+SUDO add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
 SUDO apt-get update
 SUDO apt-get install -y r-base r-base-dev
 SUDO apt-get install -y libgdal-dev libproj-dev
@@ -20,6 +23,6 @@ SUDO apt-get install -y libcairo2-dev libudunits2-dev
 fi
 
 #PIP install --no-cache-dir -r $HERE/requirements.txt
-#SUDO Rscript -e 'options(install.packages.check.source="no"); install.packages(c("remotes", "mlr", "mlrMBO", "mlrCPO", "farff", "xgboost"), repos="https://cloud.r-project.org/", dependencies = TRUE)'
-SUDO Rscript -e 'remotes::install_github("${REPO}", ref="'"${VERSION}"'")'
+Rscript -e 'options(install.packages.check.source="no"); install.packages(c("remotes", "mlr", "mlrMBO", "mlrCPO", "farff", "GenSA", "rgenoud", "xgboost"), repos="https://cloud.r-project.org/")'
+Rscript -e 'remotes::install_github("'"${REPO}"'", ref="'"${VERSION}"'")'
 

--- a/frameworks/autoxgboost/setup.sh
+++ b/frameworks/autoxgboost/setup.sh
@@ -6,7 +6,7 @@ REPO=${2:-"ja-thomas/autoxgboost"}
 if [[ "$VERSION" == "latest" || "$VERSION" == "stable" ]]; then
     VERSION="master"
 fi
-. ${HERE}/../shared/setup.sh ""
+. ${HERE}/../shared/setup.sh "${HERE}"
 if [[ -x "$(command -v apt-get)" ]]; then
 SUDO apt-get update
 #SUDO apt-get install -y software-properties-common apt-transport-https libxml2-dev
@@ -26,3 +26,4 @@ fi
 Rscript -e 'options(install.packages.check.source="no"); install.packages(c("remotes", "mlr", "mlrMBO", "mlrCPO", "farff", "GenSA", "rgenoud", "xgboost"), repos="https://cloud.r-project.org/")'
 Rscript -e 'remotes::install_github("'"${REPO}"'", ref="'"${VERSION}"'")'
 
+Rscript -e 'packageVersion("autoxgboost")' | awk '{print $2}' | sed "s/[‘’]//g" >> "${HERE}/.installed"

--- a/frameworks/constantpredictor/__init__.py
+++ b/frameworks/constantpredictor/__init__.py
@@ -1,3 +1,13 @@
+import os
+from amlb.benchmark import __installed_file__
+from amlb.utils import dir_of
+
+
+def setup(*args, **kwargs):
+    from sklearn import __version__
+    with open(os.path.join(dir_of(__file__), __installed_file__), 'w') as f:
+        f.write('\n'.join([__version__, ""]))
+
 
 def run(*args, **kwargs):
     from .exec import run

--- a/frameworks/constantpredictor/exec.py
+++ b/frameworks/constantpredictor/exec.py
@@ -1,6 +1,5 @@
 import logging
 
-import sklearn
 from sklearn.dummy import DummyClassifier, DummyRegressor
 
 from amlb.benchmark import TaskConfig
@@ -8,14 +7,11 @@ from amlb.data import Dataset
 from amlb.results import save_predictions
 from amlb.utils import Timer
 
-from frameworks.shared.callee import save_metadata
-
 log = logging.getLogger(__name__)
 
 
 def run(dataset: Dataset, config: TaskConfig):
     log.info("\n**** Constant predictor (sklearn dummy) ****\n")
-    save_metadata(config, version=sklearn.__version__)
 
     is_classification = config.type == 'classification'
     predictor = DummyClassifier(strategy='prior') if is_classification else DummyRegressor(strategy='median')

--- a/frameworks/flaml/__init__.py
+++ b/frameworks/flaml/__init__.py
@@ -1,8 +1,8 @@
-from amlb.resources import config as rconfig
 from amlb.utils import call_script_in_same_dir
 
+
 def setup(*args, **kwargs):
-    call_script_in_same_dir(__file__, "setup.sh", rconfig().root_dir, *args, **kwargs)
+    call_script_in_same_dir(__file__, "setup.sh", *args, **kwargs)
 
 
 def run(dataset, config):

--- a/frameworks/flaml/setup.sh
+++ b/frameworks/flaml/setup.sh
@@ -1,17 +1,13 @@
 #!/usr/bin/env bash
 HERE=$(dirname "$0")
-AMLB_DIR="$1"
-VERSION=${2:-"stable"}
-REPO=${3:-"https://github.com/microsoft/FLAML.git"}
-PKG=${4:-"flaml"}
+VERSION=${1:-"stable"}
+REPO=${2:-"https://github.com/microsoft/FLAML.git"}
+PKG=${3:-"flaml"}
 if [[ "$VERSION" == "latest" ]]; then
     VERSION="main"
 fi
 
-# by passing the module directory to `setup.sh`, it tells it to automatically create a virtual env under the current module.
-# this virtual env is then used to run the exec.py only, and can be configured here using `PIP` and `PY` commands.
-. ${HERE}/../shared/setup.sh ${HERE}
-#. ${AMLB_DIR}/frameworks/shared/setup.sh ${HERE}
+. ${HERE}/../shared/setup.sh ${HERE} true
 
 if [[ "$VERSION" == "stable" ]]; then
     PIP install --no-cache-dir -U ${PKG}
@@ -24,3 +20,5 @@ else
     git clone --depth 1 --single-branch --branch ${VERSION} --recurse-submodules ${REPO} ${TARGET_DIR}
     PIP install -U -e ${TARGET_DIR}
 fi
+
+PY -c "from flaml import __version__; print(__version__)" >> "${HERE}/.installed"

--- a/frameworks/hyperoptsklearn/exec.py
+++ b/frameworks/hyperoptsklearn/exec.py
@@ -14,14 +14,13 @@ import hyperopt
 from sklearn.metrics import accuracy_score, roc_auc_score, f1_score, log_loss, mean_absolute_error, mean_squared_error, mean_squared_log_error, r2_score
 
 from utils import InterruptTimeout, Timer, dir_of, kill_proc_tree
-from frameworks.shared.callee import call_run, result, save_metadata
+from frameworks.shared.callee import call_run, result
 
 log = logging.getLogger(__name__)
 
 
 def run(dataset, config):
     log.info(f"\n**** Hyperopt-sklearn [v{config.framework_version}] ****\n")
-    save_metadata(config)
 
     is_classification = config.type == 'classification'
 

--- a/frameworks/hyperoptsklearn/setup.sh
+++ b/frameworks/hyperoptsklearn/setup.sh
@@ -7,7 +7,7 @@ if [[ "$VERSION" == "latest" ]]; then
     VERSION="master"
 fi
 
-. ${HERE}/../shared/setup.sh ${HERE}
+. ${HERE}/../shared/setup.sh ${HERE} true
 
 if [[ "$VERSION" == "stable" ]]; then
     PIP install --no-cache-dir -U ${PKG}

--- a/frameworks/lightautoml/__init__.py
+++ b/frameworks/lightautoml/__init__.py
@@ -1,11 +1,10 @@
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
-from amlb.resources import config as rconfig
 from amlb.utils import call_script_in_same_dir
 
 
 def setup(*args, **kwargs):
-    call_script_in_same_dir(__file__, "setup.sh", rconfig().root_dir, *args, **kwargs)
+    call_script_in_same_dir(__file__, "setup.sh", *args, **kwargs)
 
 
 def run(dataset: Dataset, config: TaskConfig):

--- a/frameworks/lightautoml/exec.py
+++ b/frameworks/lightautoml/exec.py
@@ -12,14 +12,13 @@ from lightautoml.tasks import Task
 from lightautoml.automl.presets.tabular_presets import TabularAutoML, TabularUtilizedAutoML
 from lightautoml import __version__
 
-from frameworks.shared.callee import call_run, result, output_subdir, utils, save_metadata
+from frameworks.shared.callee import call_run, result, output_subdir, utils
 
 log = logging.getLogger(__name__)
 
 
 def run(dataset, config):
     log.info(f"\n**** lightautoml (R) [{__version__}] ****\n")
-    save_metadata(config, version=__version__)
 
     warnings.simplefilter(action='ignore', category=FutureWarning)
     warnings.simplefilter(action='ignore', category=DeprecationWarning)

--- a/frameworks/lightautoml/setup.sh
+++ b/frameworks/lightautoml/setup.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 HERE=$(dirname "$0")
-AMLB_DIR="$1"
-VERSION=${2:-"latest"}
-REPO=${3:-"https://github.com/sberbank-ai-lab/LightAutoML.git"}
-PKG=${4:-"lightautoml"}
+VERSION=${1:-"latest"}
+REPO=${2:-"https://github.com/sberbank-ai-lab/LightAutoML.git"}
+PKG=${3:-"lightautoml"}
 if [[ "$VERSION" == "latest" ]]; then
     VERSION="master"
 fi
 
 # creating local venv
-. ${HERE}/../shared/setup.sh ${HERE}
+. ${HERE}/../shared/setup.sh ${HERE} true
 
 
 if [[ "$VERSION" == "stable" ]]; then
@@ -23,3 +22,5 @@ else
     cd "${TARGET_DIR}"
     bash build_package.sh
 fi
+
+PY -c "from lightautoml import __version__; print(__version__)" >> "${HERE}/.installed"

--- a/frameworks/mljarsupervised/__init__.py
+++ b/frameworks/mljarsupervised/__init__.py
@@ -1,15 +1,13 @@
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
-from amlb.resources import config as rconfig
 from amlb.utils import call_script_in_same_dir
 
 
 def setup(*args, **kwargs):
-    call_script_in_same_dir(__file__, "setup.sh", rconfig().root_dir, *args, **kwargs)
+    call_script_in_same_dir(__file__, "setup.sh", *args, **kwargs)
 
 
 def run(dataset: Dataset, config: TaskConfig):
-    from amlb.datautils import impute
     from frameworks.shared.caller import run_in_venv
 
     data = dict(

--- a/frameworks/mljarsupervised/exec.py
+++ b/frameworks/mljarsupervised/exec.py
@@ -10,14 +10,13 @@ matplotlib.use("agg")  # no need for tk
 import supervised
 from supervised.automl import AutoML
 
-from frameworks.shared.callee import call_run, result, output_subdir, save_metadata, utils
+from frameworks.shared.callee import call_run, result, output_subdir, utils
 
 log = logging.getLogger(os.path.basename(__file__))
 
 
 def run(dataset, config):
     log.info(f"\n**** mljar-supervised [v{supervised.__version__}] ****\n")
-    save_metadata(config, version=supervised.__version__)
 
     # Mapping of benchmark metrics to MLJAR metrics
     metrics_mapping = dict(

--- a/frameworks/mljarsupervised/setup.sh
+++ b/frameworks/mljarsupervised/setup.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
 HERE=$(dirname "$0")
-AMLB_DIR="$1"
-VERSION=${2:-"stable"}
-REPO=${3:-"https://github.com/mljar/mljar-supervised.git"}
-PKG=${4:-"mljar-supervised"}
+VERSION=${1:-"stable"}
+REPO=${2:-"https://github.com/mljar/mljar-supervised.git"}
+PKG=${3:-"mljar-supervised"}
 if [[ "$VERSION" == "latest" ]]; then
     VERSION="master"
 fi
 
 # creating local venv
-. ${HERE}/../shared/setup.sh ${HERE}
+. ${HERE}/../shared/setup.sh ${HERE} true
 
 if [[ -x "$(command -v apt-get)" ]]; then
     SUDO apt-get install -y build-essential swig
@@ -26,3 +25,5 @@ else
     git clone --depth 1 --single-branch --branch ${VERSION} --recurse-submodules ${REPO} ${TARGET_DIR}
     PIP install -U -e ${TARGET_DIR}
 fi
+
+PY -c "from supervised import __version__; print(__version__)" >> "${HERE}/.installed"

--- a/frameworks/mlr3automl/exec.py
+++ b/frameworks/mlr3automl/exec.py
@@ -5,7 +5,6 @@ from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
 from amlb.datautils import read_csv
 from amlb.utils import dir_of, run_cmd
-from frameworks.shared.callee import save_metadata
 
 log = logging.getLogger(__name__)
 
@@ -13,7 +12,6 @@ log = logging.getLogger(__name__)
 def run(dataset: Dataset, config: TaskConfig):
     #TODO: use rpy2 instead? not necessary here though as the call is very simple
     log.info(f"\n**** mlr3automl (R) [{config.framework_version}] ****\n")
-    save_metadata(config)
 
     here = dir_of(__file__)
 

--- a/frameworks/mlr3automl/exec.py
+++ b/frameworks/mlr3automl/exec.py
@@ -18,11 +18,11 @@ def run(dataset: Dataset, config: TaskConfig):
     here = dir_of(__file__)
 
     meta_results_file = os.path.join(config.output_dir, "meta_results.csv")
-    run_cmd(r"""Rscript --vanilla -e "
-                source('{script}'); 
-                run('{train}', '{test}', target.index = {target_index}, '{type}', '{output}', {cores}, 
-                    time.budget = {time_budget}, meta_results_file='{meta_results}', seed='{seed}', name='{name}')
-                " """.format(
+    run_cmd(("Rscript --vanilla -e \""
+             "source('{script}'); "
+             "run('{train}', '{test}', target.index = {target_index}, '{type}', '{output}', {cores},"
+             " time.budget = {time_budget}, meta_results_file='{meta_results}', seed='{seed}', name='{name}')"
+             "\"").format(
         script=os.path.join(here, 'exec.R'),
         train=dataset.train.path,
         test=dataset.test.path,

--- a/frameworks/mlr3automl/setup.sh
+++ b/frameworks/mlr3automl/setup.sh
@@ -4,12 +4,15 @@ VERSION=${1:-"stable"}
 REPO=${2:-"https://github.com/a-hanf"}
 MLR_REPO=${3:-"https://github.com/mlr-org"}
 
-. $HERE/../shared/setup.sh
+. $HERE/../shared/setup.sh ""
 if [[ -x "$(command -v apt-get)" ]]; then
 SUDO apt-get update
-SUDO apt-get install -y software-properties-common apt-transport-https libxml2-dev
-SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 51716619E084DAB9
-SUDO add-apt-repository 'deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu bionic-cran35/'
+#SUDO apt-get install -y software-properties-common apt-transport-https libxml2-dev
+#SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 51716619E084DAB9
+#SUDO add-apt-repository 'deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu bionic-cran35/'
+SUDO apt-get install -y software-properties-common dirmngr
+SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+SUDO add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
 SUDO apt-get update
 SUDO apt-get install -y r-base r-base-dev
 SUDO apt-get install -y libgdal-dev libproj-dev
@@ -17,14 +20,15 @@ SUDO apt-get install -y libssl-dev libcurl4-openssl-dev
 SUDO apt-get install -y libcairo2-dev libudunits2-dev
 fi
 
-SUDO Rscript -e 'options(install.packages.check.source="no"); install.packages(c("remotes", "checkmate", "R6", "xgboost", "ranger", "LiblineaR", "emoa", "e1071", "glmnet"), repos="https://cloud.r-project.org/", dependencies = TRUE)'
-SUDO Rscript -e 'remotes::install_github("'${MLR_REPO}'/mlr3pipelines")'
-SUDO Rscript -e 'remotes::install_github("'${MLR_REPO}'/mlr3oml")'
-SUDO Rscript -e 'remotes::install_github("'${MLR_REPO}'/paradox")'
-SUDO Rscript -e 'remotes::install_github("'${MLR_REPO}'/mlr3extralearners")'
-SUDO Rscript -e 'remotes::install_github("'${MLR_REPO}'/mlr3misc")'
-SUDO Rscript -e 'remotes::install_github("'${REPO}'/mlr3automl")'
-SUDO Rscript -e 'remotes::install_github("'${MLR_REPO}'/mlr3tuning@autotuner-notimeout")'
-SUDO Rscript -e 'remotes::install_github("'${MLR_REPO}'/mlr3@master")'
-SUDO Rscript -e 'remotes::install_github("'${MLR_REPO}'/mlr3hyperband@master")'
+Rscript -e 'options(install.packages.check.source="no"); install.packages(c("mlr3", "mlr3pipelines", "mlr3misc", "mlr3oml", "mlr3hyperband", "mlr3tuning", "paradox"), repos="https://cloud.r-project.org/")'
+Rscript -e 'options(install.packages.check.source="no"); install.packages(c("remotes", "checkmate", "R6", "xgboost", "ranger", "LiblineaR", "emoa", "e1071", "glmnet"), repos="https://cloud.r-project.org/")'
+Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/mlr3extralearners")'
+Rscript -e 'remotes::install_github("'"${REPO}"'/mlr3automl")'
+#Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/mlr3pipelines")'
+#Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/mlr3oml")'
+#Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/paradox")'
+#Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/mlr3misc")'
+#Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/mlr3tuning@autotuner-notimeout")'
+#Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/mlr3@master")'
+#Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/mlr3hyperband@master")'
 

--- a/frameworks/mlr3automl/setup.sh
+++ b/frameworks/mlr3automl/setup.sh
@@ -4,7 +4,7 @@ VERSION=${1:-"stable"}
 REPO=${2:-"https://github.com/a-hanf"}
 MLR_REPO=${3:-"https://github.com/mlr-org"}
 
-. $HERE/../shared/setup.sh ""
+. $HERE/../shared/setup.sh "$HERE"
 if [[ -x "$(command -v apt-get)" ]]; then
 SUDO apt-get update
 #SUDO apt-get install -y software-properties-common apt-transport-https libxml2-dev
@@ -32,3 +32,4 @@ Rscript -e 'remotes::install_github("'"${REPO}"'/mlr3automl")'
 #Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/mlr3@master")'
 #Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/mlr3hyperband@master")'
 
+Rscript -e 'packageVersion("mlr3automl")' | awk '{print $2}' | sed "s/[‘’]//g" >> "${HERE}/.installed"

--- a/frameworks/oboe/exec.py
+++ b/frameworks/oboe/exec.py
@@ -5,14 +5,13 @@ import sys
 sys.path.append("{}/lib/oboe/automl".format(os.path.realpath(os.path.dirname(__file__))))
 from auto_learner import AutoLearner
 
-from frameworks.shared.callee import call_run, result, save_metadata, utils
+from frameworks.shared.callee import call_run, result, utils
 
 log = logging.getLogger(__name__)
 
 
 def run(dataset, config):
     log.info(f"\n**** Oboe [{config.framework_version}] ****\n")
-    save_metadata(config)
 
     is_classification = config.type == 'classification'
     if not is_classification:

--- a/frameworks/oboe/setup.sh
+++ b/frameworks/oboe/setup.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 HERE=$(dirname "$0")
-VERSION=${2:-"stable"}
+VERSION=${1:-"stable"}
 REPO=${2:-"https://github.com/udellgroup/oboe.git"}
 PKG=${3:-"oboe"}
 if [[ "$VERSION" == "latest" ]]; then
     VERSION="master"
 fi
 
-. ${HERE}/../shared/setup.sh ${HERE}
+. ${HERE}/../shared/setup.sh ${HERE} true
 
 if [[ "$VERSION" == "stable" ]]; then
     PIP install --no-cache-dir -U ${PKG}

--- a/frameworks/ranger/exec.py
+++ b/frameworks/ranger/exec.py
@@ -6,15 +6,12 @@ from amlb.data import Dataset
 from amlb.datautils import read_csv
 from amlb.utils import dir_of, run_cmd
 
-from frameworks.shared.callee import save_metadata
-
 log = logging.getLogger(__name__)
 
 
 def run(dataset: Dataset, config: TaskConfig):
     #TODO: use rpy2 instead? not necessary here though as the call is very simple
     log.info("\n**** Random Forest (R) ****\n")
-    save_metadata(config)
 
     here = dir_of(__file__)
     meta_results_file = os.path.join(config.output_dir, "meta_results.csv")

--- a/frameworks/ranger/exec.py
+++ b/frameworks/ranger/exec.py
@@ -16,22 +16,18 @@ def run(dataset: Dataset, config: TaskConfig):
     log.info("\n**** Random Forest (R) ****\n")
     save_metadata(config)
 
-    is_classification = config.type == 'classification'
-    if not is_classification:
-        raise ValueError('Regression is not supported.')
-
     here = dir_of(__file__)
     meta_results_file = os.path.join(config.output_dir, "meta_results.csv")
-    run_cmd(r"""Rscript --vanilla -e "
-            source('{script}'); 
-            run('{train}', '{test}', '{output}', 
-                cores={cores}, meta_results_file='{meta_results}')
-            " """.format(
+    run_cmd(("Rscript --vanilla -e \""
+             "source('{script}'); "
+             "run('{train}', '{test}', '{output}', cores={cores}, meta_results_file='{meta_results}', task_type='{task_type}')"
+             "\"").format(
         script=os.path.join(here, 'exec.R'),
         train=dataset.train.path,
         test=dataset.test.path,
         output=config.output_predictions_file,
         meta_results=meta_results_file,
+        task_type=config.type,
         cores=config.cores
     ), _live_output_=True)
 

--- a/frameworks/ranger/setup.sh
+++ b/frameworks/ranger/setup.sh
@@ -3,12 +3,16 @@ HERE=$(dirname "$0")
 . ${HERE}/../shared/setup.sh ""
 if [[ -x "$(command -v apt-get)" ]]; then
     SUDO apt-get update
-    SUDO apt-get install -y software-properties-common apt-transport-https libxml2-dev
-    SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 51716619E084DAB9
-    SUDO add-apt-repository 'deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu bionic-cran35/'
+#    SUDO apt-get install -y software-properties-common apt-transport-https libxml2-dev
+#    SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 51716619E084DAB9
+#    SUDO add-apt-repository 'deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu bionic-cran35/'
+    SUDO apt-get install -y software-properties-common dirmngr
+    SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+    SUDO add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
+#    SUDO add-apt-repository ppa:c2d4u.team/c2d4u4.0+
     SUDO apt-get update
     SUDO apt-get install -y r-base r-base-dev
 fi
 #PIP install --no-cache-dir -r $HERE/requirements.txt
 
-SUDO Rscript -e 'options(install.packages.check.source="no"); install.packages(c("mlr", "mlrCPO", "ranger", "farff"), repos="https://cloud.r-project.org/")'
+Rscript -e 'options(install.packages.check.source="no"); install.packages(c("ranger", "mlr3", "mlr3learners", "mlr3pipelines", "farff"), repos="https://cloud.r-project.org/")'

--- a/frameworks/ranger/setup.sh
+++ b/frameworks/ranger/setup.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 HERE=$(dirname "$0")
-. ${HERE}/../shared/setup.sh ""
+. ${HERE}/../shared/setup.sh "$HERE"
+
 if [[ -x "$(command -v apt-get)" ]]; then
     SUDO apt-get update
 #    SUDO apt-get install -y software-properties-common apt-transport-https libxml2-dev
@@ -16,3 +17,5 @@ fi
 #PIP install --no-cache-dir -r $HERE/requirements.txt
 
 Rscript -e 'options(install.packages.check.source="no"); install.packages(c("ranger", "mlr3", "mlr3learners", "mlr3pipelines", "farff"), repos="https://cloud.r-project.org/")'
+
+Rscript -e 'packageVersion("ranger")' | awk '{print $2}' | sed "s/[‘’]//g" >> "${HERE}/.installed"

--- a/frameworks/shared/setup.sh
+++ b/frameworks/shared/setup.sh
@@ -3,8 +3,8 @@
 echo "shared/setup.sh" "$@"
 SHARED_DIR="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd -P)"
 MODULE_ROOT="$1"
+CREATE_VENV=${2:-false}
 APP_ROOT=$(dirname $(dirname "$SHARED_DIR"))
-#APP_ROOT="$(pwd)"
 
 SUDO() {
   if [[ $EUID == 0 ]]; then
@@ -14,8 +14,10 @@ SUDO() {
   fi
 }
 
+# retrieve PY_EXEC_PATH from .setup_env
+source "$MODULE_ROOT/.setup_env"
 
-if [[ -n "$MODULE_ROOT" ]]; then
+if [[ -n "$MODULE_ROOT" && "$CREATE_VENV" == "true" ]]; then
     PY_VENV="$MODULE_ROOT/venv"
 elif [[ -d "$APP_ROOT/venv" ]]; then
     PY_VENV="$APP_ROOT/venv"
@@ -24,14 +26,14 @@ fi
 if [[ -n "$PY_VENV" ]]; then
     py_exec="$PY_VENV/bin/python"
     if [[ ! -x py_exec ]]; then
-        python3 -m venv "$PY_VENV"
+        $PY_EXEC_PATH -m venv "$PY_VENV"
         $py_exec -m pip install -U pip wheel
     fi
     pip_exec="$py_exec -m pip"
     py_exec="$py_exec -W ignore"
 else
-    pip_exec="python3 -m pip"
-    py_exec="python3 -W ignore"
+    pip_exec="$PY_EXEC_PATH -m pip"
+    py_exec="$PY_EXEC_PATH -W ignore"
 fi
 
 PY() {

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -72,7 +72,7 @@ openml:
 
 versions:
   pip:
-  python: 3.7  # should we also enforce the Python version in docker images/ec2 instances?
+  python: 3.7  # the minor version of Python installed on containers/instances, also used as a based version for virtual environments created for each framework.
 
 container: &container
   force_branch: true  # set to true if image can only be built from a clean branch, with same tag as defined in `project_repository`.

--- a/runbenchmark.py
+++ b/runbenchmark.py
@@ -154,7 +154,7 @@ finally:
         out_dirs = bench.output_dirs
         for d in archives:
             if d in out_dirs:
-                zip_path(out_dirs[d], os.path.join(out_dirs.session, f"{d}.zip"))
+                zip_path(out_dirs[d], os.path.join(out_dirs.session, f"{d}.zip"), arcpathformat='long')
                 shutil.rmtree(out_dirs[d], ignore_errors=True)
 
     sys.exit(code)


### PR DESCRIPTION
- Upgrading to R4, changing CRAN repository.
- Fixed Python setup on Linux (aws + containers): some `apt-get` commands executed on framework setup require the original system Py version.
- improve detection of python exec: it doesn't have to use the default `python3` to create the venv.
- improved detection of the real version of the framework.
- modified ranger to use R4 and mlr3: setting a proper setup template for future R frameworks.