### PR TITLE
Fix config bug with delay_between_jobs

### DIFF
--- a/amlb/runners/aws.py
+++ b/amlb/runners/aws.py
@@ -215,7 +215,7 @@ class AWSBenchmark(Benchmark):
         else:
             queueing_strategy = MultiThreadingJobRunner.QueueingStrategy.enforce_job_priority
             return MultiThreadingJobRunner(jobs, self.parallel_jobs,
-                                           delay_secs=rconfig().delay_between_jobs,
+                                           delay_secs=rconfig().job_scheduler.delay_between_jobs,
                                            done_async=True,
                                            queueing_strategy=queueing_strategy)
 


### PR DESCRIPTION
The `delay_between_jobs` config param was moved under `job_scheduler` in [this commit](https://github.com/openml/automlbenchmark/blob/cea54d78bba2b7746344cc796c3e40939c07fb7f/resources/config.yaml#L63) which causes this error when running the benchmark in parallel `-p` on AWS:

```
'Namespace' object has no attribute 'delay_between_jobs'
Traceback (most recent call last):
  File "runbenchmark.py", line 142, in <module>
    res = bench.run(args.task, args.fold)
  File "/home/ledell/github/automlbenchmark/amlb/runners/aws.py", line 201, in run
    return super().run(task_name, fold)
  File "/home/ledell/github/automlbenchmark/amlb/benchmark.py", line 199, in run
    results = self._run_jobs(jobs)
  File "/home/ledell/github/automlbenchmark/amlb/benchmark.py", line 222, in _run_jobs
    self.job_runner = self._create_job_runner(jobs)
  File "/home/ledell/github/automlbenchmark/amlb/runners/aws.py", line 218, in _create_job_runner
    delay_secs=rconfig().delay_between_jobs,
  File "/home/ledell/github/automlbenchmark/amlb/utils/core.py", line 167, in __getattr__
    raise AttributeError(f"'Namespace' object has no attribute '{item}'")
AttributeError: 'Namespace' object has no attribute 'delay_between_jobs'
```