### PR TITLE
Install requirements.txt for Tuned Random Forest

### DIFF
--- a/frameworks/TunedRandomForest/setup.sh
+++ b/frameworks/TunedRandomForest/setup.sh
@@ -22,4 +22,5 @@ else
     PIP install -U -e ${TARGET_DIR}
 fi
 
+PIP install --no-cache-dir -r ${HERE}/requirements.txt
 PY -c "from sklearn import __version__; print(__version__)" >> "${HERE}/.installed"


### PR DESCRIPTION
`Stopit` module is used to ensure fitting normally stops in reasonable time for
Tuned Random Forest to return a model. For whatever reason it seemed to
no longer be installed.