### PR TITLE
ensure that return statements are executed outside finally blocks to

### DIFF
--- a/amlb/job.py
+++ b/amlb/job.py
@@ -208,7 +208,7 @@ class JobRunner:
             self.set_state(State.stopped)
             if t is not None:
                 log.info("All jobs executed in %.3f seconds.", t.duration)
-            return self.results
+        return self.results
 
     def stop(self):
         if self.state not in [State.stopping, State.stopped]:


### PR DESCRIPTION
Ensure that return statements are executed outside finally blocks to avoid swallowing exceptions