### PR TITLE
Update AutoGluon to 0.2.0

### DIFF
--- a/frameworks/AutoGluon/setup.sh
+++ b/frameworks/AutoGluon/setup.sh
@@ -18,6 +18,7 @@ fi
 PIP install --upgrade pip
 PIP install --upgrade setuptools wheel
 PIP install "mxnet<2.0.0"
+PIP install "scikit-learn-intelex<2021.3"
 
 if [[ "$VERSION" == "stable" ]]; then
     PIP install --no-cache-dir -U ${PKG}


### PR DESCRIPTION
This updates AutoGluon to support the latest release, [0.2.0](https://github.com/awslabs/autogluon/releases/tag/v0.2.0).

Instead of specifying sklearnex as an optional dependency in the install as we would normally do, I've made it installed on its own prior so AutoGluon 0.1.0 can still be run without issue.