### PR TITLE
improve cancellation logic during aws job setup

### DIFF
--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -7,7 +7,6 @@
 - run the jobs.
 - collect and save results.
 """
-import threading
 from copy import copy
 from enum import Enum
 from importlib import import_module, invalidate_caches

--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -7,7 +7,7 @@
 - run the jobs.
 - collect and save results.
 """
-
+import threading
 from copy import copy
 from enum import Enum
 from importlib import import_module, invalidate_caches
@@ -225,7 +225,8 @@ class Benchmark:
         self.job_runner = self._create_job_runner(jobs)
 
         def on_interrupt(*_):
-            log.warning("**** SESSION CANCELLED BY USER ****")
+            log.warning("*** SESSION CANCELLED BY USER ***")
+            log.warning("*** Please wait for the application to terminate gracefully ***")
             self.job_runner.stop()
             self.cleanup()
             # threading.Thread(target=self.job_runner.stop)

--- a/amlb/job.py
+++ b/amlb/job.py
@@ -14,7 +14,6 @@ import pprint
 import queue
 import signal
 import threading
-import time
 
 from .utils import Namespace, Timer, ThreadSafeCounter, InterruptTimeout, is_main_thread, raise_in_thread, signal_handler
 

--- a/amlb/job.py
+++ b/amlb/job.py
@@ -47,15 +47,15 @@ class CancelledError(JobError):
 class Job:
 
     state_machine = [
-        (None, [State.created]),
-        (State.created, [State.starting, State.cancelling]),
-        (State.starting, [State.running, State.rescheduling, State.cancelling]),
-        (State.running, [State.completing, State.rescheduling, State.cancelling]),
-        (State.completing, [State.stopping]),
-        (State.rescheduling, [State.starting, State.stopping]),
-        (State.cancelling, [State.stopping, State.stopped]),
-        (State.stopping, [State.stopped]),
-        (State.stopped, None)
+        (None,                  [State.created]),
+        (State.created,         [State.starting, State.cancelling]),
+        (State.starting,        [State.running, State.rescheduling, State.cancelling]),
+        (State.running,         [State.completing, State.rescheduling, State.cancelling]),
+        (State.completing,      [State.stopping]),
+        (State.rescheduling,    [State.starting, State.stopping]),
+        (State.cancelling,      [State.stopping, State.stopped]),
+        (State.stopping,        [State.stopped]),
+        (State.stopped,         None)
     ]
 
     @classmethod
@@ -189,12 +189,12 @@ class Job:
 class JobRunner:
 
     state_machine = [
-        (None, [State.created]),
-        (State.created, [State.starting, State.stopping]),
-        (State.starting, [State.running, State.stopping]),
-        (State.running, [State.stopping]),
-        (State.stopping, [State.stopped]),
-        (State.stopped, None)
+        (None,              [State.created]),
+        (State.created,     [State.starting, State.stopping]),
+        (State.starting,    [State.running, State.stopping]),
+        (State.running,     [State.stopping]),
+        (State.stopping,    [State.stopped]),
+        (State.stopped,     None)
     ]
 
     @classmethod

--- a/amlb/utils/process.py
+++ b/amlb/utils/process.py
@@ -257,8 +257,8 @@ def call_script_in_same_dir(caller_file, script_file, *args, **kwargs):
     return run_script(script_path, *args, **kwargs)
 
 
-def is_main_thread():
-    return threading.current_thread() == threading.main_thread()
+def is_main_thread(tid=None):
+    return get_thread(tid) == threading.main_thread()
 
 
 def get_thread(tid=None):

--- a/amlb/utils/time.py
+++ b/amlb/utils/time.py
@@ -3,6 +3,7 @@ import logging
 import math
 import threading
 import time
+from typing import Callable
 
 from .core import identity, threadsafe_generator
 
@@ -38,10 +39,12 @@ def datetime_iso(datetime=None, date=True, time=True, micros=False, date_sep='-'
     return datetime.strftime(strf)
 
 
-def countdown(timeout_secs, on_timeout=None, message=None, interval=1, log_level=logging.INFO):
+def countdown(timeout_secs, on_timeout: Callable = None, message: str = None, interval=1, log_level=logging.INFO,
+              interrupt_event: threading.Event = None, interrupt_cond: Callable = None):
     timeout_epoch = time.time() + timeout_secs
     remaining = timeout_secs
-    while remaining > 0:
+    interrupt = interrupt_event or threading.Event()
+    while remaining > 0 and not interrupt.is_set():
         mins, secs = divmod(remaining, 60)
         hours, mins = divmod(mins, 60)
         if message:
@@ -49,8 +52,10 @@ def countdown(timeout_secs, on_timeout=None, message=None, interval=1, log_level
         else:
             log.log(log_level, "countdown: %02d:%02d:%02d", hours, mins, secs)
         next_sleep = min(interval, remaining)
-        time.sleep(next_sleep)
+        interrupt.wait(next_sleep)
         remaining = math.ceil(timeout_epoch - time.time())
+        if interrupt_cond and interrupt_cond():
+            interrupt.set()
     if on_timeout:
         on_timeout()
 

--- a/amlb/utils/time.py
+++ b/amlb/utils/time.py
@@ -54,7 +54,7 @@ def countdown(timeout_secs, on_timeout: Callable = None, message: str = None, in
         next_sleep = min(interval, remaining)
         interrupt.wait(next_sleep)
         remaining = math.ceil(timeout_epoch - time.time())
-        if interrupt_cond and interrupt_cond():
+        if not interrupt.is_set() and interrupt_cond and interrupt_cond():
             interrupt.set()
     if on_timeout:
         on_timeout()

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -198,7 +198,7 @@ aws:                    # configuration namespace for AWS mode.
   max_timeout_seconds: 21600    #
   os_mem_size_mb: 0             # overrides the default amount of memory left to the os in AWS mode, and set to 0 for fairness as we can't always prevent frameworks from using all available memory.
   overhead_time_seconds: 1800   # amount of additional time allowed for the job to complete on aws before the instance is stopped.
-  query_interval_seconds: 30   # check instance state every N seconds
+  query_interval_seconds: 30    # check instance state every N seconds
 
   resource_files: []            # additional resource files or directories that are made available to benchmark runs on ec2, from remote input or user directory.
                                 # Those files are actually uploaded to s3 bucket (precisely to s3://{s3.bucket}/{s3.root_key}/user),


### PR DESCRIPTION
Ctrl-C is failing to interrupt Jobs in theur setup phase (mainly occurs in AWS mode, with instances waiting for next retry to obtain a Spot instance).
This PR replaces usage of `time.sleep` (which is difficult to interrupt) by an `threading.Event` that can be interrupted easily.

Job/Jobrunner logic has also been improved by making the state machine explicit.