### PR TITLE
Upgrade openml to 0.12.2 and make use of new connectivity options

### DIFF
--- a/amlb/benchmarks/openml.py
+++ b/amlb/benchmarks/openml.py
@@ -28,8 +28,8 @@ def load_oml_benchmark(benchmark: str) -> Tuple[str, Optional[str], List[Namespa
     if oml_type == 't':
         log.info("Loading openml task %s.", oml_id)
         # We first have the retrieve the task because we don't know the dataset id
-        t = openml.tasks.get_task(oml_id, download_data=False)
-        data = openml.datasets.get_dataset(t.dataset_id, download_data=False)
+        t = openml.tasks.get_task(oml_id, download_data=False, download_qualities=False)
+        data = openml.datasets.get_dataset(t.dataset_id, download_data=False, download_qualities=False)
         tasks = [Namespace(name=str_sanitize(data.name),
                            description=data.description,
                            openml_task_id=t.id)]

--- a/amlb/benchmarks/openml.py
+++ b/amlb/benchmarks/openml.py
@@ -25,6 +25,12 @@ def load_oml_benchmark(benchmark: str) -> Tuple[str, Optional[str], List[Namespa
     domain, oml_type, oml_id = benchmark.split('/')
     path = None  # benchmark file does not exist on disk
     name = benchmark  # name is later passed as cli input again for containers, it needs to remain parsable
+
+    if openml.config.retry_policy != "robot":
+        log.debug(
+            "Setting openml retry_policy from '%s' to 'robot'." % openml.config.retry_policy)
+        openml.config.set_retry_policy("robot")
+
     if oml_type == 't':
         log.info("Loading openml task %s.", oml_id)
         # We first have the retrieve the task because we don't know the dataset id

--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -39,8 +39,8 @@ class OpenmlLoader:
         if task_id is not None:
             if dataset_id is not None:
                 log.warning("Ignoring dataset id {} as a task id {} was already provided.".format(dataset_id, task_id))
-            task = oml.tasks.get_task(task_id)
-            dataset = task.get_dataset()
+            task = oml.tasks.get_task(task_id, download_qualities=False)
+            dataset = oml.datasets.get_dataset(task.dataset_id, download_qualities=False)
             _, nfolds, _ = task.get_split_dimensions()
             if fold >= nfolds:
                 raise ValueError("OpenML task {} only accepts `fold` < {}.".format(task_id, nfolds))

--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -46,26 +46,9 @@ class OpenmlLoader:
                 raise ValueError("OpenML task {} only accepts `fold` < {}.".format(task_id, nfolds))
         elif dataset_id is not None:
             raise NotImplementedError("OpenML raw datasets are not supported yet, please use an OpenML task instead.")
-            dataset = oml.datasets.get_dataset(dataset_id)
-            task = AutoTask(dataset)
-            if fold > 0:
-                raise ValueError("OpenML raw datasets {} only accepts `fold` = 0.".format(task_id))
         else:
             raise ValueError("A task id or a dataset id are required when using OpenML.")
         return OpenmlDataset(task, dataset, fold)
-
-
-class AutoTask(oml.OpenMLTask):
-    """A minimal task implementation providing only the information necessary to get the logic of this current module working."""
-
-    def __init__(self, oml_dataset: oml.OpenMLDataset):
-        self._dataset = oml_dataset
-        self._nrows = oml_dataset.qualities['NumberOfInstances']
-        self.target_name = oml_dataset.default_target_attribute
-
-    def get_train_test_split_indices(self, fold=0):
-        # TODO: make auto split 80% train, 20% test (make this configurable, also random vs sequential) and save it to disk
-        pass
 
 
 class OpenmlDataset(Dataset):

--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -72,12 +72,9 @@ class OpenmlDataset(Dataset):
                 return DatasetType.regression
             return None
 
-        nclasses = self._oml_dataset.qualities.get('NumberOfClasses', -1)
-        if nclasses >= 0:
-            return get_type(nclasses)
-        else:
-            target = next(f for f in self.features if f.is_target)
-            return get_type(len(target.values))
+        if hasattr(self._oml_task, "class_labels"):
+            return get_type(len(self._oml_task.class_labels))
+        return DatasetType.regression
 
     @property
     def train(self):

--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -34,6 +34,10 @@ class OpenmlLoader:
         if cache_dir:
             oml.config.set_cache_directory(cache_dir)
 
+        if oml.config.retry_policy != "robot":
+            log.debug("Setting openml retry_policy from '%s' to 'robot'." % oml.config.retry_policy)
+            oml.config.set_retry_policy("robot")
+
     @profile(logger=log)
     def load(self, task_id=None, dataset_id=None, fold=0):
         if task_id is not None:

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ Documentation: <https://openml.github.io/automlbenchmark/>
 ### Pre-requisites
 To run the benchmarks, you will need:
 * Python 3.7+.
-* PIP3: ensure you have a recent version. If necessary, upgrade your pip using `pip3 install -U pip`.
+* PIP3: ensure you have a recent version. If necessary, upgrade your pip using `python -m pip install -U pip`.
 * The Python libraries listed in [requirements.txt](../requirements.txt): it is strongly recommended to first create a [Python virtual environment](https://docs.python.org/3/library/venv.html#venv-def) (cf. also [Pyenv](https://github.com/pyenv/pyenv): quick install using `curl https://pyenv.run | bash` or `brew install pyenv`) and work in it if you don't want to mess up your global Python environment.
 * [Docker](https://docs.docker.com/install/), if you plan to run the benchmarks in a container.
 
@@ -77,13 +77,12 @@ pyenv local ve-automl
 Then pip install the dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+python -m pip install -r requirements.txt
 ```
 
 - _**NOTE**: in case of issues when installing Python requirements, you may want to try the following:_
-    - _on some platforms, we need to ensure that requirements are installed sequentially:_ `xargs -L 1 pip install < requirements.txt`.
-    - _enforce the `pip3` version above in your virtualenv:_ `pip3 install --upgrade pip==19.3.1`.
-    - _when installing on Windows using `python -m pip` is recommended, and may be required to successfully install `requirements-dev.txt`.
+    - _on some platforms, we need to ensure that requirements are installed sequentially:_ `xargs -L 1 python -m pip install < requirements.txt`.
+    - _enforce the `python -m pip` version above in your virtualenv:_ `python -m pip install --upgrade pip==19.3.1`.
 
 ## Quickstart
 To run a benchmark call the `runbenchmark.py` script with at least the following arguments:

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,7 +83,7 @@ pip3 install -r requirements.txt
 - _**NOTE**: in case of issues when installing Python requirements, you may want to try the following:_
     - _on some platforms, we need to ensure that requirements are installed sequentially:_ `xargs -L 1 pip install < requirements.txt`.
     - _enforce the `pip3` version above in your virtualenv:_ `pip3 install --upgrade pip==19.3.1`.
-
+    - _when installing on Windows using `python -m pip` is recommended, and may be required to successfully install `requirements-dev.txt`.
 
 ## Quickstart
 To run a benchmark call the `runbenchmark.py` script with at least the following arguments:

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ numpy>=1.20,<2.0
 pandas>=1.2.4,<2.0
 psutil>=5.4,<6.0
 ruamel.yaml>=0.15,<1.0
-openml==0.11.0
+openml==0.12.2
 scikit-learn>=0.24
 pyarrow>=4.0
 tables>=3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,9 @@ botocore==1.20.74
     #   boto3
     #   s3transfer
 certifi==2020.12.5
-    # via requests
+    # via
+    #   minio
+    #   requests
 chardet==4.0.0
     # via requests
 idna==2.10
@@ -26,6 +28,8 @@ liac-arff==2.5.0
     # via
     #   -r requirements.in
     #   openml
+minio==7.0.3
+    # via openml
 numexpr==2.7.3
     # via tables
 numpy==1.20.3
@@ -38,7 +42,7 @@ numpy==1.20.3
     #   scikit-learn
     #   scipy
     #   tables
-openml==0.11.0
+openml==0.12.2
     # via -r requirements.in
 pandas==1.2.4
     # via
@@ -47,7 +51,9 @@ pandas==1.2.4
 psutil==5.8.0
     # via -r requirements.in
 pyarrow==4.0.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   openml
 python-dateutil==2.8.1
     # via
     #   botocore
@@ -80,6 +86,7 @@ threadpoolctl==2.1.0
 urllib3==1.26.4
     # via
     #   botocore
+    #   minio
     #   requests
 xmltodict==0.12.0
     # via openml

--- a/runbenchmark.py
+++ b/runbenchmark.py
@@ -5,6 +5,8 @@ import re
 import shutil
 import sys
 
+import openml
+
 # prevent asap other modules from defining the root logger using basicConfig
 import amlb.logger
 
@@ -149,6 +151,10 @@ config_args = ns({k: v for k, v in config_args if v is not None})
 log.debug("Config args: %s.", config_args)
 # merging all configuration files
 amlb.resources.from_configs(config_default, config_default_dirs, config_user, config_args)
+
+if openml.config.retry_policy != "robot":
+    log.debug("Setting openml retry_policy from '%s' to 'robot'." % openml.config.retry_policy)
+    openml.config.set_retry_policy("robot")
 
 code = 0
 bench = None

--- a/runbenchmark.py
+++ b/runbenchmark.py
@@ -5,8 +5,6 @@ import re
 import shutil
 import sys
 
-import openml
-
 # prevent asap other modules from defining the root logger using basicConfig
 import amlb.logger
 
@@ -151,10 +149,6 @@ config_args = ns({k: v for k, v in config_args if v is not None})
 log.debug("Config args: %s.", config_args)
 # merging all configuration files
 amlb.resources.from_configs(config_default, config_default_dirs, config_user, config_args)
-
-if openml.config.retry_policy != "robot":
-    log.debug("Setting openml retry_policy from '%s' to 'robot'." % openml.config.retry_policy)
-    openml.config.set_retry_policy("robot")
 
 code = 0
 bench = None

--- a/tests/unit/amlb/datasets/openml/test_openml_dataloader.py
+++ b/tests/unit/amlb/datasets/openml/test_openml_dataloader.py
@@ -55,7 +55,7 @@ def _assert_kc2_features(dataset):
     assert all([p.values is None for p in dataset.predictors])
     assert not any([p.has_missing_values for p in dataset.predictors])
 
-    assert dataset.train.X.dtypes.apply(lambda dt: pd.api.types.is_float_dtype(dt)).all()
+    assert dataset.train.X.dtypes.apply(lambda dt: pd.api.types.is_numeric_dtype(dt)).all()
     assert pd.api.types.is_categorical_dtype(dataset.train.y.dtypes.iloc[0])
 
 
@@ -109,7 +109,7 @@ def _assert_cholesterol_features(dataset):
     assert len(categoricals) == 7
     assert len([p for p in dataset.predictors if p.has_missing_values]) == 2
 
-    assert dataset.train.X.dtypes.filter(items=numericals).apply(lambda dt: pd.api.types.is_float_dtype(dt)).all()
+    assert dataset.train.X.dtypes.filter(items=numericals).apply(lambda dt: pd.api.types.is_numeric_dtype(dt)).all()
     assert dataset.train.X.dtypes.filter(items=categoricals).apply(lambda dt: pd.api.types.is_categorical_dtype(dt)).all()
     assert pd.api.types.is_float_dtype(dataset.train.y.dtypes.iloc[0])
 

--- a/tests/unit/amlb/datasets/openml/test_openml_dataloader.py
+++ b/tests/unit/amlb/datasets/openml/test_openml_dataloader.py
@@ -56,6 +56,8 @@ def _assert_kc2_features(dataset):
     assert not any([p.has_missing_values for p in dataset.predictors])
 
     assert dataset.train.X.dtypes.apply(lambda dt: pd.api.types.is_numeric_dtype(dt)).all()
+    assert len(dataset.train.X.select_dtypes(include=['float']).columns) == 18
+    assert len(dataset.train.X.select_dtypes(include=['uint8']).columns) == 3
     assert pd.api.types.is_categorical_dtype(dataset.train.y.dtypes.iloc[0])
 
 
@@ -111,6 +113,8 @@ def _assert_cholesterol_features(dataset):
 
     assert dataset.train.X.dtypes.filter(items=numericals).apply(lambda dt: pd.api.types.is_numeric_dtype(dt)).all()
     assert dataset.train.X.dtypes.filter(items=categoricals).apply(lambda dt: pd.api.types.is_categorical_dtype(dt)).all()
+    assert len(dataset.train.X.select_dtypes(include=['float']).columns) == 2
+    assert len(dataset.train.X.select_dtypes(include=['uint8']).columns) == 4
     assert pd.api.types.is_float_dtype(dataset.train.y.dtypes.iloc[0])
 
 


### PR DESCRIPTION
Upgrade and improvements:
 - upgrades openml-python dependency to 0.12.2
 - uses the `retry_policy` option introduced in `0.12.2`
 - use the introduced `download_qualities` parameter of `get_task` to avoid downloading `qualities.xml` altogether.