### PR TITLE
Fix mismatch between arff header and data

### DIFF
--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -256,7 +256,15 @@ class ArffSplitter(DataSplitter[str]):
 
     def _get_categorical_values(self, col):
         feat = next((f for f in self.ds._oml_dataset.features.values() if f.name == col), None)
-        return feat.nominal_values if feat is not None else None
+        if feat is not None:
+            # openml-python converts categorical features which look boolean to
+            # boolean values, which always write values as 'True' and 'False',
+            # so we need to adapt the header accordingly.
+            # Not doing so causes an issue in the R packages.
+            if set(v.lower() for v in feat.nominal_values) == {"true", "false"}:
+                return ["True", "False"]
+            return feat.nominal_values
+        return None
 
 
 class CsvSplitter(DataSplitter[str]):

--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -262,7 +262,7 @@ class ArffSplitter(DataSplitter[str]):
             # so we need to adapt the header accordingly.
             # Not doing so causes an issue in the R packages.
             if set(v.lower() for v in feat.nominal_values) == {"true", "false"}:
-                return ["True", "False"]
+                return [v.lower().capitalize() for v in feat.nominal_values]
             return feat.nominal_values
         return None
 


### PR DESCRIPTION
Due to the conversion that openml-python does from a categorical arff column to a boolean pandas column, true/false categoricals are actually written as True/False (note capitalization) in the data but the features still describe it as true/false. This leads to a is match in the ARFF header and the actual data, which caused issues for R frameworks. 

Confirmed in #315.