### PR TITLE
Add R packages to 'all frameworks' CI

### DIFF
--- a/.github/workflows/run_all_frameworks.yml
+++ b/.github/workflows/run_all_frameworks.yml
@@ -50,7 +50,7 @@ jobs:
           skip_evaluation=0
           if [[ $is_common -eq 0 ]];
           then
-            FRAMEWORKS='["autogluon", "autosklearn", "gama", "h2oautoml", "mlplanweka", "tpot", "tunedrandomforest"]'
+            FRAMEWORKS='["autogluon", "autosklearn", "autoxgboost", "gama", "h2oautoml", "mlplanweka", "mlr3automl", "tpot", "tunedrandomforest"]'
             TASKS='["iris", "kc2", "cholesterol"]'
             BENCHMARK='["test"]'
           else

--- a/frameworks/autoxgboost/exec.py
+++ b/frameworks/autoxgboost/exec.py
@@ -19,7 +19,7 @@ def run(dataset: Dataset, config: TaskConfig):
 
     meta_results_file = os.path.join(config.output_dir, "meta_results.csv")
     run_cmd(("Rscript --vanilla -e \""
-             "source('{script}'); "
+             ".libPaths('frameworks/autoxgboost/r-packages/'); source('{script}'); "
              "run('{train}', '{test}', target.index = {target_index}, '{type}', '{output}', {cores},"
              " time.budget = {time_budget}, meta_results_file='{meta_results}')"
              "\"").format(

--- a/frameworks/autoxgboost/exec.py
+++ b/frameworks/autoxgboost/exec.py
@@ -19,10 +19,11 @@ def run(dataset: Dataset, config: TaskConfig):
 
     meta_results_file = os.path.join(config.output_dir, "meta_results.csv")
     run_cmd(("Rscript --vanilla -e \""
-             ".libPaths('frameworks/autoxgboost/r-packages/'); source('{script}'); "
+             ".libPaths('{package_directory}'); source('{script}'); "
              "run('{train}', '{test}', target.index = {target_index}, '{type}', '{output}', {cores},"
              " time.budget = {time_budget}, meta_results_file='{meta_results}')"
              "\"").format(
+        package_directory=os.path.join(here, "r-packages"),
         script=os.path.join(here, 'exec.R'),
         train=dataset.train.path,
         test=dataset.test.path,

--- a/frameworks/autoxgboost/setup.sh
+++ b/frameworks/autoxgboost/setup.sh
@@ -25,6 +25,6 @@ fi
 mkdir "${HERE}/r-packages/"
 
 Rscript -e 'options(install.packages.check.source="no"); install.packages(c("remotes", "mlr", "mlrMBO", "mlrCPO", "farff", "GenSA", "rgenoud", "xgboost"), repos="https://cloud.r-project.org/", lib="'"${HERE}/r-packages/"'")'
-Rscript -e 'remotes::install_github("'"${REPO}"'", ref="'"${VERSION}"'", lib="'"${HERE}/r-packages/"'")'
+Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); remotes::install_github("'"${REPO}"'", ref="'"${VERSION}"'", lib="'"${HERE}/r-packages/"'")'
 
 Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); packageVersion("autoxgboost")' | awk '{print $2}' | sed "s/[‘’]//g" >> "${HERE}/.installed"

--- a/frameworks/autoxgboost/setup.sh
+++ b/frameworks/autoxgboost/setup.sh
@@ -8,22 +8,23 @@ if [[ "$VERSION" == "latest" || "$VERSION" == "stable" ]]; then
 fi
 . ${HERE}/../shared/setup.sh "${HERE}"
 if [[ -x "$(command -v apt-get)" ]]; then
-SUDO apt-get update
-#SUDO apt-get install -y software-properties-common apt-transport-https libxml2-dev
-#SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 51716619E084DAB9
-#SUDO add-apt-repository 'deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu bionic-cran35/'
-SUDO apt-get install -y software-properties-common dirmngr
-SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
-SUDO add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
-SUDO apt-get update
-SUDO apt-get install -y r-base r-base-dev
-SUDO apt-get install -y libgdal-dev libproj-dev
-SUDO apt-get install -y libssl-dev libcurl4-openssl-dev
-SUDO apt-get install -y libcairo2-dev libudunits2-dev
+  SUDO apt-get update
+  SUDO apt-get install -y software-properties-common dirmngr
+  SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+  SUDO add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
+  SUDO apt-get update
+  SUDO apt-get install -y r-base r-base-dev
+  SUDO apt-get install -y libgdal-dev libproj-dev
+  SUDO apt-get install -y libssl-dev libcurl4-openssl-dev
+  SUDO apt-get install -y libcairo2-dev libudunits2-dev
 fi
 
-#PIP install --no-cache-dir -r $HERE/requirements.txt
-Rscript -e 'options(install.packages.check.source="no"); install.packages(c("remotes", "mlr", "mlrMBO", "mlrCPO", "farff", "GenSA", "rgenoud", "xgboost"), repos="https://cloud.r-project.org/")'
-Rscript -e 'remotes::install_github("'"${REPO}"'", ref="'"${VERSION}"'")'
+# We install the packages to a subdirectory in the framework folder, similar to venvs for Python, because:
+# - we want to be able to install different package versions for different frameworks in one local installation
+# - the default package directory is not always writeable (e.g. on Github CI)
+mkdir "${HERE}/r-packages/"
 
-Rscript -e 'packageVersion("autoxgboost")' | awk '{print $2}' | sed "s/[‘’]//g" >> "${HERE}/.installed"
+Rscript -e 'options(install.packages.check.source="no"); install.packages(c("remotes", "mlr", "mlrMBO", "mlrCPO", "farff", "GenSA", "rgenoud", "xgboost"), repos="https://cloud.r-project.org/", lib="'"${HERE}/r-packages/"'")'
+Rscript -e 'remotes::install_github("'"${REPO}"'", ref="'"${VERSION}"'", lib="'"${HERE}/r-packages/"'")'
+
+Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); packageVersion("autoxgboost")' | awk '{print $2}' | sed "s/[‘’]//g" >> "${HERE}/.installed"

--- a/frameworks/mlr3automl/exec.py
+++ b/frameworks/mlr3automl/exec.py
@@ -17,7 +17,7 @@ def run(dataset: Dataset, config: TaskConfig):
 
     meta_results_file = os.path.join(config.output_dir, "meta_results.csv")
     run_cmd(("Rscript --vanilla -e \""
-             "source('{script}'); "
+             ".libPaths('frameworks/mlr3automl/r-packages/'); source('{script}'); "
              "run('{train}', '{test}', target.index = {target_index}, '{type}', '{output}', {cores},"
              " time.budget = {time_budget}, meta_results_file='{meta_results}', seed='{seed}', name='{name}')"
              "\"").format(

--- a/frameworks/mlr3automl/exec.py
+++ b/frameworks/mlr3automl/exec.py
@@ -17,10 +17,11 @@ def run(dataset: Dataset, config: TaskConfig):
 
     meta_results_file = os.path.join(config.output_dir, "meta_results.csv")
     run_cmd(("Rscript --vanilla -e \""
-             ".libPaths('frameworks/mlr3automl/r-packages/'); source('{script}'); "
+             ".libPaths('{package_directory}'); source('{script}'); "
              "run('{train}', '{test}', target.index = {target_index}, '{type}', '{output}', {cores},"
              " time.budget = {time_budget}, meta_results_file='{meta_results}', seed='{seed}', name='{name}')"
              "\"").format(
+        package_directory=os.path.join(here, "r-packages"),
         script=os.path.join(here, 'exec.R'),
         train=dataset.train.path,
         test=dataset.test.path,

--- a/frameworks/mlr3automl/setup.sh
+++ b/frameworks/mlr3automl/setup.sh
@@ -24,7 +24,7 @@ mkdir "${HERE}/r-packages/"
 
 Rscript -e 'options(install.packages.check.source="no"); install.packages(c("mlr3", "mlr3pipelines", "mlr3misc", "mlr3oml", "mlr3hyperband", "mlr3tuning", "paradox"), repos="https://cloud.r-project.org/", lib="'"${HERE}/r-packages/"'")'
 Rscript -e 'options(install.packages.check.source="no"); install.packages(c("remotes", "checkmate", "R6", "xgboost", "ranger", "LiblineaR", "emoa", "e1071", "glmnet"), repos="https://cloud.r-project.org/", lib="'"${HERE}/r-packages/"'")'
-Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/mlr3extralearners", lib="'"${HERE}/r-packages/"'")'
-Rscript -e 'remotes::install_github("'"${REPO}"'/mlr3automl", lib="'"${HERE}/r-packages/"'")'
+Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); remotes::install_github("'"${MLR_REPO}"'/mlr3extralearners", lib="'"${HERE}/r-packages/"'")'
+Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); remotes::install_github("'"${REPO}"'/mlr3automl", lib="'"${HERE}/r-packages/"'")'
 
 Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); packageVersion("mlr3automl")' | awk '{print $2}' | sed "s/[‘’]//g" >> "${HERE}/.installed"

--- a/frameworks/mlr3automl/setup.sh
+++ b/frameworks/mlr3automl/setup.sh
@@ -7,29 +7,24 @@ MLR_REPO=${3:-"https://github.com/mlr-org"}
 . $HERE/../shared/setup.sh "$HERE"
 if [[ -x "$(command -v apt-get)" ]]; then
 SUDO apt-get update
-#SUDO apt-get install -y software-properties-common apt-transport-https libxml2-dev
-#SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 51716619E084DAB9
-#SUDO add-apt-repository 'deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu bionic-cran35/'
-SUDO apt-get install -y software-properties-common dirmngr
-SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
-SUDO add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
-SUDO apt-get update
-SUDO apt-get install -y r-base r-base-dev
-SUDO apt-get install -y libgdal-dev libproj-dev
-SUDO apt-get install -y libssl-dev libcurl4-openssl-dev
-SUDO apt-get install -y libcairo2-dev libudunits2-dev
+  SUDO apt-get install -y software-properties-common dirmngr
+  SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+  SUDO add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"
+  SUDO apt-get update
+  SUDO apt-get install -y r-base r-base-dev
+  SUDO apt-get install -y libgdal-dev libproj-dev
+  SUDO apt-get install -y libssl-dev libcurl4-openssl-dev
+  SUDO apt-get install -y libcairo2-dev libudunits2-dev
 fi
 
-Rscript -e 'options(install.packages.check.source="no"); install.packages(c("mlr3", "mlr3pipelines", "mlr3misc", "mlr3oml", "mlr3hyperband", "mlr3tuning", "paradox"), repos="https://cloud.r-project.org/")'
-Rscript -e 'options(install.packages.check.source="no"); install.packages(c("remotes", "checkmate", "R6", "xgboost", "ranger", "LiblineaR", "emoa", "e1071", "glmnet"), repos="https://cloud.r-project.org/")'
-Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/mlr3extralearners")'
-Rscript -e 'remotes::install_github("'"${REPO}"'/mlr3automl")'
-#Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/mlr3pipelines")'
-#Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/mlr3oml")'
-#Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/paradox")'
-#Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/mlr3misc")'
-#Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/mlr3tuning@autotuner-notimeout")'
-#Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/mlr3@master")'
-#Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/mlr3hyperband@master")'
+# We install the packages to a subdirectory in the framework folder, similar to venvs for Python, because:
+# - we want to be able to install different package versions for different frameworks in one local installation
+# - the default package directory is not always writeable (e.g. on Github CI)
+mkdir "${HERE}/r-packages/"
 
-Rscript -e 'packageVersion("mlr3automl")' | awk '{print $2}' | sed "s/[‘’]//g" >> "${HERE}/.installed"
+Rscript -e 'options(install.packages.check.source="no"); install.packages(c("mlr3", "mlr3pipelines", "mlr3misc", "mlr3oml", "mlr3hyperband", "mlr3tuning", "paradox"), repos="https://cloud.r-project.org/", lib="'"${HERE}/r-packages/"'")'
+Rscript -e 'options(install.packages.check.source="no"); install.packages(c("remotes", "checkmate", "R6", "xgboost", "ranger", "LiblineaR", "emoa", "e1071", "glmnet"), repos="https://cloud.r-project.org/", lib="'"${HERE}/r-packages/"'")'
+Rscript -e 'remotes::install_github("'"${MLR_REPO}"'/mlr3extralearners", lib="'"${HERE}/r-packages/"'")'
+Rscript -e 'remotes::install_github("'"${REPO}"'/mlr3automl", lib="'"${HERE}/r-packages/"'")'
+
+Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); packageVersion("mlr3automl")' | awk '{print $2}' | sed "s/[‘’]//g" >> "${HERE}/.installed"


### PR DESCRIPTION
Requires #324 to be resolved before R frameworks work on KC1 (part of the `validation` benchmark which is used for framework specific changes only).

Adds `mlr3automl` and `autoxgboost` to the frameworks to run CI against.