### PR TITLE
Enforce core constraints when using docker

### DIFF
--- a/amlb/runners/docker.py
+++ b/amlb/runners/docker.py
@@ -43,7 +43,7 @@ class DockerBenchmark(ContainerBenchmark):
         return os.path.join(self._framework_dir, 'Dockerfile')
 
     def _start_container(self, script_params=""):
-        """Implementes the container run method"""
+        """Implements the container run method"""
         in_dir = rconfig().input_dir
         out_dir = rconfig().output_dir
         custom_dir = rconfig().user_dir
@@ -52,7 +52,7 @@ class DockerBenchmark(ContainerBenchmark):
         script_extra_params = "--session="  # in combination with `self.output_dirs.session` usage below to prevent creation of 2 sessions locally
         inst_name = f"{self.sid}.{str_sanitize(str_digest(script_params))}"
         cmd = (
-            "docker run --name {name} {options} "
+            "docker run --name {name} {options}  --cpus {cores} "
             "-v {input}:/input -v {output}:/output -v {custom}:/custom "
             "--rm {image} {params} -i /input -o /output -u /custom -s skip -Xrun_mode=docker {extra_params}"
         ).format(
@@ -64,6 +64,7 @@ class DockerBenchmark(ContainerBenchmark):
             image=self.image,
             params=script_params,
             extra_params=script_extra_params,
+            cores=self.constraint_def['cores']
         )
         log.info("Starting docker: %s.", cmd)
         log.info("Datasets are loaded by default from folder %s.", in_dir)


### PR DESCRIPTION
When using docker, run the docker container with exactly the number of (virtual) cores specified in `resources/constraints.yaml`. This has the advantage that if a framework ignores the core constraint provided to it, it still cannot access more cores than allocated if using the docker runner.

Note that if more cores are requested than the host has, the test stops with an error. For example, if I add this constraint on a machine with 8 cores:
```
toolarge:
  folds: 10
  max_runtime_seconds: 600
  cores: 64
```
and run the benchmark, it stops with the following error:
```
~/automlbenchmark$ python runbenchmark.py flaml small toolarge -m docker
...
Starting job docker.small.toolarge.all_tasks.all_folds.flaml.
Starting docker: docker run --name flaml.small.toolarge.docker.20210618T184308.oY89DFXAOMw5B0wDQ_9p5A__ --shm-size=2048M  --cpus 64 -v /home/t-moekayali/.openml/cache:/input -v /home/t-moekayali/automlbenchmark/results/flaml.small.toolarge.docker.20210618T184308:/output -v /home/t-moekayali/.config/automlbenchmark:/custom --rm automlbenchmark/flaml:stable-dev flaml small toolarge   -Xseed=auto -i /input -o /output -u /custom -s skip -Xrun_mode=docker --session=.
Datasets are loaded by default from folder /home/t-moekayali/.openml/cache.
Generated files will be available in folder /home/t-moekayali/automlbenchmark/results.
Running cmd `docker run --name flaml.small.toolarge.docker.20210618T184308.oY89DFXAOMw5B0wDQ_9p5A__ --shm-size=2048M  --cpus 64 -v /home/t-moekayali/.openml/cache:/input -v /home/t-moekayali/automlbenchmark/results/flaml.small.toolarge.docker.20210618T184308:/output -v /home/t-moekayali/.config/automlbenchmark:/custom --rm automlbenchmark/flaml:stable-dev flaml small toolarge   -Xseed=auto -i /input -o /output -u /custom -s skip -Xrun_mode=docker --session=`
docker: Error response from daemon: Range of CPUs is from 0.01 to 8.00, as there are only 8 CPUs available.
```