### PR TITLE
[Auto-sklearn] Fixes problems with new scipy 1.7.0 version

### DIFF
--- a/frameworks/autosklearn/requirements.txt
+++ b/frameworks/autosklearn/requirements.txt
@@ -1,2 +1,3 @@
 packaging
 openml
+scipy>=0.14.1,<1.7.0


### PR DESCRIPTION
A new scipy version is breaking the SMAC package, one of Auto-Sklearn dependencies. 

This PR aims to work-around this problem by using an older version of scipy in the install requirements of Auto-sklearn.