### PR TITLE
Replace hardcoded python3 by python{pyv}

### DIFF
--- a/amlb/runners/docker.py
+++ b/amlb/runners/docker.py
@@ -137,8 +137,8 @@ WORKDIR /bench
 # packages that we need to data pre- and postprocessing without breaking it.
 RUN $SPIP install -U pip wheel
 RUN $SPY -m venv venv
-ENV PIP /bench/venv/bin/python3 -m pip
-ENV PY /bench/venv/bin/python3 -W ignore
+ENV PIP /bench/venv/bin/python{pyv} -m pip
+ENV PY /bench/venv/bin/python{pyv} -W ignore
 #RUN $PIP install -U pip=={pipv} wheel
 RUN $PIP install -U pip wheel
 

--- a/amlb/runners/singularity.py
+++ b/amlb/runners/singularity.py
@@ -168,10 +168,9 @@ add-apt-repository -y ppa:deadsnakes/ppa
 apt-get update
 apt-get -y install python{pyv} python{pyv}-venv python{pyv}-dev python3-pip
 #update-alternatives --install /usr/bin/python3 python3 $(which python{pyv}) 1
-pip3 install -U pip wheel
 
 # aliases for the python system
-SPIP=python{pyv} -m pip
+SPIP="python{pyv} -m pip"
 SPY=python{pyv}
 
 # Enforce UTF-8 encoding
@@ -187,9 +186,10 @@ cd /bench
 # packages that we need to data pre- and postprocessing without breaking it.
 $SPIP install -U pip wheel
 $SPY -m venv venv
-PIP=/bench/venv/bin/python3 -m pip
-PY=/bench/venv/bin/python3
+PIP="/bench/venv/bin/python{pyv} -m pip"
+PY="/bench/venv/bin/python{pyv} -W ignore"
 #$PIP install -U pip=={pipv} wheel
+ls -al /bench/venv/bin/
 $PIP install -U pip wheel
 
 mkdir /input
@@ -199,19 +199,19 @@ mkdir /custom
 
 (grep -v '^\\s*#' | xargs -L 1 $PIP install --no-cache-dir) < requirements.txt
 
-RUN $PY {script} {framework} -s only
+$PY {script} {framework} -s only
 {custom_commands}
 
 %environment
 export DEBIAN_FRONTEND=noninteractive
-export SPIP=python3 -m pip
-export SPY=python3
+export SPIP=python{pyv} -m pip
+export SPY=python{pyv}
 export PYTHONUTF8=1
 export PYTHONIOENCODING=utf-8
 export LANG=C.UTF-8
 export LC_ALL=C.UTF-8
-export PIP=/bench/venv/bin/python3 -m pip
-export PY=/bench/venv/bin/python3
+export PIP=/bench/venv/bin/python{pyv} -m pip
+export PY=/bench/venv/bin/python{pyv}
 %runscript
 cd /bench
 exec /bin/bash -c "$PY {script} ""$@"

--- a/amlb/runners/singularity.py
+++ b/amlb/runners/singularity.py
@@ -189,7 +189,6 @@ $SPY -m venv venv
 PIP="/bench/venv/bin/python{pyv} -m pip"
 PY="/bench/venv/bin/python{pyv} -W ignore"
 #$PIP install -U pip=={pipv} wheel
-ls -al /bench/venv/bin/
 $PIP install -U pip wheel
 
 mkdir /input


### PR DESCRIPTION
I observed that python3 does not work in my singularity build as it is not a symlink to the system python, but something else:

```
-rwxr-xr-x 1 root root 5482296 Jul  2 07:54 python
-rwxr-xr-x 1 root root 5482296 Jul  2 07:54 python3
lrwxrwxrwx 1 root root      18 Jul  2 07:56 python3.7 -> /usr/bin/python3.7
```

I therefore propose to use the python version that's given by the `{pyv}` variable everywhere, also in the docker file.

In addition, this PR adds some brackets to the singularity file creation and removes a `RUN` which broke my build.