### PR TITLE
Allow R-framework version to be specified by commit hash

### DIFF
--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -491,7 +491,7 @@ class BenchmarkTask:
         task_config.type_ = self._dataset.type.name
         task_config.framework = self.benchmark.framework_name
         task_config.framework_params = framework_def.params
-        task_config.framework_version = self.benchmark._installed_version()[0]
+        task_config.framework_version = ':'.join(self.benchmark._installed_version())
 
         # allowing to pass framework parameters through command line, e.g.: -Xf.verbose=True -Xf.n_estimators=3000
         if rconfig()['f'] is not None:

--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -491,7 +491,7 @@ class BenchmarkTask:
         task_config.type_ = self._dataset.type.name
         task_config.framework = self.benchmark.framework_name
         task_config.framework_params = framework_def.params
-        task_config.framework_version = ':'.join(self.benchmark._installed_version())
+        task_config.framework_version = self.benchmark._installed_version()[0]
 
         # allowing to pass framework parameters through command line, e.g.: -Xf.verbose=True -Xf.n_estimators=3000
         if rconfig()['f'] is not None:

--- a/frameworks/autoxgboost/setup.sh
+++ b/frameworks/autoxgboost/setup.sh
@@ -9,7 +9,7 @@ if [[ "$VERSION" == "latest" || "$VERSION" == "stable" ]]; then
 fi
 
 if [[ "$VERSION" =~ ^# ]]; then
-  VERSION="${VERSION:1:8}"
+  VERSION="${VERSION:1}"
 else
   # if VERSION is not a hash, it should be a branch (or a format which is not (officially) supported)
   COMMIT=$(git ls-remote "https://github.com/${REPO}" | grep "refs/heads/${VERSION}" | cut -f 1)
@@ -17,7 +17,7 @@ else
     echo "Could not resolve version ${VERSION}. It is not a branch on https://github.com/${REPO}."
     echo "Continuing setup, install_github will try to resolve 'ref=${VERSION}'."
   else
-    VERSION="${COMMIT:0:7}"
+    VERSION=$COMMIT
   fi
 fi
 
@@ -43,4 +43,4 @@ Rscript -e 'options(install.packages.check.source="no"); install.packages(c("rem
 Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); remotes::install_github("'"${REPO}"'", ref="'"${VERSION}"'", lib="'"${HERE}/r-packages/"'")'
 
 OFFICIAL_VERSION=$(Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); packageVersion("autoxgboost")' | awk '{print $2}' | sed "s/[‘’]//g")
-echo "${OFFICIAL_VERSION}#${VERSION}" >> "${HERE}/.installed"
+echo "${OFFICIAL_VERSION}#${VERSION:0:7}" >> "${HERE}/.installed"

--- a/frameworks/autoxgboost/setup.sh
+++ b/frameworks/autoxgboost/setup.sh
@@ -38,5 +38,5 @@ mkdir "${HERE}/r-packages/"
 Rscript -e 'options(install.packages.check.source="no"); install.packages(c("remotes", "mlr", "mlrMBO", "mlrCPO", "farff", "GenSA", "rgenoud", "xgboost"), repos="https://cloud.r-project.org/", lib="'"${HERE}/r-packages/"'")'
 Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); remotes::install_github("'"${REPO}"'", ref="'"${VERSION}"'", lib="'"${HERE}/r-packages/"'")'
 
-Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); packageVersion("autoxgboost")' | awk '{print $2}' | sed "s/[‘’]//g" >> "${HERE}/.installed"
-echo "${VERSION}" >> "${HERE}/.installed"
+OFFICIAL_VERSION=$(Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); packageVersion("autoxgboost")' | awk '{print $2}' | sed "s/[‘’]//g")
+echo "${OFFICIAL_VERSION}#${VERSION}" >> "${HERE}/.installed"

--- a/frameworks/autoxgboost/setup.sh
+++ b/frameworks/autoxgboost/setup.sh
@@ -3,17 +3,21 @@ HERE=$(dirname "$0")
 VERSION=${1:-"stable"}
 REPO=${2:-"ja-thomas/autoxgboost"}
 
-# Version can be specified as 'stable', 'latest', a full 40-character commit hash or a branch
+# Version can be specified as 'stable', 'latest', a branch or a commit hash (indicated by starting with '#')
 if [[ "$VERSION" == "latest" || "$VERSION" == "stable" ]]; then
   VERSION="master"
 fi
 
-if ! [[ "$VERSION" =~ ^[a-fA-F0-9]{40}$ ]]; then
+if [[ "$VERSION" =~ ^# ]]; then
+  VERSION="${VERSION:1:8}"
+else
   # if VERSION is not a hash, it should be a branch (or a format which is not (officially) supported)
-  VERSION=$(git ls-remote "https://github.com/${REPO}" | grep "refs/heads/${VERSION}" | cut -f 1)
-  if [[ -z $VERSION ]]; then
+  COMMIT=$(git ls-remote "https://github.com/${REPO}" | grep "refs/heads/${VERSION}" | cut -f 1)
+  if [[ -z $COMMIT ]]; then
     echo "Could not resolve version ${VERSION}. It is not a branch on https://github.com/${REPO}."
     echo "Continuing setup, install_github will try to resolve 'ref=${VERSION}'."
+  else
+    VERSION="${COMMIT:0:7}"
   fi
 fi
 

--- a/frameworks/autoxgboost/setup.sh
+++ b/frameworks/autoxgboost/setup.sh
@@ -28,3 +28,4 @@ Rscript -e 'options(install.packages.check.source="no"); install.packages(c("rem
 Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); remotes::install_github("'"${REPO}"'", ref="'"${VERSION}"'", lib="'"${HERE}/r-packages/"'")'
 
 Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); packageVersion("autoxgboost")' | awk '{print $2}' | sed "s/[‘’]//g" >> "${HERE}/.installed"
+echo "${VERSION}" >> "${HERE}/.installed"

--- a/frameworks/autoxgboost/setup.sh
+++ b/frameworks/autoxgboost/setup.sh
@@ -40,5 +40,3 @@ Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); remotes::install_github("'"${R
 
 Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); packageVersion("autoxgboost")' | awk '{print $2}' | sed "s/[‘’]//g" >> "${HERE}/.installed"
 echo "${VERSION}" >> "${HERE}/.installed"
-
-cat "${HERE}/.installed"

--- a/frameworks/mlr3automl/setup.sh
+++ b/frameworks/mlr3automl/setup.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 HERE=$(dirname "$0")
 VERSION=${1:-"stable"}
-REPO=${2:-"https://github.com/a-hanf"}
+REPO=${2:-"a-hanf/mlr3automl"}
 MLR_REPO=${3:-"https://github.com/mlr-org"}
+
+if [[ "$VERSION" == "latest" || "$VERSION" == "stable" ]]; then
+    VERSION="master"
+fi
 
 . $HERE/../shared/setup.sh "$HERE"
 if [[ -x "$(command -v apt-get)" ]]; then
@@ -25,6 +29,6 @@ mkdir "${HERE}/r-packages/"
 Rscript -e 'options(install.packages.check.source="no"); install.packages(c("mlr3", "mlr3pipelines", "mlr3misc", "mlr3oml", "mlr3hyperband", "mlr3tuning", "paradox"), repos="https://cloud.r-project.org/", lib="'"${HERE}/r-packages/"'")'
 Rscript -e 'options(install.packages.check.source="no"); install.packages(c("remotes", "checkmate", "R6", "xgboost", "ranger", "LiblineaR", "emoa", "e1071", "glmnet"), repos="https://cloud.r-project.org/", lib="'"${HERE}/r-packages/"'")'
 Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); remotes::install_github("'"${MLR_REPO}"'/mlr3extralearners", lib="'"${HERE}/r-packages/"'")'
-Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); remotes::install_github("'"${REPO}"'/mlr3automl", lib="'"${HERE}/r-packages/"'")'
+Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); remotes::install_github("'"${REPO}"'", ref="'"${VERSION}"'", lib="'"${HERE}/r-packages/"'")'
 
 Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); packageVersion("mlr3automl")' | awk '{print $2}' | sed "s/[‘’]//g" >> "${HERE}/.installed"

--- a/frameworks/mlr3automl/setup.sh
+++ b/frameworks/mlr3automl/setup.sh
@@ -10,7 +10,7 @@ if [[ "$VERSION" == "latest" || "$VERSION" == "stable" ]]; then
 fi
 
 if [[ "$VERSION" =~ ^# ]]; then
-  VERSION="${VERSION:1:8}"
+  VERSION="${VERSION:1}"
 else
   # if VERSION is not a hash, it should be a branch (or a format which is not (officially) supported)
   COMMIT=$(git ls-remote "https://github.com/${REPO}" | grep "refs/heads/${VERSION}" | cut -f 1)
@@ -18,7 +18,7 @@ else
     echo "Could not resolve version ${VERSION}. It is not a branch on https://github.com/${REPO}."
     echo "Continuing setup, install_github will try to resolve 'ref=${VERSION}'."
   else
-    VERSION="${COMMIT:0:7}"
+    VERSION=$COMMIT
   fi
 fi
 
@@ -46,4 +46,4 @@ Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); remotes::install_github("'"${M
 Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); remotes::install_github("'"${REPO}"'", ref="'"${VERSION}"'", lib="'"${HERE}/r-packages/"'")'
 
 OFFICIAL_VERSION=$(Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); packageVersion("mlr3automl")' | awk '{print $2}' | sed "s/[‘’]//g")
-echo "${OFFICIAL_VERSION}#${VERSION}" >> "${HERE}/.installed"
+echo "${OFFICIAL_VERSION}#${VERSION:0:7}" >> "${HERE}/.installed"

--- a/frameworks/mlr3automl/setup.sh
+++ b/frameworks/mlr3automl/setup.sh
@@ -41,5 +41,5 @@ Rscript -e 'options(install.packages.check.source="no"); install.packages(c("rem
 Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); remotes::install_github("'"${MLR_REPO}"'/mlr3extralearners", lib="'"${HERE}/r-packages/"'")'
 Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); remotes::install_github("'"${REPO}"'", ref="'"${VERSION}"'", lib="'"${HERE}/r-packages/"'")'
 
-Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); packageVersion("mlr3automl")' | awk '{print $2}' | sed "s/[‘’]//g" >> "${HERE}/.installed"
-echo "${VERSION}" >> "${HERE}/.installed"
+OFFICIAL_VERSION=$(Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); packageVersion("mlr3automl")' | awk '{print $2}' | sed "s/[‘’]//g")
+echo "${OFFICIAL_VERSION}#${VERSION}" >> "${HERE}/.installed"

--- a/frameworks/mlr3automl/setup.sh
+++ b/frameworks/mlr3automl/setup.sh
@@ -43,5 +43,3 @@ Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); remotes::install_github("'"${R
 
 Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); packageVersion("mlr3automl")' | awk '{print $2}' | sed "s/[‘’]//g" >> "${HERE}/.installed"
 echo "${VERSION}" >> "${HERE}/.installed"
-
-cat "${HERE}/.installed"

--- a/frameworks/mlr3automl/setup.sh
+++ b/frameworks/mlr3automl/setup.sh
@@ -32,3 +32,4 @@ Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); remotes::install_github("'"${M
 Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); remotes::install_github("'"${REPO}"'", ref="'"${VERSION}"'", lib="'"${HERE}/r-packages/"'")'
 
 Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); packageVersion("mlr3automl")' | awk '{print $2}' | sed "s/[‘’]//g" >> "${HERE}/.installed"
+echo "${VERSION}" >> "${HERE}/.installed"

--- a/frameworks/mlr3automl/setup.sh
+++ b/frameworks/mlr3automl/setup.sh
@@ -4,17 +4,21 @@ VERSION=${1:-"stable"}
 REPO=${2:-"a-hanf/mlr3automl"}
 MLR_REPO=${3:-"https://github.com/mlr-org"}
 
-# Version can be specified as 'stable', 'latest', a full 40-character commit hash or a branch
+# Version can be specified as 'stable', 'latest', a branch or a commit hash (indicated by starting with '#')
 if [[ "$VERSION" == "latest" || "$VERSION" == "stable" ]]; then
   VERSION="master"
 fi
 
-if ! [[ "$VERSION" =~ ^[a-fA-F0-9]{40}$ ]]; then
+if [[ "$VERSION" =~ ^# ]]; then
+  VERSION="${VERSION:1:8}"
+else
   # if VERSION is not a hash, it should be a branch (or a format which is not (officially) supported)
-  VERSION=$(git ls-remote "https://github.com/${REPO}" | grep "refs/heads/${VERSION}" | cut -f 1)
-  if [[ -z $VERSION ]]; then
+  COMMIT=$(git ls-remote "https://github.com/${REPO}" | grep "refs/heads/${VERSION}" | cut -f 1)
+  if [[ -z $COMMIT ]]; then
     echo "Could not resolve version ${VERSION}. It is not a branch on https://github.com/${REPO}."
     echo "Continuing setup, install_github will try to resolve 'ref=${VERSION}'."
+  else
+    VERSION="${COMMIT:0:7}"
   fi
 fi
 

--- a/frameworks/mlr3automl/setup.sh
+++ b/frameworks/mlr3automl/setup.sh
@@ -4,8 +4,18 @@ VERSION=${1:-"stable"}
 REPO=${2:-"a-hanf/mlr3automl"}
 MLR_REPO=${3:-"https://github.com/mlr-org"}
 
+# Version can be specified as 'stable', 'latest', a full 40-character commit hash or a branch
 if [[ "$VERSION" == "latest" || "$VERSION" == "stable" ]]; then
-    VERSION="master"
+  VERSION="master"
+fi
+
+if ! [[ "$VERSION" =~ ^[a-fA-F0-9]{40}$ ]]; then
+  # if VERSION is not a hash, it should be a branch (or a format which is not (officially) supported)
+  VERSION=$(git ls-remote "https://github.com/${REPO}" | grep "refs/heads/${VERSION}" | cut -f 1)
+  if [[ -z $VERSION ]]; then
+    echo "Could not resolve version ${VERSION}. It is not a branch on https://github.com/${REPO}."
+    echo "Continuing setup, install_github will try to resolve 'ref=${VERSION}'."
+  fi
 fi
 
 . $HERE/../shared/setup.sh "$HERE"
@@ -33,3 +43,5 @@ Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); remotes::install_github("'"${R
 
 Rscript -e '.libPaths("'"${HERE}/r-packages/"'"); packageVersion("mlr3automl")' | awk '{print $2}' | sed "s/[‘’]//g" >> "${HERE}/.installed"
 echo "${VERSION}" >> "${HERE}/.installed"
+
+cat "${HERE}/.installed"


### PR DESCRIPTION
Useful to refer to a version of mlr3automl (since there are no official releases).
Will test this Monday when I have AWS access again (I can't test it on Windows - even in docker I encounter some encoding issue with installing R frameworks).