### PR TITLE
Sort categoricals in alphabetical order

### DIFF
--- a/.github/workflows/run_all_frameworks.yml
+++ b/.github/workflows/run_all_frameworks.yml
@@ -39,8 +39,6 @@ jobs:
           echo Common files: $common_files
           echo Changed files: $changed_files
 
-          shopt -u globstar
-
           is_common=1
           for f in $changed_files
           do

--- a/.github/workflows/run_all_frameworks.yml
+++ b/.github/workflows/run_all_frameworks.yml
@@ -25,6 +25,10 @@ jobs:
         name: Detect Common Changes  # detect if any changes occurred that should trigger all frameworks.
         run: |
           changed_files=$(git diff --name-only HEAD..$GITHUB_BASE_REF)
+
+          # globs should be interpreted recursively to find all files
+          shopt -s globstar
+
           common_files="amlb/** "\
           "resources/** "\
           "frameworks/shared/** "\
@@ -34,6 +38,8 @@ jobs:
           "requirements.txt"
           echo Common files: $common_files
           echo Changed files: $changed_files
+
+          shopt -u globstar
 
           is_common=1
           for f in $changed_files

--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -262,8 +262,8 @@ class ArffSplitter(DataSplitter[str]):
             # so we need to adapt the header accordingly.
             # Not doing so causes an issue in the R packages.
             if set(v.lower() for v in feat.nominal_values) == {"true", "false"}:
-                return [v.lower().capitalize() for v in feat.nominal_values]
-            return feat.nominal_values
+                return sorted(v.lower().capitalize() for v in feat.nominal_values)
+            return sorted(feat.nominal_values)
         return None
 
 


### PR DESCRIPTION
This is in particular important for the target column in classification tasks, where AutoWEKA preserves the order of those variables in the column-order for their class probabilities. And we expect those to be alphabetical. This approach seemed more sensible to me than either reading the ARFF header or the WEKA predictions file to figure out the order WEKA used.

I am not sure how to handle custom ARFF input in this scenario. Automatic splits for it aren't supported yet ([I think?](https://github.com/openml/automlbenchmark/blob/9e5b66d11a804b19595d602f3f3e7e54e544e201/amlb/datasets/file.py#L224)), but an explicit `train` and `test` file would simply have to enforce this order itself.

**Edit: Modifies the CI script to detect changed files in subdirectories too.**