### PR TITLE
Make Parquet the default serialization format

### DIFF
--- a/frameworks/GAMA/__init__.py
+++ b/frameworks/GAMA/__init__.py
@@ -9,8 +9,6 @@ def setup(*args, **kwargs):
 
 def run(dataset: Dataset, config: TaskConfig):
     from frameworks.shared.caller import run_in_venv
-    from frameworks.shared.serialization import ser_config
-    ser_config.pandas_serializer = 'parquet'  # can't use pickle due to pandas version mismatch
 
     data = dict(
         target=dataset.target.name,

--- a/frameworks/GAMA/requirements.txt
+++ b/frameworks/GAMA/requirements.txt
@@ -1,2 +1,1 @@
 packaging
-pyarrow

--- a/frameworks/shared/requirements.in
+++ b/frameworks/shared/requirements.in
@@ -1,5 +1,5 @@
 psutil>=5.4
 ruamel.yaml>=0.15
 
-#pyarrow>=4.0   # if using parquet serializer (let the client choose)
+pyarrow>=4.0
 #tables>=3.6    # if using hdf serializer (let the client choose)

--- a/frameworks/shared/requirements.txt
+++ b/frameworks/shared/requirements.txt
@@ -4,7 +4,11 @@
 #
 #    pip-compile frameworks/shared/requirements.in
 #
+numpy==1.21.0
+    # via pyarrow
 psutil==5.8.0
+    # via -r frameworks/shared/requirements.in
+pyarrow==4.0.1
     # via -r frameworks/shared/requirements.in
 ruamel.yaml.clib==0.2.2
     # via ruamel.yaml

--- a/frameworks/shared/serialization.py
+++ b/frameworks/shared/serialization.py
@@ -20,7 +20,7 @@ def _import_data_libraries():
 
 ser_config = ns(
     # 'pickle', 'parquet', 'hdf', 'json'
-    pandas_serializer=os.environ.get('AMLB_SER_PD_MODE') or 'pickle',
+    pandas_serializer=os.environ.get('AMLB_SER_PD_MODE') or 'parquet',
     # 'infer', 'bz2', 'gzip', None ?
     # 'infer' (here=None) is the fastest but no compression,
     # 'gzip' fast write and read with good compression.


### PR DESCRIPTION
As discussed in #339, the pandas version discrepancy causes issues for frameworks. Specifically there currently is a bug that prevents pickled dataframes to compatible between pandas 1.2.4 and 1.3.0. Moving forward using `parquet` as the serialized format between main and subprocesses should still offer good performance while being less likely to cause issues with mismatched versions.

Note: this is not only important for frameworks that use serialized input data, but their output (the reason AutoGluon currently fails despite already having Parquet input).