### PR TITLE
Use OML to determine data type for empty columns

### DIFF
--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -241,8 +241,9 @@ class ArffSplitter(DataSplitter[str]):
             attributes = [(c,
                            ('INTEGER' if pat.is_integer_dtype(dt)
                             else 'REAL' if pat.is_float_dtype(dt)
-                            else 'NUMERIC' if pat.is_numeric_dtype(dt)
-                            # else ['0', '1'] if pat.is_bool_dtype(dt)
+                           # columns with all values missing will be interpreted as string by default,
+                           # but we can use openml meta-data to find out if it should be considered numeric instead.
+                            else 'NUMERIC' if pat.is_numeric_dtype(dt) or self._is_numeric(c)
                             else self._get_categorical_values(c) if pat.is_categorical_dtype(dt)
                             else 'STRING'
                            ))
@@ -253,6 +254,10 @@ class ArffSplitter(DataSplitter[str]):
                 attributes=attributes,
                 data=df.values
             ), file)
+
+    def _is_numeric(self, col):
+        feat = next((f for f in self.ds._oml_dataset.features.values() if f.name == col), None)
+        return feat.data_type.lower() == "numeric"
 
     def _get_categorical_values(self, col):
         feat = next((f for f in self.ds._oml_dataset.features.values() if f.name == col), None)


### PR DESCRIPTION
Some datasets contain all-empty columns. Current behavior is to interpret these columns as a `STRING` ([default fallback when creating the split file](https://github.com/openml/automlbenchmark/blob/ace241b67f9e48757d3a9a199e71d3ee97715558/amlb/datasets/openml.py#L241-L249)). OpenML still has meta-data on what the (intended) type of the column is, so we can use that instead. Because OpenML does not make distinctions between `integer` and `floats` we only check the `numeric`  property last.

Addresses the first issue of #350 (the second issue is fundamentally an OpenML issue - so we hope "they" can fix it without us having to do a patch, see [EvaluationEngine#37](https://github.com/openml/EvaluationEngine/issues/37)).

Running `python runbenchmark.py autoweka openml/t/3945 test -f 0 -m docker -s force` on this branch *with a correct `features.xml` already present in the cache* runs successfully:
![image](https://user-images.githubusercontent.com/15890747/125801010-047dc147-c00e-42d7-ba05-74c435365dfb.png)

*note:* Because the KDD dataset features both issues, it is needed to use an old `features.xml` file which does not expose the second issue (missing categorical values in the ARFF header because of incomplete OpenML data).  You can use [this old file](https://github.com/openml/automlbenchmark/files/6823643/features.xml.txt), take care to rename the extension (Github wouldn't let me upload `.xml` directly).
