### PR TITLE
Install opencv-python to avoid error on import

### DIFF
--- a/frameworks/lightautoml/setup.sh
+++ b/frameworks/lightautoml/setup.sh
@@ -10,6 +10,7 @@ fi
 # creating local venv
 . ${HERE}/../shared/setup.sh ${HERE} true
 
+apt-get install -y python3-opencv
 
 if [[ "$VERSION" == "stable" ]]; then
     PIP install --no-cache-dir -U ${PKG}


### PR DESCRIPTION
With the current setup, an error is produced on first import. This means the final statement in the setup script exits with an error, which prevents the benchmark from running on light automl (see [lama#53](https://github.com/sberbank-ai-lab/LightAutoML/issues/53) for more information).

edit: I still noticed an error running the framework (at least on iris and APSFailure). But it's unrelated. Looks like it probably has to do with changes to the input data (encoding), I'll look into it separately.