### PR TITLE
Fix LAMA - don't return `truth`

### DIFF
--- a/frameworks/lightautoml/exec.py
+++ b/frameworks/lightautoml/exec.py
@@ -65,7 +65,6 @@ def run(dataset, config):
         output_file=config.output_predictions_file,
         probabilities=probabilities,
         predictions=predictions,
-        truth=y_test,
         target_is_encoded=is_classification,
         training_duration=training.duration,
         predict_duration=predict.duration,

--- a/frameworks/lightautoml/exec.py
+++ b/frameworks/lightautoml/exec.py
@@ -53,6 +53,8 @@ def run(dataset, config):
 
         predictions = np.argmax(probabilities, axis=1)
         class_map = automl.outer_pipes[0].ml_algos[0].models[0][0].reader.class_mapping
+        if class_map is None and df_train[label].dtype == bool:
+            class_map = {False: 0, True: 1}
         if class_map:
             column_to_class = {col: class_ for class_, col in class_map.items()}
             predictions = list(map(column_to_class.get, predictions))

--- a/frameworks/lightautoml/exec.py
+++ b/frameworks/lightautoml/exec.py
@@ -58,7 +58,7 @@ def run(dataset, config):
         if class_map:
             column_to_class = {col: class_ for class_, col in class_map.items()}
             predictions = list(map(column_to_class.get, predictions))
-            probabilities_labels = list(class_map)
+            probabilities_labels = [column_to_class[col] for col in sorted(column_to_class)]
     else:
         probabilities = None
         predictions = preds


### PR DESCRIPTION
When processing the results, if `truth` is returned it is processed based on `is_encoded` - regardless of if only the predictions are encoded or also truth ([here](https://github.com/openml/automlbenchmark/blob/c6eb3784ddde723fc4c7a3230886b1a67d142cb3/amlb/results.py#L290-L298)).

I'm not entirely sure what the original reason was, but it seems to me that there is no good reason for allowing the frameworks return `truth` (or even pass labels of the test data in the first place)? I'd be curious to know why it's a thing (and consequently see if perhaps we should rework that in the future).