### PR TITLE
Fix CI to work from forks and correctly diff to master

### DIFF
--- a/.github/workflows/run_all_frameworks.yml
+++ b/.github/workflows/run_all_frameworks.yml
@@ -24,7 +24,7 @@ jobs:
       - id: find-required-tests
         name: Detect Common Changes  # detect if any changes occurred that should trigger all frameworks.
         run: |
-          changed_files=$(git diff --name-only HEAD..$GITHUB_BASE_REF)
+          changed_files=$(git diff --name-only HEAD...$GITHUB_BASE_REF)
 
           shopt -s globstar
           common_files="amlb/** "\

--- a/.github/workflows/run_all_frameworks.yml
+++ b/.github/workflows/run_all_frameworks.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: pull base branch
         run: |
-          git fetch origin $GITHUB_BASE_REF
+          git fetch --unshallow origin $GITHUB_BASE_REF
           git branch --track $GITHUB_BASE_REF origin/$GITHUB_BASE_REF
       - id: find-required-tests
         name: Detect Common Changes  # detect if any changes occurred that should trigger all frameworks.

--- a/.github/workflows/run_all_frameworks.yml
+++ b/.github/workflows/run_all_frameworks.yml
@@ -23,7 +23,7 @@ jobs:
       - id: find-required-tests
         name: Detect Common Changes  # detect if any changes occurred that should trigger all frameworks.
         run: |
-          changed_files=$(git diff --name-only HEAD...$GITHUB_BASE_REF)
+          changed_files=$(git diff --name-only $GITHUB_BASE_REF...HEAD)
 
           shopt -s globstar
           common_files="amlb/** "\

--- a/.github/workflows/run_all_frameworks.yml
+++ b/.github/workflows/run_all_frameworks.yml
@@ -18,9 +18,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: pull base branch
         run: |
-          git fetch --all
-          git checkout -b $GITHUB_BASE_REF origin/$GITHUB_BASE_REF
-          git checkout $GITHUB_HEAD_REF
+          git fetch origin $GITHUB_BASE_REF
+          git branch --track $GITHUB_BASE_REF origin/$GITHUB_BASE_REF
       - id: find-required-tests
         name: Detect Common Changes  # detect if any changes occurred that should trigger all frameworks.
         run: |


### PR DESCRIPTION
Fixes #330:
 - PRs from a fork now work the same as from a branch on the original repo (see #362 as example). The previous implementation erroneously tried to checkout the working branch instead of the merge head, which was impossible if the branch lived on a fork. We avoid it altogether by setting tracking through `git branch` instead of `git checkout`, so our `HEAD` stays on the merge commit. There's also a little optimization to only fetch the `GITHUB_BASE_REF` instead of all branches and tags.
 - The difference between the merge commit and the base branch is now correctly found by comparing to the point where the branch branched off.
 
 It does **not** add unit test on the unmerged branch, as suggested in #330.