### PR TITLE
Convert probabilities_labels to str

### DIFF
--- a/amlb/results.py
+++ b/amlb/results.py
@@ -273,6 +273,8 @@ class TaskResult:
             truth = truth.values
         if isinstance(probabilities, DF):
             probabilities = probabilities.values
+        if probabilities_labels:
+            probabilities_labels = [str(label) for label in probabilities_labels]
 
         if probabilities is not None:
             prob_cols = probabilities_labels if probabilities_labels else dataset.target.label_encoder.classes


### PR DESCRIPTION
Sometimes labels are provided as non-str (in particular boolean for e.g. kc1), which does not work when we index on them as column names later.

FLAML was affected by this (kc1), I verified locally with a docker run that the patch solved the issue.