### PR TITLE
Issue 370: ensure that sparse data are handled by frameworks that don't support them

### DIFF
--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -18,7 +18,7 @@ import scipy as sci
 
 from ..data import Dataset, DatasetType, Datasplit, Feature
 from ..resources import config as rconfig
-from ..utils import as_list, lazy_property, path_from_split, profile, split_path
+from ..utils import as_list, lazy_property, path_from_split, profile, split_path, unsparsify
 
 
 log = logging.getLogger(__name__)
@@ -300,7 +300,8 @@ class ParquetSplitter(DataSplitter[str]):
         train_path, test_path = self.ds._get_split_paths(".parquet")
         if not os.path.isfile(train_path) or not os.path.isfile(test_path):
             X = self.ds._load_full_data('dataframe')
-            train, test = X.iloc[self.train_ind, :], X.iloc[self.test_ind, :]
+            # parquet doesn't support sparse dataframes
+            train, test = unsparsify(X.iloc[self.train_ind, :], X.iloc[self.test_ind, :], fmt='dense')
             train.to_parquet(train_path)
             test.to_parquet(test_path)
         return train_path, test_path

--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -14,9 +14,9 @@ import numpy as np
 import pandas as pd
 import pandas.api.types as pat
 import openml as oml
-import scipy as sci
+import scipy.sparse as sp
 
-from ..data import Dataset, DatasetType, Datasplit, Feature
+from ..data import AM, DF, Dataset, DatasetType, Datasplit, Feature
 from ..resources import config as rconfig
 from ..utils import as_list, lazy_property, path_from_split, profile, split_path, unsparsify
 
@@ -25,6 +25,8 @@ log = logging.getLogger(__name__)
 
 # hack (only adding a ? to the regexp pattern) to ensure that '?' values remain quoted when we save dataplits in arff format.
 arff._RE_QUOTE_CHARS = re.compile(r'[?"\'\\\s%,\000-\031]', re.UNICODE)
+
+
 
 
 class OpenmlLoader:
@@ -159,12 +161,12 @@ class OpenmlDatasplit(Datasplit):
 
     @lazy_property
     @profile(logger=log)
-    def data(self) -> pd.DataFrame:
+    def data(self) -> DF:
         return self._get_data('dataframe')
 
     @lazy_property
     @profile(logger=log)
-    def data_enc(self) -> np.ndarray:
+    def data_enc(self) -> AM:
         return self._get_data('array')
 
     def _get_data(self, fmt):
@@ -178,8 +180,6 @@ class OpenmlDatasplit(Datasplit):
 
 
 T = TypeVar('T')
-A = Union[np.ndarray, sci.sparse.csr_matrix]
-DF = pd.DataFrame
 
 
 class DataSplitter(Generic[T]):
@@ -193,14 +193,14 @@ class DataSplitter(Generic[T]):
         pass
 
 
-class ArraySplitter(DataSplitter[A]):
+class ArraySplitter(DataSplitter[AM]):
     format = 'array'
 
     def __init__(self, ds: OpenmlDataset):
         super().__init__(ds)
 
     @profile(logger=log)
-    def split(self) -> Tuple[A, A]:
+    def split(self) -> Tuple[AM, AM]:
         X = self.ds._load_full_data('array')
         return X[self.train_ind, :], X[self.test_ind, :]
 
@@ -301,7 +301,7 @@ class ParquetSplitter(DataSplitter[str]):
         if not os.path.isfile(train_path) or not os.path.isfile(test_path):
             X = self.ds._load_full_data('dataframe')
             # arrow (used to write parquet files) doesn't support sparse dataframes: https://github.com/apache/arrow/issues/1894
-            train, test = unsparsify(X.iloc[self.train_ind, :], X.iloc[self.test_ind, :], fmt='dense')
+            train, test = unsparsify(X.iloc[self.train_ind, :], X.iloc[self.test_ind, :])
             train.to_parquet(train_path)
             test.to_parquet(test_path)
         return train_path, test_path

--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -300,7 +300,7 @@ class ParquetSplitter(DataSplitter[str]):
         train_path, test_path = self.ds._get_split_paths(".parquet")
         if not os.path.isfile(train_path) or not os.path.isfile(test_path):
             X = self.ds._load_full_data('dataframe')
-            # parquet doesn't support sparse dataframes
+            # arrow (used to write parquet files) doesn't support sparse dataframes: https://github.com/apache/arrow/issues/1894
             train, test = unsparsify(X.iloc[self.train_ind, :], X.iloc[self.test_ind, :], fmt='dense')
             train.to_parquet(train_path)
             test.to_parquet(test_path)

--- a/amlb/frameworks/definitions.py
+++ b/amlb/frameworks/definitions.py
@@ -185,7 +185,7 @@ def _update_frameworks_with_parent_definitions(frameworks: Namespace):
     for name, framework in frameworks:
         parents = _find_all_parents(framework, frameworks)
         for parent in parents:
-            framework | copy.deepcopy(parent)
+            framework |= copy.deepcopy(parent)
 
 
 def _add_defaults_to_frameworks(frameworks: Namespace, config):

--- a/amlb/frameworks/definitions.py
+++ b/amlb/frameworks/definitions.py
@@ -185,7 +185,7 @@ def _update_frameworks_with_parent_definitions(frameworks: Namespace):
     for name, framework in frameworks:
         parents = _find_all_parents(framework, frameworks)
         for parent in parents:
-            framework % copy.deepcopy(parent)
+            framework | copy.deepcopy(parent)
 
 
 def _add_defaults_to_frameworks(frameworks: Namespace, config):

--- a/amlb/resources.py
+++ b/amlb/resources.py
@@ -186,7 +186,7 @@ class Resources:
 
         defaults = Namespace.merge(defaults, hard_defaults, Namespace(name='__defaults__'))
         for task in tasks:
-            task % defaults   # add missing keys from hard defaults + defaults
+            task | defaults   # add missing keys from hard defaults + defaults
             self._validate_task(task)
 
         self._validate_task(defaults, lenient=True)

--- a/amlb/resources.py
+++ b/amlb/resources.py
@@ -164,7 +164,7 @@ class Resources:
 
         constraints = Namespace()
         for ef in constraints_file:
-            constraints + config_load(ef)
+            constraints += config_load(ef)
 
         for name, c in constraints:
             c.name = str_sanitize(name)
@@ -186,7 +186,7 @@ class Resources:
 
         defaults = Namespace.merge(defaults, hard_defaults, Namespace(name='__defaults__'))
         for task in tasks:
-            task | defaults   # add missing keys from hard defaults + defaults
+            task |= defaults   # add missing keys from hard defaults + defaults
             self._validate_task(task)
 
         self._validate_task(defaults, lenient=True)

--- a/amlb/results.py
+++ b/amlb/results.py
@@ -445,7 +445,7 @@ class TaskResult:
         entry.info = result.info
         if scoring_errors:
             entry.info = "; ".join(filter(lambda it: it, [entry.info, *scoring_errors]))
-        entry % Namespace({k: v for k, v in meta_result if k not in required_meta_res})
+        entry | Namespace({k: v for k, v in meta_result if k not in required_meta_res})
         log.info("Metric scores: %s", entry)
         return entry
 

--- a/amlb/results.py
+++ b/amlb/results.py
@@ -273,13 +273,13 @@ class TaskResult:
             truth = truth.values
         if isinstance(probabilities, DF):
             probabilities = probabilities.values
-        if probabilities_labels:
+        if probabilities_labels is not None:
             probabilities_labels = [str(label) for label in probabilities_labels]
 
         if probabilities is not None:
             prob_cols = probabilities_labels if probabilities_labels else dataset.target.label_encoder.classes
             df = to_data_frame(probabilities, columns=prob_cols)
-            if probabilities_labels:
+            if probabilities_labels is not None:
                 df = df[sort(prob_cols)]  # reorder columns alphabetically: necessary to match label encoding
                 if any(prob_cols != df.columns.values):
                     encoding_map = {prob_cols.index(col): i for i, col in enumerate(df.columns.values)}

--- a/amlb/results.py
+++ b/amlb/results.py
@@ -445,7 +445,7 @@ class TaskResult:
         entry.info = result.info
         if scoring_errors:
             entry.info = "; ".join(filter(lambda it: it, [entry.info, *scoring_errors]))
-        entry | Namespace({k: v for k, v in meta_result if k not in required_meta_res})
+        entry |= Namespace({k: v for k, v in meta_result if k not in required_meta_res})
         log.info("Metric scores: %s", entry)
         return entry
 

--- a/amlb/utils/__init__.py
+++ b/amlb/utils/__init__.py
@@ -14,4 +14,7 @@ from .core import *
 from .modules import *
 from .os import *
 from .process import *
+from .serialization import *
 from .time import *
+
+__all__ = [s for s in dir() if not s.startswith('_')]

--- a/amlb/utils/config.py
+++ b/amlb/utils/config.py
@@ -24,7 +24,7 @@ class YAMLNamespaceConstructor(SafeConstructor):
         data = Namespace()
         yield data
         value = self.construct_mapping(node)
-        data + value
+        data += value
 
 
 YAMLNamespaceConstructor.init()

--- a/amlb/utils/core.py
+++ b/amlb/utils/core.py
@@ -9,9 +9,24 @@ import json
 import logging
 import pprint
 import re
+import sys
 import threading
+import types
 
 log = logging.getLogger(__name__)
+
+
+def register_module(module_name):
+    if module_name not in sys.modules:
+        mod = types.ModuleType(module_name)
+        sys.modules[module_name] = mod
+    return sys.modules[module_name]
+
+
+def register_submodule(mod, name):
+    fullname = '.'.join([mod.__name__, name])
+    module = register_module(fullname)
+    setattr(mod, name, module)
 
 
 class Namespace:
@@ -148,7 +163,7 @@ class Namespace:
             self.__dict__.update(other)
         return self
 
-    def __mod__(self, other):
+    def __or__(self, other):
         """extends self with other (adds only missing keys)"""
         if other is not None:
             for k, v in other:
@@ -195,7 +210,7 @@ class Namespace:
         return isinstance(other, Namespace) and self.__dict__ == other.__dict__
 
     def __hash__(self):
-        return hash(self.__dict__)
+        return hash(repr(self))
 
     def __str__(self):
         return Namespace.printer.pformat(Namespace.dict(self))

--- a/amlb/utils/core.py
+++ b/amlb/utils/core.py
@@ -65,7 +65,7 @@ class Namespace:
             if ns is None:
                 continue
             if not deep:
-                merged + ns
+                merged += ns
             else:
                 for k, v in ns:
                     if isinstance(v, Namespace):
@@ -158,12 +158,24 @@ class Namespace:
         self.__dict__.update(dict(*args, **kwargs))
 
     def __add__(self, other):
+        res = Namespace()
+        res += self
+        res += other
+        return res
+
+    def __iadd__(self, other):
         """extends self with other (always overrides)"""
         if other is not None:
             self.__dict__.update(other)
         return self
 
     def __or__(self, other):
+        res = Namespace()
+        res |= self
+        res |= other
+        return res
+
+    def __ior__(self, other):
         """extends self with other (adds only missing keys)"""
         if other is not None:
             for k, v in other:

--- a/amlb/utils/serialization.py
+++ b/amlb/utils/serialization.py
@@ -136,7 +136,8 @@ def serialize_data(data, path, config: Optional[ns] = None):
             json_dump(data, path, style='compact')
         else:
             path = f"{root}.pkl"
-            pickle.dump(data, path)
+            with open(path, 'wb') as f:
+                pickle.dump(data, f)
     return path
 
 
@@ -180,7 +181,8 @@ def deserialize_data(path, config: Optional[ns] = None):
     elif ext == '.json':
         return json_load(path)
     elif ext == '.pkl':
-        return pickle.load(path)
+        with open(path, 'rb') as f:
+            return pickle.load(f)
     else:
         raise SerializationError(f"Can not deserialize file `{path}` in unknown format.")
 

--- a/examples/custom/extensions/GradientBoosting/exec.py
+++ b/examples/custom/extensions/GradientBoosting/exec.py
@@ -5,7 +5,7 @@ from sklearn.ensemble import GradientBoostingClassifier, GradientBoostingRegress
 
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
-from amlb.datautils import impute
+from amlb.datautils import impute_array
 from amlb.results import save_predictions
 from amlb.utils import Timer
 
@@ -17,7 +17,7 @@ def run(dataset: Dataset, config: TaskConfig):
 
     is_classification = config.type == 'classification'
 
-    X_train, X_test = impute(dataset.train.X_enc, dataset.test.X_enc)
+    X_train, X_test = impute_array(dataset.train.X_enc, dataset.test.X_enc)
     y_train, y_test = dataset.train.y, dataset.test.y
 
     estimator = GradientBoostingClassifier if is_classification else GradientBoostingRegressor

--- a/examples/custom/extensions/Stacking/__init__.py
+++ b/examples/custom/extensions/Stacking/__init__.py
@@ -8,10 +8,10 @@ def setup(*args, **kwargs):
 
 
 def run(dataset: Dataset, config: TaskConfig):
-    from amlb.datautils import impute
+    from amlb.datautils import impute_array
     from frameworks.shared.caller import run_in_venv
 
-    X_train_enc, X_test_enc = impute(dataset.train.X_enc, dataset.test.X_enc)
+    X_train_enc, X_test_enc = impute_array(dataset.train.X_enc, dataset.test.X_enc)
     data = dict(
         train=dict(
             X_enc=X_train_enc,

--- a/examples/custom/extensions/Stacking/exec.py
+++ b/examples/custom/extensions/Stacking/exec.py
@@ -14,7 +14,8 @@ from sklearn.ensemble import StackingClassifier, StackingRegressor
 from sklearn.linear_model import LinearRegression, LogisticRegression, SGDClassifier, SGDRegressor
 from sklearn.svm import LinearSVC, LinearSVR
 
-from frameworks.shared.callee import call_run, result, utils
+from frameworks.shared.callee import call_run, result
+from frameworks.shared.utils import Timer
 
 log = logging.getLogger(os.path.basename(__file__))
 
@@ -62,7 +63,7 @@ def run(dataset, config):
             **training_params
         )
 
-    with utils.Timer() as training:
+    with Timer() as training:
         estimator.fit(X_train, y_train)
 
     predictions = estimator.predict(X_test)

--- a/frameworks/DecisionTree/exec.py
+++ b/frameworks/DecisionTree/exec.py
@@ -7,9 +7,7 @@ from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
 from amlb.datautils import impute_array
 from amlb.results import save_predictions
-from amlb.utils import Timer
-
-from frameworks.shared.serialization import unsparsify
+from amlb.utils import Timer, unsparsify
 
 log = logging.getLogger(__name__)
 

--- a/frameworks/DecisionTree/exec.py
+++ b/frameworks/DecisionTree/exec.py
@@ -9,6 +9,8 @@ from amlb.datautils import impute_array
 from amlb.results import save_predictions
 from amlb.utils import Timer
 
+from frameworks.shared.serialization import unsparsify
+
 log = logging.getLogger(__name__)
 
 
@@ -17,8 +19,8 @@ def run(dataset: Dataset, config: TaskConfig):
 
     is_classification = config.type == 'classification'
 
-    X_train, X_test = impute_array(dataset.train.X_enc, dataset.test.X_enc)
-    y_train, y_test = dataset.train.y_enc, dataset.test.y_enc
+    X_train, X_test = impute_array(*unsparsify(dataset.train.X_enc, dataset.test.X_enc, fmt='array'))
+    y_train, y_test = unsparsify(dataset.train.y_enc, dataset.test.y_enc, fmt='array')
 
     estimator = DecisionTreeClassifier if is_classification else DecisionTreeRegressor
     predictor = estimator(random_state=config.seed, **config.framework_params)

--- a/frameworks/GAMA/__init__.py
+++ b/frameworks/GAMA/__init__.py
@@ -23,7 +23,10 @@ def run(dataset: Dataset, config: TaskConfig):
             y=dataset.test.y
         ),
     )
+    options = dict(
+        serialization=dict(sparse_dataframe_deserialized_format='dense')
+    )
 
     return run_in_venv(__file__, "exec.py",
-                       input_data=data, dataset=dataset, config=config)
+                       input_data=data, dataset=dataset, config=config, options=options)
 

--- a/frameworks/MLPlan/exec.py
+++ b/frameworks/MLPlan/exec.py
@@ -96,8 +96,8 @@ def run(dataset, config):
         probabilities = stats["probabilities"]
         probabilities_labels = stats["probabilities_labels"]
     else:
-        probabilities = []
-        probabilities_labels = []
+        probabilities = None
+        probabilities_labels = None
 
     if version == "0.2.3":
         target_encoded = is_classification

--- a/frameworks/TPOT/__init__.py
+++ b/frameworks/TPOT/__init__.py
@@ -1,7 +1,7 @@
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
 from amlb.datautils import Encoder, impute_array
-from amlb.utils import call_script_in_same_dir
+from amlb.utils import call_script_in_same_dir, unsparsify
 
 
 def setup(*args, **kwargs):
@@ -12,7 +12,7 @@ def run(dataset: Dataset, config: TaskConfig):
     from frameworks.shared.caller import run_in_venv
 
     X_train, X_test = dataset.train.X_enc, dataset.test.X_enc
-    y_train, y_test = dataset.train.y_enc, dataset.test.y_enc
+    y_train, y_test = unsparsify(dataset.train.y_enc, dataset.test.y_enc)
     data = dict(
         train=dict(
             X=X_train,

--- a/frameworks/TPOT/exec.py
+++ b/frameworks/TPOT/exec.py
@@ -14,7 +14,7 @@ os.environ['MKL_NUM_THREADS'] = '1'
 from tpot import TPOTClassifier, TPOTRegressor, __version__
 
 from frameworks.shared.callee import call_run, output_subdir, result
-from frameworks.shared.utils import Timer
+from frameworks.shared.utils import Timer, is_sparse
 
 
 log = logging.getLogger(__name__)
@@ -45,6 +45,7 @@ def run(dataset, config):
 
     training_params = {k: v for k, v in config.framework_params.items() if not k.startswith('_')}
     n_jobs = config.framework_params.get('_n_jobs', config.cores)  # useful to disable multicore, regardless of the dataset config
+    config_dict = config.framework_params.get('_config_dict', "TPOT sparse" if is_sparse(X_train) else None)
 
     log.info('Running TPOT with a maximum time of %ss on %s cores, optimizing %s.',
              config.max_runtime_seconds, n_jobs, scoring_metric)
@@ -55,6 +56,7 @@ def run(dataset, config):
                      max_time_mins=runtime_min,
                      scoring=scoring_metric,
                      random_state=config.seed,
+                     config_dict=config_dict,
                      **training_params)
 
     with Timer() as training:

--- a/frameworks/autosklearn/__init__.py
+++ b/frameworks/autosklearn/__init__.py
@@ -1,6 +1,6 @@
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
-from amlb.utils import call_script_in_same_dir
+from amlb.utils import call_script_in_same_dir, unsparsify
 
 
 def setup(*args, **kwargs):
@@ -10,14 +10,16 @@ def setup(*args, **kwargs):
 def run(dataset: Dataset, config: TaskConfig):
     from frameworks.shared.caller import run_in_venv
 
+    X_train, X_test = dataset.train.X_enc, dataset.test.X_enc
+    y_train, y_test = unsparsify(dataset.train.y_enc, dataset.test.y_enc)
     data = dict(
         train=dict(
-            X=dataset.train.X_enc,
-            y=dataset.train.y_enc
+            X=X_train,
+            y=y_train
         ),
         test=dict(
-            X=dataset.test.X_enc,
-            y=dataset.test.y_enc
+            X=X_test,
+            y=y_test
         ),
         predictors_type=['Numerical' if p.is_numerical() else 'Categorical' for p in dataset.predictors]
     )

--- a/frameworks/autosklearn/__init__.py
+++ b/frameworks/autosklearn/__init__.py
@@ -21,12 +21,7 @@ def run(dataset: Dataset, config: TaskConfig):
         ),
         predictors_type=['Numerical' if p.is_numerical() else 'Categorical' for p in dataset.predictors]
     )
-    # options = dict(serialization=dict(
-    #     sparse_matrix_deserialized_format='array'
-    # ))
 
     return run_in_venv(__file__, "exec.py",
-                       input_data=data, dataset=dataset, config=config,
-                       # options=options
-                       )
+                       input_data=data, dataset=dataset, config=config)
 

--- a/frameworks/autosklearn/__init__.py
+++ b/frameworks/autosklearn/__init__.py
@@ -21,7 +21,12 @@ def run(dataset: Dataset, config: TaskConfig):
         ),
         predictors_type=['Numerical' if p.is_numerical() else 'Categorical' for p in dataset.predictors]
     )
+    # options = dict(serialization=dict(
+    #     sparse_matrix_deserialized_format='array'
+    # ))
 
     return run_in_venv(__file__, "exec.py",
-                       input_data=data, dataset=dataset, config=config)
+                       input_data=data, dataset=dataset, config=config,
+                       # options=options
+                       )
 

--- a/frameworks/constantpredictor/exec.py
+++ b/frameworks/constantpredictor/exec.py
@@ -7,6 +7,8 @@ from amlb.data import Dataset
 from amlb.results import save_predictions
 from amlb.utils import Timer
 
+from frameworks.shared.serialization import unsparsify
+
 log = logging.getLogger(__name__)
 
 
@@ -17,10 +19,11 @@ def run(dataset: Dataset, config: TaskConfig):
     predictor = DummyClassifier(strategy='prior') if is_classification else DummyRegressor(strategy='median')
 
     encode = config.framework_params.get('_encode', False)
-    X_train = dataset.train.X_enc if encode else dataset.train.X
-    y_train = dataset.train.y_enc if encode else dataset.train.y
-    X_test = dataset.test.X_enc if encode else dataset.test.X
-    y_test = dataset.test.y_enc if encode else dataset.test.y
+
+    X_train = unsparsify(dataset.train.X_enc if encode else dataset.train.X, fmt='array')
+    y_train = unsparsify(dataset.train.y_enc if encode else dataset.train.y, fmt='array')
+    X_test = unsparsify(dataset.test.X_enc if encode else dataset.test.X, fmt='array')
+    y_test = unsparsify(dataset.test.y_enc if encode else dataset.test.y, fmt='array')
 
     with Timer() as training:
         predictor.fit(X_train, y_train)

--- a/frameworks/constantpredictor/exec.py
+++ b/frameworks/constantpredictor/exec.py
@@ -5,9 +5,7 @@ from sklearn.dummy import DummyClassifier, DummyRegressor
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
 from amlb.results import save_predictions
-from amlb.utils import Timer
-
-from frameworks.shared.serialization import unsparsify
+from amlb.utils import Timer, unsparsify
 
 log = logging.getLogger(__name__)
 

--- a/frameworks/flaml/__init__.py
+++ b/frameworks/flaml/__init__.py
@@ -19,6 +19,9 @@ def run(dataset, config):
         ),
         problem_type=dataset.type.name
     )
+    options = dict(
+        serialization=dict(sparse_dataframe_deserialized_format='dense')
+    )
 
     return run_in_venv(__file__, "exec.py",
-                       input_data=data, dataset=dataset, config=config)
+                       input_data=data, dataset=dataset, config=config, options=options)

--- a/frameworks/hyperoptsklearn/__init__.py
+++ b/frameworks/hyperoptsklearn/__init__.py
@@ -1,7 +1,7 @@
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
-from amlb.datautils import Encoder, impute
-from amlb.utils import call_script_in_same_dir
+from amlb.datautils import Encoder, impute_array
+from amlb.utils import call_script_in_same_dir, unsparsify
 
 
 def setup(*args, **kwargs):
@@ -11,8 +11,8 @@ def setup(*args, **kwargs):
 def run(dataset: Dataset, config: TaskConfig):
     from frameworks.shared.caller import run_in_venv
 
-    X_train, X_test = impute(dataset.train.X_enc, dataset.test.X_enc)
-    y_train, y_test = dataset.train.y_enc, dataset.test.y_enc
+    X_train, X_test = impute_array(*unsparsify(dataset.train.X_enc, dataset.test.X_enc, fmt='array'))
+    y_train, y_test = unsparsify(dataset.train.y_enc, dataset.test.y_enc, fmt='array')
     data = dict(
         train=dict(
             X=X_train,

--- a/frameworks/lightautoml/__init__.py
+++ b/frameworks/lightautoml/__init__.py
@@ -23,6 +23,9 @@ def run(dataset: Dataset, config: TaskConfig):
         ),
         problem_type=dataset.type.name
     )
+    options = dict(
+        serialization=dict(sparse_dataframe_deserialized_format='dense')
+    )
 
     return run_in_venv(__file__, "exec.py",
-                       input_data=data, dataset=dataset, config=config)
+                       input_data=data, dataset=dataset, config=config, options=options)

--- a/frameworks/mljarsupervised/__init__.py
+++ b/frameworks/mljarsupervised/__init__.py
@@ -21,6 +21,9 @@ def run(dataset: Dataset, config: TaskConfig):
         ),
         problem_type=dataset.type.name
     )
+    options = dict(
+        serialization=dict(sparse_dataframe_deserialized_format='dense')
+    )
 
     return run_in_venv(__file__, "exec.py",
-                       input_data=data, dataset=dataset, config=config)
+                       input_data=data, dataset=dataset, config=config, options=options)

--- a/frameworks/shared/caller.py
+++ b/frameworks/shared/caller.py
@@ -6,14 +6,13 @@ from tempfile import TemporaryDirectory, mktemp
 from typing import Union
 
 import numpy as np
-import pandas as pd
 
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
 from amlb.resources import config as rconfig
 from amlb.results import NoResultError, save_predictions
 
-from .serialization import deserialize_data, serialize_data, ser_config
+from .serialization import is_serializable_data, deserialize_data, serialize_data, ser_config
 from .utils import Namespace as ns, Timer, dir_of, run_cmd, json_dumps, json_load, profile
 
 log = logging.getLogger(__name__)
@@ -65,7 +64,7 @@ def _make_input_dataset(input_data, dataset, tmpdir):
     input_data = ns.from_dict(input_data)
 
     def make_path(k, v, parents=None):
-        if isinstance(v, (np.ndarray,  pd.DataFrame, pd.Series)):
+        if is_serializable_data(v):
             path = os.path.join(tmpdir, '.'.join(parents+[k, 'data']))
             if vector_keys.match(k):
                 v = as_col(v)

--- a/frameworks/shared/caller.py
+++ b/frameworks/shared/caller.py
@@ -89,15 +89,16 @@ def run_in_venv(caller_file, script_file: str, *args,
     script_path = os.path.join(here, script_file)
     cmd = f"{python_exec} {script_path}"
 
+    options = ns.from_dict(options) if options else ns()
+    ser_config = options['serialization']
+    env = options['env'] or ns()
+
     with TemporaryDirectory() as tmpdir:
 
-        ds = _make_input_dataset(input_data, dataset, tmpdir)
+        ds = _make_input_dataset(input_data, dataset, tmpdir, serialization=ser_config)
 
         config.result_dir = tmpdir
         config.result_file = mktemp(dir=tmpdir)
-        options = ns.from_dict(options) if options else ns()
-        ser_config = options['serialization']
-        env = options['env'] or ns()
 
         params = json_dumps(dict(dataset=ds, config=config, options=options), style='compact')
         log.debug("Params passed to subprocess:\n%s", params)

--- a/frameworks/shared/caller.py
+++ b/frameworks/shared/caller.py
@@ -3,7 +3,7 @@ import logging
 import os
 import re
 from tempfile import TemporaryDirectory, mktemp
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -12,8 +12,8 @@ from amlb.data import Dataset
 from amlb.resources import config as rconfig
 from amlb.results import NoResultError, save_predictions
 
-from .serialization import is_serializable_data, deserialize_data, serialize_data, ser_config
 from .utils import Namespace as ns, Timer, dir_of, run_cmd, json_dumps, json_load, profile
+from .utils import is_serializable_data, deserialize_data, serialize_data
 
 log = logging.getLogger(__name__)
 
@@ -60,7 +60,7 @@ def venv_python_exec(fmwk_dir):
 
 
 @profile(logger=log)
-def _make_input_dataset(input_data, dataset, tmpdir):
+def _make_input_dataset(input_data, dataset, tmpdir, serialization: Optional[ns] = None):
     input_data = ns.from_dict(input_data)
 
     def make_path(k, v, parents=None):
@@ -68,7 +68,7 @@ def _make_input_dataset(input_data, dataset, tmpdir):
             path = os.path.join(tmpdir, '.'.join(parents+[k, 'data']))
             if vector_keys.match(k):
                 v = as_col(v)
-            path = serialize_data(v, path)
+            path = serialize_data(v, path, config=serialization)
             return k, path
         return k, v
 
@@ -80,6 +80,7 @@ def _make_input_dataset(input_data, dataset, tmpdir):
 
 def run_in_venv(caller_file, script_file: str, *args,
                 input_data: Union[dict, ns], dataset: Dataset, config: TaskConfig,
+                options: Union[None, dict, ns] = None,
                 process_results=None,
                 python_exec=None):
     here = dir_of(caller_file)
@@ -94,8 +95,11 @@ def run_in_venv(caller_file, script_file: str, *args,
 
         config.result_dir = tmpdir
         config.result_file = mktemp(dir=tmpdir)
+        options = ns.from_dict(options) if options else ns()
+        ser_config = options['serialization']
+        env = options['env'] or ns()
 
-        params = json_dumps(dict(dataset=ds, config=config), style='compact')
+        params = json_dumps(dict(dataset=ds, config=config, options=options), style='compact')
         log.debug("Params passed to subprocess:\n%s", params)
         cmon = rconfig().monitoring
         monitor = (dict(interval_seconds=cmon.interval_seconds,
@@ -112,9 +116,7 @@ def run_in_venv(caller_file, script_file: str, *args,
             ]),
             AMLB_PATH=os.path.join(rconfig().root_dir, "amlb"),
             AMLB_LOG_TRACE=str(logging.TRACE if hasattr(logging, 'TRACE') else ''),
-            AMLB_SER_PD_MODE=str(ser_config.pandas_serializer or ''),
-            AMLB_SER_PD_COMPR=str(ser_config.pandas_compression or ''),
-            AMLB_SER_PD_PQT_COMPR=str(ser_config.pandas_parquet_compression or ''),
+            **{k: str(v) for k, v in env}
         )
 
         with Timer() as proc_timer:
@@ -139,7 +141,7 @@ def run_in_venv(caller_file, script_file: str, *args,
             raise NoResultError(res.error_message)
 
         for name in ['predictions', 'truth', 'probabilities']:
-            res[name] = deserialize_data(res[name]) if res[name] is not None else None
+            res[name] = deserialize_data(res[name], config=ser_config) if res[name] is not None else None
 
         if callable(process_results):
             res = process_results(res)

--- a/frameworks/shared/serialization.py
+++ b/frameworks/shared/serialization.py
@@ -16,10 +16,10 @@ def _import_data_libraries():
     except ImportError:
         pd = None
     try:
-        import scipy as sp
+        import scipy as sci
     except ImportError:
-        sp = None
-    return np, pd, sp
+        sci = None
+    return np, pd, sci
 
 
 ser_config = ns(
@@ -36,8 +36,12 @@ ser_config = ns(
     numpy_pickle=True,
     # if sparse matrices should be compressed during serialization.
     sparse_matrix_compression=True,
-    # if sparse matrices should be deserialized as dense matrices.
-    sparse_matrix_to_dense=True,
+    # if sparse matrices should be deserialized to some specific format:
+    #  None (no change), 'array' (numpy), 'dense' (dense matrix).
+    sparse_matrix_deserialized_format='array',
+    # if sparse dataframes should be deserialized to some specific format:
+    #  None (no change), 'array' (numpy), 'dense' (dense dataframe/series).
+    sparse_dataframe_deserialized_format=None
 )
 
 
@@ -45,23 +49,53 @@ __series__ = '_series_'
 
 
 def is_serializable_data(data):
-    np, pd, sp = _import_data_libraries()
-    return isinstance(data, (np.ndarray, sp.sparse.spmatrix, pd.DataFrame, pd.Series))
+    np, pd, sci = _import_data_libraries()
+    return isinstance(data, (np.ndarray, sci.sparse.spmatrix, pd.DataFrame, pd.Series))
+
+
+def unsparsify(*data, fmt=None):
+    if len(data) == 1:
+        return _unsparsify(data[0], fmt=fmt)
+    else:
+        return tuple(_unsparsify(d, fmt=fmt) for d in data)
+
+
+def _unsparsify(data, fmt=None):
+    """
+    :param data: the matrix to process.
+    :param fmt: one of None, 'array', 'dense'
+    :return: the original matrix is fmt is None,
+            a numpy array if fmt is 'array',
+            a dense version of the data type if fmt is 'dense'.
+    """
+    if fmt is None:
+        return data
+    np, pd, sci = _import_data_libraries()
+    if sci and isinstance(data, sci.sparse.spmatrix):
+        return (data.toarray() if fmt == 'array'
+                else data.todense() if fmt == 'dense'
+                else data)
+    elif pd and isinstance(data, (pd.DataFrame, pd.Series)):
+        return (data.to_numpy() if fmt == 'array'
+                else data.sparse.to_dense() if fmt == 'dense' and hasattr(data, 'sparse')
+                else data)
+    else:
+        return data
 
 
 @profile(log)
 def serialize_data(data, path):
-    np, pd, sp = _import_data_libraries()
+    np, pd, sci = _import_data_libraries()
     if np and isinstance(data, np.ndarray):
         root, ext = os.path.splitext(path)
         path = f"{root}.npy"
         np.save(path, data, allow_pickle=ser_config.numpy_pickle)
-    elif sp and isinstance(data, sp.sparse.spmatrix):
+    elif sci and isinstance(data, sci.sparse.spmatrix):
         root, ext = os.path.splitext(path)
         # use custom extension to recognize sparsed matrices from file name.
         # .npz is automatically appended if missing, and can also potentially be used for numpy arrays.
         path = f"{root}.spy.npz"
-        sp.sparse.save_npz(path, data, compressed=ser_config.sparse_matrix_compression)
+        sci.sparse.save_npz(path, data, compressed=ser_config.sparse_matrix_compression)
     elif pd and isinstance(data, (pd.DataFrame, pd.Series)):
         if isinstance(data, pd.DataFrame):
             # pandas has this habit of inferring value types when data are loaded from file,
@@ -85,7 +119,7 @@ def serialize_data(data, path):
 
 @profile(log)
 def deserialize_data(path):
-    np, pd, sp = _import_data_libraries()
+    np, pd, sci = _import_data_libraries()
     base, ext = os.path.splitext(path)
     if ext == '.npy':
         if np is None:
@@ -94,10 +128,10 @@ def deserialize_data(path):
     elif ext == '.npz':
         _, ext2 = os.path.splitext(base)
         if ext2 == '.spy':
-            if sp is None:
+            if sci is None:
                 raise ImportError(f"Scipy is required to deserialize {path}.")
-            sp_matrix = sp.sparse.load_npz(path)
-            return sp_matrix.todense() if ser_config.sparse_matrix_to_dense else sp_matrix
+            sp_matrix = sci.sparse.load_npz(path)
+            return unsparsify(sp_matrix, fmt=ser_config.sparse_matrix_deserialized_format)
         else:
             if np is None:
                 raise ImportError(f"Numpy is required to deserialize {path}.")
@@ -107,15 +141,16 @@ def deserialize_data(path):
         if pd is None:
             raise ImportError(f"Pandas is required to deserialize {path}.")
         ser = ser_config.pandas_serializer
+        df = None
         if ser == 'pickle':
-            return pd.read_pickle(path, compression=ser_config.pandas_compression)
+            df = pd.read_pickle(path, compression=ser_config.pandas_compression)
         elif ser == 'parquet':
             df = pd.read_parquet(path)
             if len(df.columns) == 1 and df.columns[0] == __series__:
-                return df.squeeze()
-            return df
+                df = df.squeeze()
         elif ser == 'hdf':
-            return pd.read_hdf(path, os.path.basename(path))
+            df = pd.read_hdf(path, os.path.basename(path))
         elif ser == 'json':
-            return pd.read_json(path, compression=ser_config.pandas_compression)
+            df = pd.read_json(path, compression=ser_config.pandas_compression)
+        return unsparsify(df, fmt=ser_config.sparse_dataframe_deserialized_format)
 

--- a/frameworks/shared/utils.py
+++ b/frameworks/shared/utils.py
@@ -1,7 +1,24 @@
 from importlib import import_module
 import importlib.util
+import logging
 import os
 import sys
+from types import ModuleType
+
+
+def setup_logger():
+    console = logging.StreamHandler(sys.stdout)
+    console.setLevel(logging.INFO)
+    handlers = [console]
+    logging.basicConfig(handlers=handlers)
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    trace_level = os.environ.get('AMLB_LOG_TRACE')
+    if trace_level:
+        logging.TRACE = int(trace_level)
+
+
+setup_logger()
 
 
 def load_module(name, path):

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,5 @@ markers =
     use_web: access internet
     slow: tests taking at least a few seconds
     stress: stress tests, not recommended to run by default
+    requires_unixlike: tests that can only run on unix-like OS
 testpaths = tests

--- a/runbenchmark.py
+++ b/runbenchmark.py
@@ -119,7 +119,7 @@ if args.profiling:
 log_levels = ns({logger: level.upper()
                  for logger, level in [d.split(':') for d in args.logging.split(',')]} if ':' in args.logging
                 else dict(console=args.logging.upper(), app=args.logging.upper(), root=args.logging.upper()) if args.logging
-                else {}) % ns(console='INFO', app='DEBUG', root='INFO')  # adding defaults if needed
+                else {}) | ns(console='INFO', app='DEBUG', root='INFO')  # adding defaults if needed
 amlb.logger.setup(log_file=os.path.join(log_dir, '{script}.{now}.log'.format(script=script_name, now=now_str)),
                   root_file=os.path.join(log_dir, '{script}.{now}.full.log'.format(script=script_name, now=now_str)),
                   root_level=log_levels.root, app_level=log_levels.app, console_level=log_levels.console, print_to_log=True)

--- a/tests/unit/amlb/utils/serialization/test_serializers.py
+++ b/tests/unit/amlb/utils/serialization/test_serializers.py
@@ -2,7 +2,62 @@ import os
 
 import pytest
 
+from amlb.utils.core import Namespace as ns
 from amlb.utils.serialization import serialize_data, deserialize_data
+
+
+@pytest.mark.use_disk
+def test_serialize_list_json(tmpdir):
+    li = [[1, 2.2, None, 3, 4.4, 'foo', True], ['bar', False, 2/3]]
+    dest = os.path.join(tmpdir, "my_list")
+    path = serialize_data(li, dest, config=ns(fallback_serializer='json'))
+    assert path == f"{dest}.json"
+
+    reloaded = deserialize_data(path)
+    assert isinstance(reloaded, list)
+    assert li == reloaded
+
+
+@pytest.mark.use_disk
+def test_serialize_list_pickle(tmpdir):
+    li = [[1, 2.2, None, 3, 4.4, 'foo', True], ['bar', False, 2/3]]
+    dest = os.path.join(tmpdir, "my_list")
+    path = serialize_data(li, dest, config=ns(fallback_serializer='pickle'))
+    assert path == f"{dest}.pkl"
+
+    reloaded = deserialize_data(path)
+    assert isinstance(reloaded, list)
+    assert li == reloaded
+
+
+@pytest.mark.use_disk
+def test_serialize_dict_json(tmpdir):
+    di = dict(
+        first=[1, 2.2, None, 3, 4.4, 'foo', True],
+        second=['bar', False, 2/3]
+    )
+    dest = os.path.join(tmpdir, "my_dict")
+    path = serialize_data(di, dest, config=ns(fallback_serializer='json'))
+    assert path == f"{dest}.json"
+
+    reloaded = deserialize_data(path)
+    assert isinstance(reloaded, dict)
+    assert di == reloaded
+
+
+@pytest.mark.use_disk
+def test_serialize_dict_pickle(tmpdir):
+    di = dict(
+        first=[1, 2.2, None, 3, 4.4, 'foo', True],
+        second=['bar', False, 2/3]
+    )
+    dest = os.path.join(tmpdir, "my_dict")
+    path = serialize_data(di, dest, config=ns(fallback_serializer='pickle'))
+    assert path == f"{dest}.pkl"
+
+    reloaded = deserialize_data(path)
+    assert isinstance(reloaded, dict)
+    assert di == reloaded
 
 
 @pytest.mark.use_disk
@@ -47,4 +102,33 @@ def test_serialize_pandas_dataframes(tmpdir):
     assert arr.compare(reloaded).empty
 
 
-# more to come
+@pytest.mark.use_disk
+def test_serialize_sparse_matrix(tmpdir):
+    pass
+
+
+@pytest.mark.use_disk
+def test_serialize_sparse_matrix_reload_as_dense(tmpdir):
+    pass
+
+
+@pytest.mark.use_disk
+def test_serialize_sparse_matrix_reload_as_array(tmpdir):
+    pass
+
+
+@pytest.mark.use_disk
+def test_serialize_sparse_dataframe(tmpdir):
+    pass
+
+
+@pytest.mark.use_disk
+def test_serialize_pandas_dataframe_reload_as_dense(tmpdir):
+    pass
+
+
+@pytest.mark.use_disk
+def test_serialize_pandas_dataframe_reload_as_array(tmpdir):
+    pass
+
+

--- a/tests/unit/amlb/utils/serialization/test_serializers.py
+++ b/tests/unit/amlb/utils/serialization/test_serializers.py
@@ -1,0 +1,50 @@
+import os
+
+import pytest
+
+from amlb.utils.serialization import serialize_data, deserialize_data
+
+
+@pytest.mark.use_disk
+def test_serialize_numpy_array(tmpdir):
+    import numpy as np
+    arr = np.array([1, 2.2, np.nan, 3, 4.4])
+    dest = os.path.join(tmpdir, "my_np_arr")
+    path = serialize_data(arr, dest)
+    assert path == f"{dest}.npy"
+
+    reloaded = deserialize_data(path)
+    assert isinstance(reloaded, np.ndarray)
+    assert np.array_equal(arr, reloaded, equal_nan=True)
+
+
+@pytest.mark.use_disk
+def test_serialize_pandas_series(tmpdir):
+    import pandas as pd
+    arr = pd.Series([1, 2.2, pd.NA, 3, 4.4])
+    dest = os.path.join(tmpdir, "my_pd_ser")
+    path = serialize_data(arr, dest)
+    assert path == f"{dest}.pd"
+
+    reloaded = deserialize_data(path)
+    assert isinstance(reloaded, pd.Series)
+    assert arr.compare(reloaded).empty
+
+
+@pytest.mark.use_disk
+def test_serialize_pandas_dataframes(tmpdir):
+    import pandas as pd
+    arr = pd.DataFrame(dict(
+        first=[1, 2.2, pd.NA, 3, 4.4],
+        second=['a', 'b', 'c', 'a', 'b']
+    ))
+    dest = os.path.join(tmpdir, "my_pd_df")
+    path = serialize_data(arr, dest)
+    assert path == f"{dest}.pd"
+
+    reloaded = deserialize_data(path)
+    assert isinstance(reloaded, pd.DataFrame)
+    assert arr.compare(reloaded).empty
+
+
+# more to come


### PR DESCRIPTION
https://github.com/openml/automlbenchmark/issues/370

I ended up trying to provide the best strategy regarding sparse data handling for each framework.

By default, sparse data (scipy matrices or pandas DataFrame with sparse columns) retrieved from the datasourse (openml or parsed from file) remain sparse.
Some frameworks (`autosklearn`, `TPOT`) don't work if `y` is sparse: for those, we make `y` dense.
Some other frameworks (`flaml`, `GAMA`, `lightautoml`, `mljar`) fail with sparse dataframes: for those, both `X` and `y` are made dense at the last possible moment (when deserializing data in the framework's process).
Some other (`Autogluon`) consume parquet files directly and we can't make those sparse as `pyarrow` fails saving dataframes with sparse columns, so the parquet files are always dense.
Same for frameworks consuming Arff or CSV files (`AutoWEKA`, `autoxgboost`, `H2OAutoML`, `MLPlan`, `MLNet`, `mlr3automl`) that we can't save to sparse format (`liac_arff` library converts sparse data to dense when saving arff files).

Note that this strategy is now easily configurable, and we can easily decide to change it.
