### PR TITLE
Disable imputation of missing values for TPOT framework

### DIFF
--- a/frameworks/TPOT/__init__.py
+++ b/frameworks/TPOT/__init__.py
@@ -11,7 +11,7 @@ def setup(*args, **kwargs):
 def run(dataset: Dataset, config: TaskConfig):
     from frameworks.shared.caller import run_in_venv
 
-    X_train, X_test = impute_array(dataset.train.X_enc, dataset.test.X_enc)
+    X_train, X_test = dataset.train.X_enc, dataset.test.X_enc
     y_train, y_test = dataset.train.y_enc, dataset.test.y_enc
     data = dict(
         train=dict(


### PR DESCRIPTION
TPOT seems to work fine without imputation: it was probably not the case in the past, but it works fine now, so as it is the only non-trivial framework for which we do imputation, let's remove this.