### PR TITLE
X_NUM_THREADS env variables should not be needed anymore

### DIFF
--- a/frameworks/GAMA/exec.py
+++ b/frameworks/GAMA/exec.py
@@ -3,13 +3,12 @@ import os
 import sys
 import tempfile as tmp
 
+os.environ['JOBLIB_TEMP_FOLDER'] = tmp.gettempdir()
 if sys.platform == 'darwin':
     os.environ['OBJC_DISABLE_INITIALIZE_FORK_SAFETY'] = 'YES'
-os.environ['JOBLIB_TEMP_FOLDER'] = tmp.gettempdir()
-os.environ['OMP_NUM_THREADS'] = '1'
-os.environ['OPENBLAS_NUM_THREADS'] = '1'
-os.environ['MKL_NUM_THREADS'] = '1'
-
+    os.environ['OMP_NUM_THREADS'] = '1'
+    os.environ['OPENBLAS_NUM_THREADS'] = '1'
+    os.environ['MKL_NUM_THREADS'] = '1'
 
 import category_encoders
 from packaging import version

--- a/frameworks/RandomForest/exec.py
+++ b/frameworks/RandomForest/exec.py
@@ -1,11 +1,13 @@
 import logging
 import os
+import sys
 import tempfile as tmp
 
 os.environ['JOBLIB_TEMP_FOLDER'] = tmp.gettempdir()
-os.environ['OMP_NUM_THREADS'] = '1'
-os.environ['OPENBLAS_NUM_THREADS'] = '1'
-os.environ['MKL_NUM_THREADS'] = '1'
+if sys.platform == 'darwin':
+    os.environ['OMP_NUM_THREADS'] = '1'
+    os.environ['OPENBLAS_NUM_THREADS'] = '1'
+    os.environ['MKL_NUM_THREADS'] = '1'
 
 import sklearn
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor

--- a/frameworks/TPOT/exec.py
+++ b/frameworks/TPOT/exec.py
@@ -4,12 +4,12 @@ import pprint
 import sys
 import tempfile as tmp
 
+os.environ['JOBLIB_TEMP_FOLDER'] = tmp.gettempdir()
 if sys.platform == 'darwin':
     os.environ['OBJC_DISABLE_INITIALIZE_FORK_SAFETY'] = 'YES'
-os.environ['JOBLIB_TEMP_FOLDER'] = tmp.gettempdir()
-os.environ['OMP_NUM_THREADS'] = '1'
-os.environ['OPENBLAS_NUM_THREADS'] = '1'
-os.environ['MKL_NUM_THREADS'] = '1'
+    os.environ['OMP_NUM_THREADS'] = '1'
+    os.environ['OPENBLAS_NUM_THREADS'] = '1'
+    os.environ['MKL_NUM_THREADS'] = '1'
 
 from tpot import TPOTClassifier, TPOTRegressor, __version__
 

--- a/frameworks/TunedRandomForest/exec.py
+++ b/frameworks/TunedRandomForest/exec.py
@@ -7,12 +7,14 @@ import logging
 import math
 import os
 import statistics
+import sys
 import tempfile as tmp
 
 os.environ['JOBLIB_TEMP_FOLDER'] = tmp.gettempdir()
-os.environ['OMP_NUM_THREADS'] = '1'
-os.environ['OPENBLAS_NUM_THREADS'] = '1'
-os.environ['MKL_NUM_THREADS'] = '1'
+if sys.platform == 'darwin':
+    os.environ['OMP_NUM_THREADS'] = '1'
+    os.environ['OPENBLAS_NUM_THREADS'] = '1'
+    os.environ['MKL_NUM_THREADS'] = '1'
 
 import sklearn
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor

--- a/frameworks/autosklearn/exec.py
+++ b/frameworks/autosklearn/exec.py
@@ -2,13 +2,16 @@ import logging
 import math
 import os
 import shutil
+import sys
 import tempfile as tmp
 import warnings
 
 os.environ['JOBLIB_TEMP_FOLDER'] = tmp.gettempdir()
-os.environ['OMP_NUM_THREADS'] = '1'
-os.environ['OPENBLAS_NUM_THREADS'] = '1'
-os.environ['MKL_NUM_THREADS'] = '1'
+if sys.platform == 'darwin':
+    os.environ['OMP_NUM_THREADS'] = '1'
+    os.environ['OPENBLAS_NUM_THREADS'] = '1'
+    os.environ['MKL_NUM_THREADS'] = '1'
+
 import autosklearn
 from autosklearn.estimators import AutoSklearnClassifier, AutoSklearnRegressor
 from autosklearn.experimental.askl2 import AutoSklearn2Classifier

--- a/frameworks/hyperoptsklearn/__init__.py
+++ b/frameworks/hyperoptsklearn/__init__.py
@@ -1,6 +1,6 @@
 from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
-from amlb.datautils import Encoder, impute
+from amlb.datautils import Encoder, impute_array
 from amlb.utils import call_script_in_same_dir
 
 
@@ -11,7 +11,7 @@ def setup(*args, **kwargs):
 def run(dataset: Dataset, config: TaskConfig):
     from frameworks.shared.caller import run_in_venv
 
-    X_train, X_test = impute(dataset.train.X_enc, dataset.test.X_enc)
+    X_train, X_test = impute_array(dataset.train.X_enc, dataset.test.X_enc)
     y_train, y_test = dataset.train.y_enc, dataset.test.y_enc
     data = dict(
         train=dict(

--- a/frameworks/hyperoptsklearn/exec.py
+++ b/frameworks/hyperoptsklearn/exec.py
@@ -3,12 +3,15 @@ import logging
 import math
 import os
 import signal
+import sys
 import tempfile as tmp
 
 os.environ['JOBLIB_TEMP_FOLDER'] = tmp.gettempdir()
-os.environ['OMP_NUM_THREADS'] = '1'
-os.environ['OPENBLAS_NUM_THREADS'] = '1'
-os.environ['MKL_NUM_THREADS'] = '1'
+if sys.platform == 'darwin':
+    os.environ['OMP_NUM_THREADS'] = '1'
+    os.environ['OPENBLAS_NUM_THREADS'] = '1'
+    os.environ['MKL_NUM_THREADS'] = '1'
+
 from hpsklearn import HyperoptEstimator, any_classifier, any_regressor
 import hyperopt
 from sklearn.metrics import accuracy_score, roc_auc_score, f1_score, log_loss, mean_absolute_error, mean_squared_error, mean_squared_log_error, r2_score


### PR DESCRIPTION
Frameworks like `autogluon`, `mljar`, `mlplan` use sklearn with numpy and scipy on multiple CPUs without having to set the following env variables on their process:
```python
os.environ['OMP_NUM_THREADS'] = '1'
os.environ['OPENBLAS_NUM_THREADS'] = '1'
os.environ['MKL_NUM_THREADS'] = '1'
```

However, if the benchmark explicitly passed the number of cpus to `mlplan`, `autosklearn` and `TPOT` (respectively through the `ncpus`, `n_jobs` (bis) parameters, this is not used by `autogluon` and `mljar`, which could explain why they don't need those env variables. (?)

I suggest to remove those "probably legacy" variables from all framework integrations, after getting approval from the framework's authors.