### PR TITLE
Write splits of sparse data into sparse arff format

### DIFF
--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -18,7 +18,7 @@ import scipy.sparse as sp
 
 from ..data import AM, DF, Dataset, DatasetType, Datasplit, Feature
 from ..resources import config as rconfig
-from ..utils import as_list, lazy_property, path_from_split, profile, split_path, unsparsify
+from ..utils import as_list, is_sparse, lazy_property, path_from_split, profile, split_path, unsparsify
 
 
 log = logging.getLogger(__name__)
@@ -248,11 +248,12 @@ class ArffSplitter(DataSplitter[str]):
                             else 'STRING'
                            ))
                           for c, dt in zip(df.columns, df.dtypes)]
+            data = sp.coo_matrix(df.values) if is_sparse(df) else df.values
             arff.dump(dict(
                 description=description,
                 relation=name,
                 attributes=attributes,
-                data=df.values
+                data=data
             ), file)
 
     def _is_numeric(self, col):


### PR DESCRIPTION
https://github.com/openml/automlbenchmark/issues/375

Still need to ensure that all frameworks reading arff files support this sparce format:
- H2O : no, might consider consuming parquet files instead.
- AutoWeka: relies on WEKA (?), so it should support sparse data.
- MLPlan: relies on WEKA (?)
- autoxgboost: relies on `farff:readARFF` (see below).
- mlr3automl: relies on `mlr3oml::read_arff`, https://rdrr.io/github/mlr-org/mlr3oml/man/read_arff.html
- ranger (actually just a R impl of RF): relies on `farff::readARFF` that doesn't support sparse Arff files, https://rdrr.io/cran/farff/man/readARFF.html