### PR TITLE
Tidy up: renamed bad filtr param

### DIFF
--- a/frameworks/H2OAutoML/exec.py
+++ b/frameworks/H2OAutoML/exec.py
@@ -3,7 +3,6 @@ import logging
 import os
 import psutil
 import re
-import shutil
 
 from packaging import version
 import pandas as pd
@@ -177,11 +176,11 @@ def save_artifacts(automl, dataset, config):
                         break
 
                 models_archive = os.path.join(models_dir, f"models_{mformat}.zip")
-                zip_path(models_dir, models_archive, filtr=lambda p: p not in models_artifacts)
+                zip_path(models_dir, models_archive, filter_=lambda p: p not in models_artifacts)
                 models_artifacts.append(models_archive)
                 clean_dir(models_dir,
-                                filtr=lambda p: p not in models_artifacts
-                                                and os.path.splitext(p)[1] in ['.json', '.zip', ''])
+                          filter_=lambda p: p not in models_artifacts
+                                          and os.path.splitext(p)[1] in ['.json', '.zip', ''])
 
         if 'model_predictions' in artifacts:
             predictions_dir = output_subdir("predictions", config)
@@ -195,14 +194,14 @@ def save_artifacts(automl, dataset, config):
                 write_preds(preds, os.path.join(predictions_dir, mid, 'predictions.csv'))
             predictions_zip = os.path.join(predictions_dir, "model_predictions.zip")
             zip_path(predictions_dir, predictions_zip)
-            clean_dir(predictions_dir, filtr=lambda p: os.path.isdir(p))
+            clean_dir(predictions_dir, filter_=lambda p: os.path.isdir(p))
 
         if 'logs' in artifacts:
             logs_dir = output_subdir("logs", config)
             logs_zip = os.path.join(logs_dir, "h2o_logs.zip")
             zip_path(logs_dir, logs_zip)
             # h2o.download_all_logs(dirname=logs_dir)
-            clean_dir(logs_dir, filtr=lambda p: p != logs_zip)
+            clean_dir(logs_dir, filter_=lambda p: p != logs_zip)
             write_csv(automl.event_log.as_data_frame(), os.path.join(logs_dir, 'aml_event_log.csv'))
     except Exception:
         log.debug("Error when saving artifacts.", exc_info=True)

--- a/frameworks/MLNet/exec.py
+++ b/frameworks/MLNet/exec.py
@@ -108,10 +108,10 @@ def run(dataset: Dataset, config: TaskConfig):
         if 'logs' in artifacts:
             logs_zip = os.path.join(log_dir, "logs.zip")
             zip_path(log_dir, logs_zip)
-            clean_dir(log_dir, filtr=lambda p: p != logs_zip)
+            clean_dir(log_dir, filter_=lambda p: p != logs_zip)
         if 'models' in artifacts:
             models_zip = os.path.join(output_dir, "models.zip")
             zip_path(output_dir, models_zip)
-            clean_dir(output_dir, filtr=lambda p: p != models_zip)
+            clean_dir(output_dir, filter_=lambda p: p != models_zip)
 
         shutil.rmtree(tmpdir, ignore_errors=True)

--- a/frameworks/autosklearn/exec.py
+++ b/frameworks/autosklearn/exec.py
@@ -173,7 +173,7 @@ def save_artifacts(estimator, config):
                 walk_apply(
                     tmp_directory,
                     _copy,
-                    filtr=lambda path: (
+                    filter_=lambda path: (
                         os.path.splitext(path)[1] not in ignore_extensions
                         and not os.path.isdir(path)
                     ),
@@ -182,7 +182,7 @@ def save_artifacts(estimator, config):
                 zip_path(
                     tmp_directory,
                     os.path.join(debug_dir, "artifacts.zip"),
-                    filtr=lambda p: os.path.splitext(p)[1] not in ignore_extensions
+                    filter_=lambda p: os.path.splitext(p)[1] not in ignore_extensions
                 )
     except Exception as e:
         log.debug("Error when saving artifacts= {e}.".format(e), exc_info=True)

--- a/runbenchmark.py
+++ b/runbenchmark.py
@@ -190,7 +190,7 @@ finally:
         out_dirs = bench.output_dirs
         for d in archives:
             if d in out_dirs:
-                zip_path(out_dirs[d], os.path.join(out_dirs.session, f"{d}.zip"), arcpathformat='long')
+                zip_path(out_dirs[d], os.path.join(out_dirs.session, f"{d}.zip"), arc_path_format='long')
                 shutil.rmtree(out_dirs[d], ignore_errors=True)
 
     sys.exit(code)


### PR DESCRIPTION
Use more standard approach of adding an underscore when param conflicts with builtins, instead of removing a letter that makes it look like a typo. 