### PR TITLE
Improve local logs in AWS mode when many instances in parallel

### DIFF
--- a/amlb/runners/aws.py
+++ b/amlb/runners/aws.py
@@ -434,7 +434,8 @@ class AWSBenchmark(Benchmark):
                     if last_line is not None:
                         last_console_line = last_line['line']
                     if new_log:
-                        log.info(new_log)
+                        around = f"[{job.ext.instance_id}:{job.name}]"
+                        log.info(f"{around}>>\n{new_log}\n<<{around}")
             except Exception as e:
                 log.exception(e)
 


### PR DESCRIPTION
make blocks from instance logs and surround them with easily searchable and identifiable pattern.

This is a workaround until I find time to add support for one logger per local job.