### PR TITLE
Improve readablity of logs in AWS mode

### DIFF
--- a/amlb/runners/aws.py
+++ b/amlb/runners/aws.py
@@ -430,10 +430,11 @@ class AWSBenchmark(Benchmark):
                 output = instance.console_output(Latest=True)
                 if 'Output' in output:
                     output = output['Output']   # note that console_output only returns the last 64kB of console
-                    new_log, last_line = tail(output, from_line=last_console_line, include_line=False)
+                    new_lines, last_line = tail(output, from_line=last_console_line, include_line=False, splitlines=True)
                     if last_line is not None:
                         last_console_line = last_line['line']
-                    if new_log:
+                    if new_lines:
+                        new_log = '\n'.join([f"[{job.ext.instance_id}]>{line}" for line in new_lines])
                         around = f"[{job.ext.instance_id}:{job.name}]"
                         log.info(f"{around}>>\n{new_log}\n<<{around}")
             except Exception as e:

--- a/amlb/utils/core.py
+++ b/amlb/utils/core.py
@@ -343,12 +343,13 @@ def str_digest(s):
     return base64.b64encode(hashlib.md5(s.encode()).digest()).decode()
 
 
-def head(s, lines=10):
+def head(s, lines=10, splitlines=False):
     s_lines = s.splitlines() if s else []
-    return '\n'.join(s_lines[:lines])
+    s_lines = s_lines[:lines]
+    return s_lines if splitlines else '\n'.join(s_lines)
 
 
-def tail(s, lines=10, from_line=None, include_line=True):
+def tail(s, lines=10, from_line=None, include_line=True, splitlines=False):
     if s is None:
         return None if from_line is None else None, None
 
@@ -367,7 +368,8 @@ def tail(s, lines=10, from_line=None, include_line=True):
             start = 0
     last_line = dict(index=len(s_lines) - 1,
                      line=s_lines[-1] if len(s_lines) > 0 else None)
-    t = '\n'.join(s_lines[start:])
+    s_lines = s_lines[start:]
+    t = s_lines if splitlines else '\n'.join(s_lines)
     return t if from_line is None else (t, last_line)
 
 


### PR DESCRIPTION
Add instance id to each line of the local console to make the logs grepable.