### PR TITLE
Improve error handling in AWS mode

### DIFF
--- a/amlb/results.py
+++ b/amlb/results.py
@@ -499,7 +499,9 @@ class NoResult(Result):
 
     def evaluate(self, metric):
         eval_res = Namespace(metric=metric, value=self.missing_result)
-        if metric not in _supported_metrics_:
+        if metric is None:
+            pass
+        elif metric not in _supported_metrics_:
             eval_res += Namespace(higher_is_better=None, message=f"Unsupported metric `{metric}`")
         else:
             eval_res.higher_is_better = get_metadata(_supported_metrics_.get(metric), 'higher_is_better')

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -191,6 +191,7 @@ aws:                    # configuration namespace for AWS mode.
       - 'SpotMaxPriceTooLow'
       - 'MaxSpotInstanceCountExceeded'
       - 'InsufficientFreeAddressesInSubnet'
+      - 'InsufficientInstanceCapacity'
     retry_on_states:                         # EC2 instance states that will trigger a job reschedule.
       - 'Server.SpotInstanceShutdown'
       - 'Server.SpotInstanceTermination'


### PR DESCRIPTION
Avoid annoying duplicate errors when there's no result due to AWS error:
```
AWSError: InsufficientInstanceCapacity; Unsupported metric `None`
```
and retry using default job scheduler retry policy on `InsufficientInstanceCapacity` error.