### PR TITLE
Fix bug when handling `NoResult` if the remote instance was killed

### DIFF
--- a/amlb/results.py
+++ b/amlb/results.py
@@ -500,7 +500,7 @@ class NoResult(Result):
     def evaluate(self, metric):
         eval_res = Namespace(metric=metric, value=self.missing_result)
         if metric is None:
-            pass
+            eval_res += Namespace(higher_is_better=None)
         elif metric not in _supported_metrics_:
             eval_res += Namespace(higher_is_better=None, message=f"Unsupported metric `{metric}`")
         else:


### PR DESCRIPTION
After remote instance was killed by `amlb` as it was hanging (no CPU activity), got the following error:

```
[ERROR] [amlb.job:06:06:28.967] Job `xxx` failed with error: 'Namespace' object has no attribute 'higher_is_better'
Traceback (most recent call last):
  File "/home/automl/automlbenchmark/amlb/runners/aws.py", line 358, in _run
    return self._wait_for_results(_self)
  File "/home/automl/automlbenchmark/amlb/runners/aws.py", line 448, in _wait_for_results
    raise AWSError("Aborting instance {} for job {}.".format(job.ext.instance_id, job.name))
amlb.runners.aws.AWSError: Aborting instance i-0400496638b60e80a for job xxx.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/automl/automlbenchmark/amlb/job.py", line 115, in start
    result = self._run()
  File "/home/automl/automlbenchmark/amlb/runners/aws.py", line 383, in _run
    return results.compute_score(result=ErrorResult(e))
  File "/home/automl/automlbenchmark/amlb/utils/process.py", line 702, in profiler
    return fn(*args, **kwargs)
  File "/home/automl/automlbenchmark/amlb/results.py", line 448, in compute_score
    set_score(do_score(entry.metric))
  File "/home/automl/automlbenchmark/amlb/results.py", line 437, in set_score
    if score.higher_is_better is False:  # if unknown metric, and higher_is_better is None, then no change
  File "/home/automl/automlbenchmark/amlb/utils/core.py", line 194, in __getattr__
    raise AttributeError(f"'Namespace' object has no attribute '{item}'")
AttributeError: 'Namespace' object has no attribute 'higher_is_better'
```