### PR TITLE
AMLB failed retrying on Spot forced termination

### DIFF
--- a/amlb/runners/aws.py
+++ b/amlb/runners/aws.py
@@ -472,7 +472,7 @@ class AWSBenchmark(Benchmark):
                     log.info("EC2 instance %s is %s: %s", job.ext.instance_id, state, state_reason_msg)
                     # self._update_instance(job.ext.instance_id, stop_reason=state_reason_msg)
                     try:
-                        if state_reason_msg in rconfig().aws.job_scheduler.retry_on_states:
+                        if any(state in state_reason_msg for state in rconfig().aws.job_scheduler.retry_on_states):
                             log.warning("Job %s was aborted due to '%s', rescheduling it.", job.name, state_reason_msg)
                             self._job_reschedule(job, reason=state_reason_msg, fallback=self._spot_fallback)
                     finally:

--- a/amlb/utils/core.py
+++ b/amlb/utils/core.py
@@ -234,8 +234,9 @@ class Namespace:
         return Namespace.dict(self)
 
 
-def repr_def(obj):
-    return "{clazz}({attributes})".format(clazz=type(obj).__name__, attributes=', '.join(("{}={!r}".format(k, v) for k, v in obj.__dict__.items())))
+def repr_def(obj, show_private=False):
+    return "{cls}({attrs!r})".format(cls=type(obj).__name__,
+                                     attrs={k: v for k, v in vars(obj).items() if show_private or not k.startswith('_')})
 
 
 def noop(*args, **kwargs):

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -196,6 +196,7 @@ aws:                    # configuration namespace for AWS mode.
     retry_on_states:                         # EC2 instance states that will trigger a job reschedule.
       - 'Server.SpotInstanceShutdown'
       - 'Server.SpotInstanceTermination'
+      - 'Server.InsufficientInstanceCapacity'
 
   max_timeout_seconds: 21600    #
   os_mem_size_mb: 0             # overrides the default amount of memory left to the os in AWS mode, and set to 0 for fairness as we can't always prevent frameworks from using all available memory.


### PR DESCRIPTION
App was expectiong message `Server.SpotInstanceTermination` but was `Server.SpotInstanceTermination: Spot instance termination`
Therefore we need to revert the search string logic.