### PR TITLE
Option to resume benchmark or rerun missing results based on previous results

### DIFF
--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -10,11 +10,8 @@ import re
 from typing import Generic, Tuple, TypeVar, Union
 
 import arff
-import numpy as np
-import pandas as pd
 import pandas.api.types as pat
 import openml as oml
-import scipy.sparse as sp
 
 from ..data import AM, DF, Dataset, DatasetType, Datasplit, Feature
 from ..resources import config as rconfig
@@ -25,8 +22,6 @@ log = logging.getLogger(__name__)
 
 # hack (only adding a ? to the regexp pattern) to ensure that '?' values remain quoted when we save dataplits in arff format.
 arff._RE_QUOTE_CHARS = re.compile(r'[?"\'\\\s%,\000-\031]', re.UNICODE)
-
-
 
 
 class OpenmlLoader:

--- a/amlb/results.py
+++ b/amlb/results.py
@@ -50,7 +50,6 @@ class ResultError(Exception):
     pass
 
 
-
 class Scoreboard:
 
     results_file = 'results.csv'

--- a/amlb/utils/time.py
+++ b/amlb/utils/time.py
@@ -111,13 +111,23 @@ class Timer:
         self.start = 0
         self.stop = 0
         self._time = clock if enabled else Timer._zero
+        self._tick = 0
 
     def __enter__(self):
-        self.start = self._time()
+        self.start = self._tick = self._time()
         return self
 
     def __exit__(self, *args):
-        self.stop = self._time()
+        self.stop = self._tick = self._time()
+
+    @property
+    def tick(self):
+        if self.stop > 0:
+            return -1
+        now = self._time()
+        tick = now - self._tick
+        self._tick = now
+        return tick
 
     @property
     def duration(self):

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -12,6 +12,7 @@ root_dir:    # app root dir: set by caller (runbenchmark.py)
 script:     # calling script: set by caller (runbenchmark.py)
 run_mode:   # target run mode (local, docker, aws): set by caller (runbenchmark.py)
 sid:        # session id: set by caller (runbenchmark.py)
+job_history:    # file containing the list of jobs already executed: set by caller (runbenchmark.py)
 
 test_mode: false        # if set to true, some additional checks are executed at runtime.
 seed: auto              # default global seed (used if not set in task definition), can be one of:
@@ -61,7 +62,7 @@ benchmarks:                     # configuration namespace for the benchmarks def
     min_vol_size_mb: -1         # default minimum amount of free space required on the volume. If <= 0, skips verification.
 
 job_scheduler:           # configuration namespace
-  stop_on_job_failure:   # if true, the entire run will be aborted on the first job failure (mainly used for testing) : set by caller (runbenchmark.py)
+  exit_on_job_failure:   # if true, the entire run will be aborted on the first job failure (mainly used for testing) : set by caller (runbenchmark.py)
   parallel_jobs: 1       # the number of jobs being run in parallel in a benchmark session, set by caller (runbenchmark.py)
   max_parallel_jobs: 10  # safety limit: increase this if you want to be able to run many jobs in parallel, especially in aws mode. Defaults to 10 to allow running the usual 10 folds in parallel with no problem.
   delay_between_jobs: 5  # delay in seconds between each parallel job start


### PR DESCRIPTION
By using the `--resume` option, the benchmark app will skip the duplicated jobs (ie. the jobs for which there's already an entry in `output_dir/results.csv`).

This is especially useful in AWS mode when there can be failures due to instances unavailability: in this case, an entry is created in `failures.csv` but not in `results.csv`, so re-rerunning the same benchmark later with the `--resume` option will run only the missing jobs.