### PR TITLE
Add a workflow to tag latest `v*` release as `stable`

### DIFF
--- a/.github/workflows/stable-tag.yml
+++ b/.github/workflows/stable-tag.yml
@@ -1,0 +1,29 @@
+name:  Tag with Stable
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  TAG: ${{ github.event.release.tag_name }}
+
+jobs:
+  tag-if-latest-stable:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.BRANCH }}
+      - name: Register git credentials
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - name: Update stable if latest
+        run: |
+          MOST_RECENT_STABLE=$(git ls-remote --tags origin | tail -n 1 | sed -E 's/.?*refs\/tags\///')
+          if [ "$TAG" == "$MOST_RECENT_STABLE" ]; then
+            git tag stable
+            git push --tags -f
+          fi
+        shell: bash

--- a/.github/workflows/stable-tag.yml
+++ b/.github/workflows/stable-tag.yml
@@ -5,25 +5,20 @@ on:
     tags:
       - 'v*'
 
-env:
-  TAG: ${{ github.event.release.tag_name }}
-
 jobs:
   tag-if-latest-stable:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ env.BRANCH }}
       - name: Register git credentials
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
       - name: Update stable if latest
         run: |
-          MOST_RECENT_STABLE=$(git ls-remote --tags origin | tail -n 1 | sed -E 's/.?*refs\/tags\///')
-          if [ "$TAG" == "$MOST_RECENT_STABLE" ]; then
+          MOST_RECENT_STABLE=$(git ls-remote --tags origin | tail -n 1 | sed -E 's/.*\s//')
+          echo "New: '""${GITHUB_REF}""', most recent: '""${MOST_RECENT_STABLE}""'"
+          if [ "$GITHUB_REF" == "$MOST_RECENT_STABLE" ]; then
             git tag stable
             git push --tags -f
           fi
-        shell: bash


### PR DESCRIPTION
Major/minor/patch versions can't use more than one digit because it relies on alphabetical order. I don't think this will be an issue, but I'm not sure how to fix this without making the script significantly more complex (by including a version parser).