### PR TITLE
Fix/docker tag

### DIFF
--- a/amlb/runners/container.py
+++ b/amlb/runners/container.py
@@ -182,7 +182,8 @@ Do you still want to build the container image? (y/[n]) """).lower() or 'n'
                 image = self._container_image_name(dev)
 
         if not image:
-            image = self._container_image_name()
+            version_tag = next((t for t in tags if t.startswith("v")), None)
+            image = self._container_image_name(version_tag)
         self._run_container_build_command(image, cache)
         return image
 

--- a/amlb/runners/container.py
+++ b/amlb/runners/container.py
@@ -182,7 +182,14 @@ Do you still want to build the container image? (y/[n]) """).lower() or 'n'
                 image = self._container_image_name(dev)
 
         if not image:
-            version_tag = next((t for t in tags if t.startswith("v")), None)
+            tags = rget().git_info.tags
+            version_tags = [t for t in tags if re.match(r"v\d+(\d+.)*", t)]
+            if len(version_tags) > 1:
+                raise InvalidStateError(
+                    "The image can't be built as more than one version tag was found."
+                    f"Found tags: {version_tags}"
+                )
+            version_tag = next(iter(version_tags), None)
             image = self._container_image_name(version_tag)
         self._run_container_build_command(image, cache)
         return image

--- a/resources/frameworks_2021Q3.yaml
+++ b/resources/frameworks_2021Q3.yaml
@@ -50,7 +50,7 @@ mljarsupervised_benchmark:
   params:
     mode: Compete
 
-MLNET:
+MLNet:
   version: '16.5.26'
 
 MLPlan:


### PR DESCRIPTION
Previously the format would be `framework_version` when creating an image on the default branch (normally `stable`). 
In case the local environment would deviate from the online latest version, `-dev` would be appended to the tag (e.g. `0.10.6-dev`).
Now in similar fashion, if everything is clean and latest on the default branch and a version tag happens to be present, it will be added to the tag e.g. `0.10.6-v2.0.1`.

Closes #403 