### PR TITLE
Fixed randomforest:latest and tunedrandomforest:latest

### DIFF
--- a/.github/workflows/stable-tag.yml
+++ b/.github/workflows/stable-tag.yml
@@ -1,0 +1,24 @@
+name:  Tag with Stable
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  tag-if-latest-stable:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Register git credentials
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - name: Update stable if latest
+        run: |
+          MOST_RECENT_STABLE=$(git ls-remote --tags origin | tail -n 1 | sed -E 's/.*\s//')
+          echo "New: '""${GITHUB_REF}""', most recent: '""${MOST_RECENT_STABLE}""'"
+          if [ "$GITHUB_REF" == "$MOST_RECENT_STABLE" ]; then
+            git tag stable
+            git push --tags -f
+          fi

--- a/amlb/__version__.py
+++ b/amlb/__version__.py
@@ -1,3 +1,3 @@
 # major.minor.patch[-label]
 _dev_version = "dev"
-__version__ = "2.0"
+__version__ = _dev_version

--- a/amlb/__version__.py
+++ b/amlb/__version__.py
@@ -1,3 +1,3 @@
 # major.minor.patch[-label]
 _dev_version = "dev"
-__version__ = _dev_version
+__version__ = "2.0"

--- a/amlb/runners/container.py
+++ b/amlb/runners/container.py
@@ -182,7 +182,15 @@ Do you still want to build the container image? (y/[n]) """).lower() or 'n'
                 image = self._container_image_name(dev)
 
         if not image:
-            image = self._container_image_name()
+            tags = rget().git_info.tags
+            version_tags = [t for t in tags if re.match(r"v\d+(\d+.)*", t)]
+            if len(version_tags) > 1:
+                raise InvalidStateError(
+                    "The image can't be built as more than one version tag was found."
+                    f"Found tags: {version_tags}"
+                )
+            version_tag = next(iter(version_tags), None)
+            image = self._container_image_name(version_tag)
         self._run_container_build_command(image, cache)
         return image
 

--- a/frameworks/RandomForest/setup.sh
+++ b/frameworks/RandomForest/setup.sh
@@ -4,7 +4,7 @@ VERSION=${1:-"stable"}
 REPO=${2:-"https://github.com/scikit-learn/scikit-learn.git"}
 PKG=${3:-"scikit-learn"}
 if [[ "$VERSION" == "latest" ]]; then
-    VERSION="master"
+    VERSION="main"
 fi
 
 . "${HERE}/../shared/setup.sh" "${HERE}" true

--- a/frameworks/TunedRandomForest/setup.sh
+++ b/frameworks/TunedRandomForest/setup.sh
@@ -4,7 +4,7 @@ VERSION=${1:-"stable"}
 REPO=${2:-"https://github.com/scikit-learn/scikit-learn.git"}
 PKG=${3:-"scikit-learn"}
 if [[ "$VERSION" == "latest" ]]; then
-    VERSION="master"
+    VERSION="main"
 fi
 
 # create venv

--- a/resources/frameworks_2021Q3.yaml
+++ b/resources/frameworks_2021Q3.yaml
@@ -15,7 +15,7 @@ AutoGluon_benchmark:
     presets: best_quality
 
 autosklearn:
-  version: '0.12.7'
+  version: '0.14.0'
 
 autosklearn2:
   extends: autosklearn

--- a/resources/frameworks_2021Q3.yaml
+++ b/resources/frameworks_2021Q3.yaml
@@ -50,7 +50,7 @@ mljarsupervised_benchmark:
   params:
     mode: Compete
 
-MLNET:
+MLNet:
   version: '16.5.26'
 
 MLPlan:


### PR DESCRIPTION
Ello,

I noticed that the 'latest' tag for scikit-learn was set to 'master' instead of their default branch, 'main':
* https://github.com/scikit-learn/scikit-learn

This just changes the `setup.sh` for both randomforest and tunedrandomforest frameworks to reflect this.

Feel free to change the base branch if needed :)

### Before
```
python runbenchmark.py randomforest:latest example
# Failed
```

### Now
```
python runbenchmark.py randomforest:latest example
# ... succeeds but a very long setup time
```