### PR TITLE
Updated setup.py for `hyperoptsklearn` as it no longer uses PyPi (also now accepts shas)

### DIFF
--- a/frameworks/hyperoptsklearn/setup.sh
+++ b/frameworks/hyperoptsklearn/setup.sh
@@ -11,7 +11,7 @@ fi
 . ${HERE}/../shared/setup.sh ${HERE} true
 
 if [[ "$VERSION" =~ ^[0-9] ]]; then
-    pip install git+https://github.com/hyperopt/hyperopt-sklearn@${VERSION}
+    PIP install git+https://github.com/hyperopt/hyperopt-sklearn@${VERSION}
 else
 #    PIP install --no-cache-dir -e git+${REPO}@${VERSION}#egg=${PKG}
     LIB=$(echo ${PKG} | sed "s/\[.*\]//")

--- a/frameworks/hyperoptsklearn/setup.sh
+++ b/frameworks/hyperoptsklearn/setup.sh
@@ -3,21 +3,27 @@ HERE=$(dirname "$0")
 VERSION=${1:-"stable"}
 REPO=${2:-"https://github.com/hyperopt/hyperopt-sklearn.git"}
 PKG=${3:-"hyperopt-sklearn"}
-if [[ "$VERSION" == "latest" ]]; then
+
+if [[ "$VERSION" == "latest" || "$VERSION" == "stable" ]]; then
     VERSION="master"
 fi
 
 . ${HERE}/../shared/setup.sh ${HERE} true
 
-if [[ "$VERSION" == "stable" ]]; then
-    PIP install --no-cache-dir -U ${PKG}
-elif [[ "$VERSION" =~ ^[0-9] ]]; then
-    PIP install --no-cache-dir -U ${PKG}==${VERSION}
+if [[ "$VERSION" =~ ^[0-9] ]]; then
+    pip install git+https://github.com/hyperopt/hyperopt-sklearn@${VERSION}
 else
 #    PIP install --no-cache-dir -e git+${REPO}@${VERSION}#egg=${PKG}
     LIB=$(echo ${PKG} | sed "s/\[.*\]//")
     TARGET_DIR="${HERE}/lib/${LIB}"
     rm -Rf ${TARGET_DIR}
-    git clone --depth 1 --single-branch --branch ${VERSION} --recurse-submodules ${REPO} ${TARGET_DIR}
+    if [[ "$VERSION" =~ ^# ]]; then
+        git clone --recurse-submodules --shallow-submodules ${REPO} ${TARGET_DIR}
+        cd ${TARGET_DIR}
+        git checkout "${VERSION:1}"
+        cd ${HERE}
+    else
+        git clone --depth 1 --single-branch --branch ${VERSION} --recurse-submodules ${REPO} ${TARGET_DIR}
+    fi
     PIP install -U -e ${HERE}/lib/${PKG}
 fi


### PR DESCRIPTION
Ello,

More fixes, this time `hyperoptsklearn` no longer exists on PyPi so I updated the setup.sh file for it to just install from github.
I've also extended the script slightly to allow for `#sha` to be allowed as the `$VERSION` argument. 

The default version for hyperoptsklearn is 'latest' as defined in `resources/frameworks.yaml` such that the `hyperoptsklearn` and `hyperoptsklearn:latest` would both work by installing from github. 

However `hyperoptsklearn:stable` would attempt to install from PyPi and hence fail.

Feel free to change the target branch once again, I'm not sure where contributions generally go for `automlbenchmark`

### Before
```bash
python runbenchmark.py -s only hyperoptsklearn # Works
python runbenchmark.py -s only hyperoptsklearn:latest # Works
python runbenchmark.py -s only hyperoptsklearn:stable # Fails
python runbenchmark.py -s only hyperoptsklearn:testtag # Fails, frameworks_testtag.yaml specifys version = components_test
```

### After
```bash
python runbenchmark.py -s only hyperoptsklearn # Works
python runbenchmark.py -s only hyperoptsklearn:latest # Works
python runbenchmark.py -s only hyperoptsklearn:stable # Works
python runbenchmark.py -s only hyperoptsklearn:testtag # Works, frameworks_testtag.yaml specifys version = component_test
python runbenchmark.py -s only hyperoptsklearn:testtag # Works, frameworks_testtag.yaml specifys version = <sha>
```