### PR TITLE
Included lightautoml in frameworks_stable

### DIFF
--- a/frameworks/mlr3automl/setup.sh
+++ b/frameworks/mlr3automl/setup.sh
@@ -24,7 +24,7 @@ fi
 
 . $HERE/../shared/setup.sh "$HERE"
 if [[ -x "$(command -v apt-get)" ]]; then
-SUDO apt-get update
+  SUDO apt-get update
   SUDO apt-get install -y software-properties-common dirmngr
   SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
   SUDO add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -cs)-cran40/"

--- a/resources/frameworks.yaml
+++ b/resources/frameworks.yaml
@@ -122,12 +122,12 @@ mljarsupervised_compete:
   description: "MLJAR is using 'Compete' mode to provide the most accurate predictor"
   params:
     mode: Compete   # set mode for Compete, default mode is Explain
-    
+
 MLNet:
   version: 'latest'
   description: |
     MLNET.CLI is a automated machine learning tool implemented by ml.net.
-    
+
 MLPlan:
   version: 'stable'
   abstract: true

--- a/resources/frameworks_latest.yaml
+++ b/resources/frameworks_latest.yaml
@@ -68,7 +68,7 @@ MLPlanWEKA:
     _backend: weka
 
 mlr3automl:
-  version: 'stable'
+  version: 'latest'
 
 oboe:
   version: 'latest'

--- a/resources/frameworks_latest.yaml
+++ b/resources/frameworks_latest.yaml
@@ -50,6 +50,9 @@ mljarsupervised_compete:
   params:
     mode: Compete   # set mode for Compete, default mode is Explain
 
+MLNet:
+  version: 'latest'
+
 MLPlan:
   abstract: true
   version: 'latest'

--- a/resources/frameworks_latest.yaml
+++ b/resources/frameworks_latest.yaml
@@ -67,6 +67,9 @@ MLPlanWEKA:
   params:
     _backend: weka
 
+mlr3automl:
+  version: 'stable'
+
 oboe:
   version: 'latest'
 

--- a/resources/frameworks_stable.yaml
+++ b/resources/frameworks_stable.yaml
@@ -63,6 +63,9 @@ MLPlanWEKA:
   params:
     _backend: weka
 
+mlr3automl:
+  version: 'stable'
+
 oboe:
   version: 'stable'
 

--- a/resources/frameworks_stable.yaml
+++ b/resources/frameworks_stable.yaml
@@ -35,6 +35,9 @@ GAMA:
 H2OAutoML:
   version: 'stable'
 
+lightautoml:
+  version: 'stable'
+
 hyperoptsklearn:
   version: 'stable'
 


### PR DESCRIPTION
Sorry, I'm doing these pull requests small and piecemeal as I diagnose some issues on our benchmarking tool.
My expectation is that any framework can be used with the tags 'stable' or 'latest' but perhaps this is incorrect.

* `frameworks_stable.yaml` didnt include 'lightautoml' but it's supported by it's `setup.sh` so I included it in.
* `frameworks_{stable,latest}.yaml` didn't include MLNet. Looking at the `setup.sh`, I included it in `frameworks_latest.yaml`. I'm unsure what you'd like to do about the 'stable' version. The simplest solution is convert both 'stable' and 'latest' to the empty string as defined in it's `setup.sh` so that it can be used with both tags.