### PR TITLE
Improv/aws meta

### DIFF
--- a/amlb/runners/aws.py
+++ b/amlb/runners/aws.py
@@ -456,6 +456,7 @@ class AWSBenchmark(Benchmark):
 
                 if state_code == 16:
                     if inst_desc['meta_info'] is None:
+                        instance_volume = list(instance.volumes.all())[0]
                         meta_info = dict(
                             instance_type=instance.instance_type,
                             launch_time=str(instance.launch_time),
@@ -465,6 +466,8 @@ class AWSBenchmark(Benchmark):
                             private_ip=instance.private_ip_address,
                             availability_zone=instance.placement['AvailabilityZone'],
                             subnet_id=instance.subnet_id,
+                            volume_size_gb=instance_volume.size,
+                            volume_type=instance_volume.volume_type,
                         )
                         self._update_instance(job.ext.instance_id, meta_info=meta_info)
                         log.info("Running EC2 instance %s: %s", instance.id, meta_info)

--- a/amlb/runners/aws.py
+++ b/amlb/runners/aws.py
@@ -456,7 +456,10 @@ class AWSBenchmark(Benchmark):
 
                 if state_code == 16:
                     if inst_desc['meta_info'] is None:
-                        instance_volume = list(instance.volumes.all())[0]
+                        volume_info = [
+                            dict(type=v.volume_type, size_gb=v.size, id=v.id)
+                            for v in instance.volumes.all()
+                        ]
                         meta_info = dict(
                             instance_type=instance.instance_type,
                             launch_time=str(instance.launch_time),
@@ -466,8 +469,7 @@ class AWSBenchmark(Benchmark):
                             private_ip=instance.private_ip_address,
                             availability_zone=instance.placement['AvailabilityZone'],
                             subnet_id=instance.subnet_id,
-                            volume_size_gb=instance_volume.size,
-                            volume_type=instance_volume.volume_type,
+                            volumes=volume_info,
                         )
                         self._update_instance(job.ext.instance_id, meta_info=meta_info)
                         log.info("Running EC2 instance %s: %s", instance.id, meta_info)


### PR DESCRIPTION
Adds `volume_type`  and `volume_size` (in gb) to the `meta_info` available of AWS instances.
Currently hardcoded to assume only one volume is used, as we do not allow for multiple volumes in the first place (and simply aggregating does not make sense if the different volumes are of a different volume type).