### PR TITLE
FRAMEWORK SETUP UPDATE: set up the framework flaml's special requirements for automlbenchmark

### DIFF
--- a/frameworks/flaml/setup.sh
+++ b/frameworks/flaml/setup.sh
@@ -10,15 +10,15 @@ fi
 . ${HERE}/../shared/setup.sh ${HERE} true
 
 if [[ "$VERSION" == "stable" ]]; then
-    PIP install --no-cache-dir -U ${PKG}
+    PIP install --no-cache-dir -U ${PKG}[benchmark]
 elif [[ "$VERSION" =~ ^[0-9] ]]; then
-    PIP install --no-cache-dir -U ${PKG}==${VERSION}
+    PIP install --no-cache-dir -U ${PKG}==${VERSION}[benchmark]
 else
 #    PIP install --no-cache-dir -e git+${REPO}@${VERSION}#egg=${PKG}
     TARGET_DIR="${HERE}/lib/${PKG}"
     rm -Rf ${TARGET_DIR}
     git clone --depth 1 --single-branch --branch ${VERSION} --recurse-submodules ${REPO} ${TARGET_DIR}
-    PIP install -U -e ${TARGET_DIR}
+    PIP install -U -e ${TARGET_DIR}[benchmark]
 fi
 
 PY -c "from flaml import __version__; print(__version__)" >> "${HERE}/.setup/installed"


### PR DESCRIPTION
- FLAML reorganized its default requirements. Some of the dependencies are no longer installed by default but are still needed to run experiments in automlbenchmark. We moved those ones into [benchmark] 