### PR TITLE
Add constraints for v2 benchmark

### DIFF
--- a/resources/constraints.yaml
+++ b/resources/constraints.yaml
@@ -28,16 +28,16 @@ test:
   cores: 8
   min_vol_size_mb: 131072
 
-ssd1h8c:
+1h8c_gp3:
   folds: 10
   max_runtime_seconds: 3600
   cores: 8
   min_vol_size_mb: 100000
-  ec2_volume_type: gp2
+  ec2_volume_type: gp3
 
-ssd4h8c:
+4h8c_gp3:
   folds: 10
   max_runtime_seconds: 14400
   cores: 8
   min_vol_size_mb: 100000
-  ec2_volume_type: gp2
+  ec2_volume_type: gp3

--- a/resources/constraints.yaml
+++ b/resources/constraints.yaml
@@ -27,3 +27,17 @@ test:
   max_runtime_seconds: 28800
   cores: 8
   min_vol_size_mb: 131072
+
+ssd1h8c:
+  folds: 10
+  max_runtime_seconds: 3600
+  cores: 8
+  min_vol_size_mb: 100000
+  ec2_volume_type: gp2
+
+ssd4h8c:
+  folds: 10
+  max_runtime_seconds: 14400
+  cores: 8
+  min_vol_size_mb: 100000
+  ec2_volume_type: gp2


### PR DESCRIPTION
For ease of reproducibility, we want to include our experimental setup in the constraints file. For our experiments we increase the volume size to 100gb and require gp3 volumes (general purpose SSD).