### PR TITLE
Accept datasets stored in s3

### DIFF
--- a/amlb/datasets/file.py
+++ b/amlb/datasets/file.py
@@ -15,7 +15,7 @@ from ..datautils import read_csv, to_data_frame
 from ..resources import config as rconfig
 from ..utils import Namespace as ns, as_list, lazy_property, list_all_files, memoize, path_from_split, profile, split_path
 
-from .fileutils import download_file, is_archive, is_valid_url, unarchive_file, url_exists
+from .fileutils import is_archive, is_valid_url, unarchive_file, get_file_handler
 
 
 log = logging.getLogger(__name__)
@@ -118,8 +118,9 @@ class FileLoader:
         elif is_valid_url(dataset):
             cached_file = os.path.join(self._cache_dir, os.path.basename(dataset))
             if not os.path.exists(cached_file):  # don't download if previously done
-                assert url_exists(dataset), f"Invalid path/url: {dataset}"
-                download_file(dataset, cached_file)
+                handler = get_file_handler(dataset)
+                assert handler.exists(dataset), f"Invalid path/url: {dataset}"
+                handler.download(dataset, dest_path=cached_file)
             return self._extract_train_test_paths(cached_file)
         else:
             raise ValueError(f"Invalid dataset description: {dataset}")

--- a/amlb/datasets/fileutils.py
+++ b/amlb/datasets/fileutils.py
@@ -70,7 +70,8 @@ scheme_handlers = dict(
     http=HttpHandler(),
     https=HttpHandler(),
     s3=S3Handler(),
-    s3a=S3Handler
+    s3a=S3Handler(),
+    s3n=S3Handler(),
 )
 
 SUPPORTED_SCHEMES = list(scheme_handlers.keys())

--- a/amlb/datasets/fileutils.py
+++ b/amlb/datasets/fileutils.py
@@ -22,11 +22,7 @@ def s3_path_to_bucket_prefix(s3_path):
 
 
 def is_s3_url(path):
-    if type(path) != str:
-        return False
-    if (path[:2] == 's3') and ('://' in path[:6]):
-        return True
-    return False
+    return isinstance(path, str) and path.lower().startswith("s3://")
 
 
 def is_valid_url(url):

--- a/amlb/datasets/fileutils.py
+++ b/amlb/datasets/fileutils.py
@@ -11,7 +11,22 @@ from ..utils import touch
 
 log = logging.getLogger(__name__)
 
-SUPPORTED_SCHEMES = ("http", "https")
+SUPPORTED_SCHEMES = ("http", "https", "s3")
+
+
+def s3_path_to_bucket_prefix(s3_path):
+    s3_path_cleaned = s3_path.split('://', 1)[1]
+    bucket, prefix = s3_path_cleaned.split('/', 1)
+
+    return bucket, prefix
+
+
+def is_s3_url(path):
+    if type(path) != str:
+        return False
+    if (path[:2] == 's3') and ('://' in path[:6]):
+        return True
+    return False
 
 
 def is_valid_url(url):
@@ -21,21 +36,45 @@ def is_valid_url(url):
 def url_exists(url):
     if not is_valid_url(url):
         return False
-    head_req = Request(url, method='HEAD')
-    try:
-        with urlopen(head_req) as test:
-            return test.status == 200
-    except URLError as e:
-        log.error(f"Cannot access url %s: %s", url, e)
-        return False
+    if not is_s3_url(url):
+        head_req = Request(url, method='HEAD')
+        try:
+            with urlopen(head_req) as test:
+                return test.status == 200
+        except URLError as e:
+            log.error(f"Cannot access url %s: %s", url, e)
+            return False
+    else:
+        import boto3
+        from botocore.errorfactory import ClientError
+        s3 = boto3.client('s3')
+        bucket, key = s3_path_to_bucket_prefix(url)
+        try:
+            s3.head_object(Bucket=bucket, Key=key)
+            return True
+        except ClientError as e:
+            log.error(f"Cannot access url %s: %s", url, e)
+            return False
 
 
 def download_file(url, dest_path):
     touch(dest_path)
     # urlretrieve(url, filename=dest_path)
-    with urlopen(url) as resp, open(dest_path, 'wb') as dest:
-        shutil.copyfileobj(resp, dest)
-
+    if not is_s3_url(url):
+        with urlopen(url) as resp, open(dest_path, 'wb') as dest:
+            shutil.copyfileobj(resp, dest)
+    else:
+        import boto3
+        from botocore.errorfactory import ClientError
+        s3 = boto3.resource('s3')
+        bucket, key = s3_path_to_bucket_prefix(url)
+        try:
+            s3.Bucket(bucket).download_file(key, dest_path)
+        except ClientError as e:
+            if e.response['Error']['Code'] == "404":
+                log.error("The object does not exist.")
+            else:
+                raise
 
 def is_archive(path):
     return zipfile.is_zipfile(path) or tarfile.is_tarfile(path)
@@ -52,4 +91,3 @@ def unarchive_file(path, dest_folder=None):
         with tarfile.open(path) as tf:
             tf.extractall(path=dest_folder)
     return dest
-

--- a/amlb/datasets/fileutils.py
+++ b/amlb/datasets/fileutils.py
@@ -2,6 +2,8 @@ import logging
 import os
 import shutil
 import tarfile
+import boto3
+from botocore.errorfactory import ClientError
 from urllib.error import URLError
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
@@ -35,8 +37,6 @@ class HttpHandler(FileHandler):
 
 class S3Handler(FileHandler):
     def exists(self, url):
-        import boto3
-        from botocore.errorfactory import ClientError
         s3 = boto3.client('s3')
         bucket, key = self._s3_path_to_bucket_prefix(url)
         try:
@@ -47,8 +47,6 @@ class S3Handler(FileHandler):
             return False
         
     def download(self, url, dest_path):
-        import boto3
-        from botocore.errorfactory import ClientError
         touch(dest_path)
         s3 = boto3.resource('s3')
         bucket, key = self._s3_path_to_bucket_prefix(url)


### PR DESCRIPTION
Currently amlb benchmark yaml file doesn't accept s3 url. This is useful when users want to benchmark on AWS machines with their own private datasets.
This PR adds the ability to parse s3 url and download the file. Users will need to have AWS credentials setup on the given machine to access the resource if it's not publicly available.