### PR TITLE
Add a GAMA configuration intended for benchmarking

### DIFF
--- a/resources/frameworks_2021Q3.yaml
+++ b/resources/frameworks_2021Q3.yaml
@@ -32,7 +32,13 @@ flaml:
   version: '0.6.2'
 
 GAMA:
-  version: '21.0.0'
+  abstract: true
+  version: '21.0.1'
+
+GAMA_benchmark:
+  extends: GAMA
+  params:
+    goal: performance
 
 H2OAutoML:
   version: '3.34.0.1'


### PR DESCRIPTION
Made the previous version abstract to avoid accidentally running the
wrong version of GAMA for the benchmark.