### PR TITLE
Openml must be configured when loading the tasks

### DIFF
--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -72,6 +72,9 @@ class Benchmark:
             return
 
         self._forward_params = locals()
+        if Benchmark.data_loader is None:
+            Benchmark.data_loader = DataLoader(rconfig())
+
         fsplits = framework_name.split(':', 1)
         framework_name = fsplits[0]
         tag = fsplits[1] if len(fsplits) > 1 else None
@@ -108,8 +111,6 @@ class Benchmark:
         and possibly download them if necessary.
         Delegates specific setup to the framework module
         """
-        Benchmark.data_loader = DataLoader(rconfig())
-
         if mode == SetupMode.skip or mode == SetupMode.auto and self._is_setup_done():
             return
 

--- a/runbenchmark.py
+++ b/runbenchmark.py
@@ -8,7 +8,7 @@ import sys
 # prevent asap other modules from defining the root logger using basicConfig
 import amlb.logger
 
-from openml.config import get_cache_directory
+from openml.config import cache_directory
 
 import amlb
 from amlb.utils import Namespace as ns, config_load, datetime_iso, str2bool, str_sanitize, zip_path
@@ -16,7 +16,7 @@ from amlb import log, AutoMLError
 
 
 default_dirs = ns(
-    input_dir=get_cache_directory(),
+    input_dir=cache_directory,
     output_dir="./results",
     user_dir="~/.config/automlbenchmark",
     root_dir=os.path.dirname(__file__)


### PR DESCRIPTION
Also use `openml.cache_directory` instead of `openml.get_cache_directory()` to read the default cache folder, as the latter doesn't point to the root of the cache folder.