### PR TITLE
Fix/kill proc tree

### DIFF
--- a/amlb/utils/process.py
+++ b/amlb/utils/process.py
@@ -286,11 +286,17 @@ def kill_proc_tree(pid=None, include_parent=True, timeout=None, on_terminate=Non
         children.append(parent)
     for proc in children:
         log.warning("Terminating process %s.", proc)
-        proc.terminate()
+        try:
+            proc.terminate()
+        except psutil.NoSuchProcess:
+            pass
     terminated, alive = psutil.wait_procs(children, timeout=timeout, callback=on_proc_terminated)
     for proc in alive:
         log.warning("Killing process %s.", proc)
-        proc.kill()
+        try:
+            proc.kill()
+        except psutil.NoSuchProcess:
+            pass
 
 
 def call_in_subprocess(target, *args, **kwargs):


### PR DESCRIPTION
Observed the following in a `tunedrandomforest` run:
```
INFO:__main__:Training final model with `max_features=3`.
WARNING:amlb.utils.process:Terminating process psutil.Process(pid=40, name='python', status='sleeping', started='12:40:33').
WARNING:amlb.utils.process:Terminating process psutil.Process(pid=41, name='python', status='sleeping', started='12:40:33').
WARNING:amlb.utils.process:Terminating process psutil.Process(pid=42, name='python', status='sleeping', started='12:40:33').
WARNING:amlb.utils.process:Terminating process psutil.Process(pid=43, name='python', status='sleeping', started='12:40:33').
WARNING:amlb.utils.process:Terminating process psutil.Process(pid=44, name='python', status='sleeping', started='12:40:33').
WARNING:amlb.utils.process:Terminating process psutil.Process(pid=45, name='python', status='sleeping', started='12:40:33').
WARNING:amlb.utils.process:Terminating process psutil.Process(pid=46, name='python', status='sleeping', started='12:40:33').
WARNING:amlb.utils.process:Terminating process psutil.Process(pid=47, status='terminated', started='12:40:33').

[DEBUG] [amlb.utils.process:12:46:17.160] Traceback (most recent call last):
  File "/bench/frameworks/TunedRandomForest/exec.py", line 139, in <module>
    call_run(run)
  File "/bench/frameworks/shared/callee.py", line 85, in call_run
    kill_proc_tree(include_parent=False, timeout=5)
  File "/bench/amlb/utils/process.py", line 289, in kill_proc_tree
    proc.terminate()
  File "/bench/frameworks/TunedRandomForest/venv/lib/python3.7/site-packages/psutil/__init__.py", line 271, in wrapper
    raise NoSuchProcess(self.pid, self._name)
psutil.NoSuchProcess: psutil.NoSuchProcess process no longer exists (pid=47)
```

which seems to be (as far as I can tell) because the parent (in this case) terminated before `proc.terminate()` was called.