### PR TITLE
Switch from release:created to release:published

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -3,7 +3,7 @@ name: Version Bump
 on:
   release:
     types:
-      - created
+      - published
 
   workflow_dispatch:
 


### PR DESCRIPTION
In our current typical release scenario a moot point. But whenever a release needs to re-done this is easier (as removing the `tag` simply sets the release back to draft, which means `release:created` is never hit a second time).