### PR TITLE
Adding capability of taking auxiliary data

### DIFF
--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -19,7 +19,7 @@ import sys
 from typing import List, Union
 
 from .job import Job, JobError, SimpleJobRunner, MultiThreadingJobRunner
-from .datasets import DataLoader, DataSourceType
+from .datasets import DataLoader, DataSourceType, DatasetWithAuxilaryData
 from .data import DatasetType
 from .datautils import read_csv
 from .resources import get as rget, config as rconfig, output_dirs as routput_dirs
@@ -488,6 +488,10 @@ class BenchmarkTask:
             self._dataset = Benchmark.data_loader.load(DataSourceType.file, dataset=self._task_def.dataset, fold=self.fold)
         else:
             raise ValueError("Tasks should have one property among [openml_task_id, openml_dataset_id, dataset].")
+
+        if hasattr(self._task_def, 'auxilary_data'):
+            auxilary_data = Benchmark.data_loader.load_auxilary_data(DataSourceType.file, auxilary_data=self._task_def.auxilary_data, fold=self.fold)
+            self._dataset = DatasetWithAuxilaryData(self._dataset, auxilary_data)
 
     def as_job(self):
         job = Job(name=rconfig().token_separator.join([

--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -19,7 +19,7 @@ import sys
 from typing import List, Union
 
 from .job import Job, JobError, SimpleJobRunner, MultiThreadingJobRunner
-from .datasets import DataLoader, DataSourceType, DatasetWithAuxilaryData
+from .datasets import DataLoader, DataSourceType, DatasetWithauxiliaryData
 from .data import DatasetType
 from .datautils import read_csv
 from .resources import get as rget, config as rconfig, output_dirs as routput_dirs
@@ -489,9 +489,9 @@ class BenchmarkTask:
         else:
             raise ValueError("Tasks should have one property among [openml_task_id, openml_dataset_id, dataset].")
 
-        if hasattr(self._task_def, 'auxilary_data'):
-            auxilary_data = Benchmark.data_loader.load_auxilary_data(DataSourceType.file, auxilary_data=self._task_def.auxilary_data, fold=self.fold)
-            self._dataset = DatasetWithAuxilaryData(self._dataset, auxilary_data)
+        if hasattr(self._task_def, 'auxiliary_data'):
+            auxiliary_data = Benchmark.data_loader.load_auxiliary_data(DataSourceType.file, auxiliary_data=self._task_def.auxiliary_data, fold=self.fold)
+            self._dataset = DatasetWithauxiliaryData(self._dataset, auxiliary_data)
 
     def as_job(self):
         job = Job(name=rconfig().token_separator.join([

--- a/amlb/datasets/__init__.py
+++ b/amlb/datasets/__init__.py
@@ -1,6 +1,6 @@
 from enum import Enum, auto
 
-from .file import FileLoader, DatasetWithAuxilaryData
+from .file import FileLoader, DatasetWithauxiliaryData
 from .openml import OpenmlLoader
 
 
@@ -24,9 +24,9 @@ class DataLoader:
         else:
             raise NotImplementedError(f"data source {source} is not supported yet")
 
-    def load_auxilary_data(self, source: DataSourceType, *args, **kwargs):
+    def load_auxiliary_data(self, source: DataSourceType, *args, **kwargs):
         if source == DataSourceType.file:
-            return self.file_loader.load_auxilary_data(*args, **kwargs)
+            return self.file_loader.load_auxiliary_data(*args, **kwargs)
         else:
             raise NotImplementedError(f"data source {source} is not supported yet")
 

--- a/amlb/datasets/__init__.py
+++ b/amlb/datasets/__init__.py
@@ -1,6 +1,6 @@
 from enum import Enum, auto
 
-from .file import FileLoader
+from .file import FileLoader, DatasetWithAuxilaryData
 from .openml import OpenmlLoader
 
 
@@ -21,6 +21,12 @@ class DataLoader:
             return self.openml_loader.load(*args, **kwargs)
         elif source == DataSourceType.file:
             return self.file_loader.load(*args, **kwargs)
+        else:
+            raise NotImplementedError(f"data source {source} is not supported yet")
+
+    def load_auxilary_data(self, source: DataSourceType, *args, **kwargs):
+        if source == DataSourceType.file:
+            return self.file_loader.load_auxilary_data(*args, **kwargs)
         else:
             raise NotImplementedError(f"data source {source} is not supported yet")
 

--- a/amlb/datasets/file.py
+++ b/amlb/datasets/file.py
@@ -56,54 +56,54 @@ class FileLoader:
             raise ValueError(f"Unsupported file type: {ext}")
 
     @profile(logger=log)
-    def load_auxilary_data(self, auxilary_data, fold=0):
-        auxilary_data = auxilary_data if isinstance(auxilary_data, ns) else ns(path=auxilary_data)
-        log.debug("Loading auxilary data %s", auxilary_data)
-        paths = self._extract_auxilary_paths(auxilary_data.path if 'path' in auxilary_data else auxilary_data, fold=fold)
+    def load_auxiliary_data(self, auxiliary_data, fold=0):
+        auxiliary_data = auxiliary_data if isinstance(auxiliary_data, ns) else ns(path=auxiliary_data)
+        log.debug("Loading auxiliary data %s", auxiliary_data)
+        paths = self._extract_auxiliary_paths(auxiliary_data.path if 'path' in auxiliary_data else auxiliary_data, fold=fold)
         train_path = paths['train'][fold]
         test_path = paths['test'][fold]
         paths = dict(train=train_path, test=test_path)
         return paths
 
-    def _extract_auxilary_paths(self, auxilary_data, fold=None):
-        train_search_pat = re.compile(r"(?:(.*)[_-])train_auxilary(?:[_-](\d+))?\.\w+")
-        test_search_pat = re.compile(r"(?:(.*)[_-])test_auxilary(?:[_-](\d+))?\.\w+")
-        if isinstance(auxilary_data, (tuple, list)):
-            assert len(auxilary_data) % 2 == 0, "auxilary data list must contain an even number of paths: [train_0, test_0, train_1, test_1, ...]."
-            return self._extract_auxilary_paths(ns(train=[p for i, p in enumerate(auxilary_data) if i % 2 == 0],
-                                                   test=[p for i, p in enumerate(auxilary_data) if i % 2 == 1]),
+    def _extract_auxiliary_paths(self, auxiliary_data, fold=None):
+        train_search_pat = re.compile(r"(?:(.*)[_-])train_auxiliary(?:[_-](\d+))?\.\w+")
+        test_search_pat = re.compile(r"(?:(.*)[_-])test_auxiliary(?:[_-](\d+))?\.\w+")
+        if isinstance(auxiliary_data, (tuple, list)):
+            assert len(auxiliary_data) % 2 == 0, "auxiliary data list must contain an even number of paths: [train_0, test_0, train_1, test_1, ...]."
+            return self._extract_auxiliary_paths(ns(train=[p for i, p in enumerate(auxiliary_data) if i % 2 == 0],
+                                                   test=[p for i, p in enumerate(auxiliary_data) if i % 2 == 1]),
                                                 fold=fold)
-        elif isinstance(auxilary_data, ns):
+        elif isinstance(auxiliary_data, ns):
             return dict(
-                train=[self._extract_auxilary_paths(p)['train'][0]
+                train=[self._extract_auxiliary_paths(p)['train'][0]
                        if i == fold else None
-                       for i, p in enumerate(as_list(auxilary_data.train))],
-                test=[self._extract_auxilary_paths(p)['train'][0]
+                       for i, p in enumerate(as_list(auxiliary_data.train))],
+                test=[self._extract_auxiliary_paths(p)['train'][0]
                       if i == fold else None
-                      for i, p in enumerate(as_list(auxilary_data.test))] if 'test' in auxilary_data else []
+                      for i, p in enumerate(as_list(auxiliary_data.test))] if 'test' in auxiliary_data else []
             )
         else:
-            assert isinstance(auxilary_data, str)
-            auxilary_data = os.path.expanduser(auxilary_data)
-            auxilary_data = auxilary_data.format(**rconfig().common_dirs)
+            assert isinstance(auxiliary_data, str)
+            auxiliary_data = os.path.expanduser(auxiliary_data)
+            auxiliary_data = auxiliary_data.format(**rconfig().common_dirs)
 
-        if os.path.exists(auxilary_data):
-            if os.path.isfile(auxilary_data):
-                # we leave the auxilary data handling to the user
-                return dict(train=[auxilary_data], test=[])
-            elif os.path.isdir(auxilary_data):
-                files = list_all_files(auxilary_data)
-                log.debug("Files found in auxilary data folder %s: %s", auxilary_data, files)
-                assert len(files) > 0, f"Empty folder: {auxilary_data}"
+        if os.path.exists(auxiliary_data):
+            if os.path.isfile(auxiliary_data):
+                # we leave the auxiliary data handling to the user
+                return dict(train=[auxiliary_data], test=[])
+            elif os.path.isdir(auxiliary_data):
+                files = list_all_files(auxiliary_data)
+                log.debug("Files found in auxiliary data folder %s: %s", auxiliary_data, files)
+                assert len(files) > 0, f"Empty folder: {auxiliary_data}"
                 if len(files) == 1:
                     return dict(train=files, test=[])
 
                 train_matches = [m for m in [train_search_pat.search(f) for f in files] if m]
                 test_matches = [m for m in [test_search_pat.search(f) for f in files] if m]
                 # verify they're for the same dataset (just based on name)
-                assert train_matches, f"Folder {auxilary_data} must contain at least one training auxilary data."
+                assert train_matches, f"Folder {auxiliary_data} must contain at least one training auxiliary data."
                 root_names = {m[1] for m in (train_matches+test_matches)}
-                assert len(root_names) == 1, f"All dataset files in {auxilary_data} should follow the same naming: xxxxx_train_N.ext or xxxxx_test_N.ext with N starting from 0."
+                assert len(root_names) == 1, f"All dataset files in {auxiliary_data} should follow the same naming: xxxxx_train_N.ext or xxxxx_test_N.ext with N starting from 0."
 
                 train_no_fold = next((m[0] for m in train_matches if m[2] is None), None)
                 test_no_fold = next((m[0] for m in test_matches if m[2] is None), None)
@@ -121,17 +121,17 @@ class FileLoader:
                         fold += 1
                     else:
                         fold = -1
-                assert len(paths) > 0, f"No dataset file found in {auxilary_data}: they should follow the naming xxxx_train.ext, xxxx_test.ext or xxxx_train_0.ext, xxxx_test_0.ext, xxxx_train_1.ext, ..."
+                assert len(paths) > 0, f"No dataset file found in {auxiliary_data}: they should follow the naming xxxx_train.ext, xxxx_test.ext or xxxx_train_0.ext, xxxx_test_0.ext, xxxx_train_1.ext, ..."
                 return paths
-        elif is_valid_url(auxilary_data):
-            cached_file = os.path.join(self._cache_dir, os.path.basename(auxilary_data))
+        elif is_valid_url(auxiliary_data):
+            cached_file = os.path.join(self._cache_dir, os.path.basename(auxiliary_data))
             if not os.path.exists(cached_file):  # don't download if previously done
-                handler = get_file_handler(auxilary_data)
-                assert handler.exists(auxilary_data), f"Invalid path/url: {auxilary_data}"
-                handler.download(auxilary_data, dest_path=cached_file)
-            return self._extract_auxilary_paths(cached_file)
+                handler = get_file_handler(auxiliary_data)
+                assert handler.exists(auxiliary_data), f"Invalid path/url: {auxiliary_data}"
+                handler.download(auxiliary_data, dest_path=cached_file)
+            return self._extract_auxiliary_paths(cached_file)
         else:
-            raise ValueError(f"Invalid dataset description: {auxilary_data}")
+            raise ValueError(f"Invalid dataset description: {auxiliary_data}")
 
     def _extract_train_test_paths(self, dataset, fold=None):
         if isinstance(dataset, (tuple, list)):
@@ -245,20 +245,20 @@ class FileDataset(Dataset):
         return meta[prop]
 
 
-class DatasetWithAuxilaryData:
+class DatasetWithauxiliaryData:
     
-    def __init__(self, dataset: FileDataset, auxilary_data_path):
+    def __init__(self, dataset: FileDataset, auxiliary_data_path):
         self._dataset = dataset
-        self._train_auxilary_data = auxilary_data_path.get('train', None)
-        self._test_auxilary_data = auxilary_data_path.get('test', None)
+        self._train_auxiliary_data = auxiliary_data_path.get('train', None)
+        self._test_auxiliary_data = auxiliary_data_path.get('test', None)
 
     @property
-    def train_auxilary_data(self) -> str:
-        return self._train_auxilary_data
+    def train_auxiliary_data(self) -> str:
+        return self._train_auxiliary_data
 
     @property
-    def test_auxilary_data(self) -> str:
-        return self._test_auxilary_data
+    def test_auxiliary_data(self) -> str:
+        return self._test_auxiliary_data
 
     @property
     def type(self) -> DatasetType:

--- a/frameworks/AutoGluon/__init__.py
+++ b/frameworks/AutoGluon/__init__.py
@@ -13,6 +13,8 @@ def run(dataset: Dataset, config: TaskConfig):
     data = dict(
         train=dict(path=dataset.train.data_path('parquet')),
         test=dict(path=dataset.test.data_path('parquet')),
+        train_aux=dict(path=dataset.train_auxilary_data),
+        test_aux=dict(path=dataset.test_auxilary_data),
         target=dict(
             name=dataset.target.name,
             classes=dataset.target.values

--- a/frameworks/AutoGluon/__init__.py
+++ b/frameworks/AutoGluon/__init__.py
@@ -13,8 +13,8 @@ def run(dataset: Dataset, config: TaskConfig):
     data = dict(
         train=dict(path=dataset.train.data_path('parquet')),
         test=dict(path=dataset.test.data_path('parquet')),
-        train_aux=dict(path=dataset.train_auxilary_data),
-        test_aux=dict(path=dataset.test_auxilary_data),
+        train_aux=dict(path=dataset.train_auxiliary_data),
+        test_aux=dict(path=dataset.test_auxiliary_data),
         target=dict(
             name=dataset.target.name,
             classes=dataset.target.values


### PR DESCRIPTION
The idea of this PR is to enable benchmark yaml taking in auxiliary data. Auxiliary data could be useful when the task requires more than train and test datasets. For example, images are needed for multimodality tasks. There are more usage possibles, and therefore we think it's worth to have auxiliary data as a general feature.

Example yaml file:
```
- name: benchmark
  folds: 1
  dataset:
    target: label
    train: train.csv
    test: test.csv
  auxiliary_data:
    train: train_aux.zip
    test: test_aux.zip  # test aux not required
```

The main difference between auxiliary data and regular dataset should be that:
1. We don't require a 1 to 1 correspondence of train and test aux data. Imagine a use case where some psudo label data are used during training, while we don't need those during testing.
2. AMLB should let the users to handle the aux data themselves because use case of the aux data could vary a lot. AMLB only prepare the data and hand users the path.