### PR TITLE
Failed to build docker images from linux

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,13 +8,10 @@ results
 **/models
 **/predictions
 **/scores
-**/.setup
-**/.installed
-**/.setup_env
 **/__pycache__
-**/lib
-**/setup
 **/venv
+frameworks/*/.setup
+frameworks/*/lib
 
 # editors/IDEs
 .idea


### PR DESCRIPTION
@PGijsbers I guess it was the same issue you were getting on Windows, right?
```
cannot locate specified Dockerfile: frameworks/constantpredictor/.setup/Dockerfile
```
after cleaning up the `.dockerignore` it seems to work. 