### PR TITLE
Respect TMP, TMPDIR, TEMP

### DIFF
--- a/frameworks/autosklearn/setup.sh
+++ b/frameworks/autosklearn/setup.sh
@@ -36,6 +36,7 @@ else
     git clone  --recurse-submodules --shallow-submodules ${DEPTH} ${REPO} ${TARGET_DIR}
     cd ${TARGET_DIR}
     git checkout "${COMMIT}"
+    git submodule update --init --recursive
     cd ${HERE}
     PIP install -U -e ${TARGET_DIR}
 fi

--- a/frameworks/shared/caller.py
+++ b/frameworks/shared/caller.py
@@ -3,7 +3,7 @@ import logging
 import os
 import re
 from tempfile import TemporaryDirectory, mktemp
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 import numpy as np
 
@@ -83,7 +83,7 @@ def run_in_venv(caller_file, script_file: str, *args,
                 options: Union[None, dict, ns] = None,
                 process_results=None,
                 python_exec=None,
-                retain_tmp_env: bool = True):
+                retained_env_vars: Optional[List[str]] = ['TMP', 'TEMP', 'TMPDIR']):
     here = dir_of(caller_file)
     if python_exec is None:  # use local virtual env by default
         python_exec = venv_python_exec(here)
@@ -94,11 +94,12 @@ def run_in_venv(caller_file, script_file: str, *args,
     ser_config = options['serialization']
     env = options['env'] or ns()
 
-    # To honour any arguments about tmpdir, we copy over
-    # the TMP, TEMP and TMPDIR environment variables
-    if retain_tmp_env:
-        for env_var in ["TMP", "TEMP", "TMPDIR"]:
-            env[env_var] = os.environ.get(env_var)
+    # Add any env variables specified if they are defined in the environment
+    if retained_env_vars:
+        for env_var in retained_env_vars:
+            env_val = os.environ.get(env_var)
+            if env_val is not None:
+                env[env_var] = env_val
 
     with TemporaryDirectory() as tmpdir:
 

--- a/frameworks/shared/caller.py
+++ b/frameworks/shared/caller.py
@@ -82,7 +82,8 @@ def run_in_venv(caller_file, script_file: str, *args,
                 input_data: Union[dict, ns], dataset: Dataset, config: TaskConfig,
                 options: Union[None, dict, ns] = None,
                 process_results=None,
-                python_exec=None):
+                python_exec=None,
+                retain_tmp_env: bool = True):
     here = dir_of(caller_file)
     if python_exec is None:  # use local virtual env by default
         python_exec = venv_python_exec(here)
@@ -92,6 +93,12 @@ def run_in_venv(caller_file, script_file: str, *args,
     options = ns.from_dict(options) if options else ns()
     ser_config = options['serialization']
     env = options['env'] or ns()
+
+    # To honour any arguments about tmpdir, we copy over
+    # the TMP, TEMP and TMPDIR environment variables
+    if retain_tmp_env:
+        for env_var in ["TMP", "TEMP", "TMPDIR"]:
+            env[env_var] = os.environ.get(env_var)
 
     with TemporaryDirectory() as tmpdir:
 


### PR DESCRIPTION
Ello,
CC: @mfeurer 

This PR copies over the environment variables `TMP`, `TMPDIR` and `TEMP` into the environment in which a framework is run. This allows users to specify where automlbenchmark and any underlying framework should place there tmpfiles.

**context**
As part of our automated benchmarking with auto-sklearn, we were filling up the `/tmp` directory of some of our nodes. This would also cause larger runs to eventually crash due to memory issues, as well as causing issues for other users of our cluster.

Debugging why it was not going into the unlimited `TMPDIR=/tmp/slurm_xxxx` folder provided by our slurm cluster, we found that `automlbenchmark` would remove any env variables that were set before running a framework.

We can not pass an argument to `autosklearn` to delete the temporary directory upon finishing as we require `automlbenchmark`'s functionality to zip up the artifacts. Hence, we rely on slurm's own cleanup of `/tmp/slurm_xxxx` once the job has finished and all artifacts zipped up.

As far as I could find, there is no way to pass env variables through automlbenchmark to the framework that is being run.

* [[link](https://github.com/openml/automlbenchmark/blob/master/frameworks/shared/caller.py#L83)] Option to add env variables through to `run_in_venv` which runs the framwork in an environment.
* [[link](https://github.com/openml/automlbenchmark/blob/master/frameworks/autosklearn/__init__.py#L27)] Autosklearn doesn't pass any options to `run_in_venv`, some other frameworks do
* We also run other frameworks to compare autosklearn so modifying just `autosklearn`'s `__init__.py` in the point above would not be sufficient.