### PR TITLE
Update to support AutoGluon v0.4

### DIFF
--- a/frameworks/AutoGluon/setup.sh
+++ b/frameworks/AutoGluon/setup.sh
@@ -9,16 +9,17 @@ fi
 
 # creating local venv
 . ${HERE}/../shared/setup.sh ${HERE} true
-#if [[ -x "$(command -v apt-get)" ]]; then
-#    SUDO apt-get install -y libomp-dev
+
+# Below fixes seg fault on MacOS due to bug in libomp: https://github.com/awslabs/autogluon/issues/1442
 if [[ -x "$(command -v brew)" ]]; then
-    brew install libomp
+    wget https://raw.githubusercontent.com/Homebrew/homebrew-core/fb8323f2b170bd4ae97e1bac9bf3e2983af3fdb0/Formula/libomp.rb
+    brew install libomp.rb
+    rm libomp.rb
 fi
 
 PIP install --upgrade pip
 PIP install --upgrade setuptools wheel
-PIP install "mxnet<2.0.0"
-PIP install "scikit-learn-intelex<2021.3"
+PIP install "scikit-learn-intelex<2021.6"
 
 if [[ "$VERSION" == "stable" ]]; then
     PIP install --no-cache-dir -U ${PKG}
@@ -29,11 +30,15 @@ else
     rm -Rf ${TARGET_DIR}
     git clone --depth 1 --single-branch --branch ${VERSION} --recurse-submodules ${REPO} ${TARGET_DIR}
     cd ${TARGET_DIR}
-    PIP install -e core/
+    # Note: Normally we would just call `./full_install.sh` but because `pip` and `PIP` are not the same,
+    # the script does not work here. Therefore, we have to explicitly install each submodule below.
+    # This has the downside that source installs of old versions of the package might not follow the below steps.
+    # It is recommended to instead use pip install of older AG versions to ensure it works correctly.
+    # https://github.com/awslabs/autogluon/blob/master/full_install.sh
+    PIP install -e common/
     PIP install -e features/
+    PIP install -e core/[all]
     PIP install -e tabular/[all]
-    PIP install -e mxnet/
-    PIP install -e extra/
     PIP install -e text/
     PIP install -e vision/
     PIP install -e autogluon/

--- a/frameworks/AutoGluon/setup.sh
+++ b/frameworks/AutoGluon/setup.sh
@@ -12,36 +12,28 @@ fi
 
 # Below fixes seg fault on MacOS due to bug in libomp: https://github.com/awslabs/autogluon/issues/1442
 if [[ -x "$(command -v brew)" ]]; then
-    wget https://raw.githubusercontent.com/Homebrew/homebrew-core/fb8323f2b170bd4ae97e1bac9bf3e2983af3fdb0/Formula/libomp.rb
-    brew install libomp.rb
-    rm libomp.rb
+    wget https://raw.githubusercontent.com/Homebrew/homebrew-core/fb8323f2b170bd4ae97e1bac9bf3e2983af3fdb0/Formula/libomp.rb -P "${HERE}/lib"
+    brew install "${HERE}/lib/libomp.rb"
 fi
 
 PIP install --upgrade pip
 PIP install --upgrade setuptools wheel
-PIP install "scikit-learn-intelex<2021.6"
 
 if [[ "$VERSION" == "stable" ]]; then
-    PIP install --no-cache-dir -U ${PKG}
+    PIP install --no-cache-dir -U "${PKG}"
+    PIP install --no-cache-dir -U "${PKG}.tabular[skex]"
 elif [[ "$VERSION" =~ ^[0-9] ]]; then
-    PIP install --no-cache-dir -U ${PKG}==${VERSION}
+    PIP install --no-cache-dir -U "${PKG}==${VERSION}"
+    PIP install --no-cache-dir -U "${PKG}.tabular[skex]==${VERSION}"
 else
     TARGET_DIR="${HERE}/lib/${PKG}"
     rm -Rf ${TARGET_DIR}
     git clone --depth 1 --single-branch --branch ${VERSION} --recurse-submodules ${REPO} ${TARGET_DIR}
     cd ${TARGET_DIR}
-    # Note: Normally we would just call `./full_install.sh` but because `pip` and `PIP` are not the same,
-    # the script does not work here. Therefore, we have to explicitly install each submodule below.
-    # This has the downside that source installs of old versions of the package might not follow the below steps.
-    # It is recommended to instead use pip install of older AG versions to ensure it works correctly.
-    # https://github.com/awslabs/autogluon/blob/master/full_install.sh
-    PIP install -e common/
-    PIP install -e features/
-    PIP install -e core/[all]
-    PIP install -e tabular/[all]
-    PIP install -e text/
-    PIP install -e vision/
-    PIP install -e autogluon/
+    PY_EXEC_NO_ARGS="$(cut -d' ' -f1 <<<"$py_exec")"
+    PY_EXEC_DIR=$(dirname "$PY_EXEC_NO_ARGS")
+    env PATH="$PY_EXEC_DIR:$PATH" bash -c ./full_install.sh
+    PIP install -e tabular/[skex]
 fi
 
 PY -c "from autogluon.tabular.version import __version__; print(__version__)" >> "${HERE}/.setup/installed"

--- a/resources/frameworks.yaml
+++ b/resources/frameworks.yaml
@@ -32,8 +32,25 @@ AutoGluon_bestquality:
   extends: AutoGluon
   description: |
     AutoGluon with 'best_quality' preset provides the most accurate overall predictor.
+    Refer to https://auto.gluon.ai/stable/tutorials/tabular_prediction/tabular-quickstart.html#presets for a description of the presets.
   params:
     presets: best_quality
+
+AutoGluon_hq:
+  extends: AutoGluon
+  description: |
+    AutoGluon with 'high_quality' preset provides a very strong predictor with 8x+ faster inference speed than 'best_quality'.
+    Refer to https://auto.gluon.ai/stable/tutorials/tabular_prediction/tabular-quickstart.html#presets for a description of the presets.
+  params:
+    presets: high_quality
+
+AutoGluon_gq:
+  extends: AutoGluon
+  description: |
+    AutoGluon with 'good_quality' preset provides a strong predictor with 16x+ faster inference speed than 'best_quality'.
+    Refer to https://auto.gluon.ai/stable/tutorials/tabular_prediction/tabular-quickstart.html#presets for a description of the presets.
+  params:
+    presets: good_quality
 
 autosklearn:
   version: 'stable'

--- a/resources/frameworks_latest.yaml
+++ b/resources/frameworks_latest.yaml
@@ -16,6 +16,16 @@ AutoGluon_bestquality:
   params:
     presets: best_quality
 
+AutoGluon_hq:
+  extends: AutoGluon
+  params:
+    presets: high_quality
+
+AutoGluon_gq:
+  extends: AutoGluon
+  params:
+    presets: good_quality
+
 autosklearn:
   version: 'latest'
 

--- a/resources/frameworks_stable.yaml
+++ b/resources/frameworks_stable.yaml
@@ -15,6 +15,16 @@ AutoGluon_bestquality:
   params:
     presets: best_quality
 
+AutoGluon_hq:
+  extends: AutoGluon
+  params:
+    presets: high_quality
+
+AutoGluon_gq:
+  extends: AutoGluon
+  params:
+    presets: good_quality
+
 autosklearn:
   version: 'stable'
 


### PR DESCRIPTION
PR to add support for AutoGluon v0.4

- Updates install from source logic to align with v0.4
- Added `AutoGluon_hq` and `AutoGluon_gq` presets that represent mid-way points between the quality of `AutoGluon_bestquality` and the inference speed of `AutoGluon`.
- Added loading test data prior to inference for a more genuine inference latency (previously loading data from file was included in inference time)
- Added `predictor.persist_models('best')` call to avoid loading models from disk during inference (for more genuine inference latency estimates).
