### PR TITLE
Ignore decoding errors on Windows

### DIFF
--- a/amlb/utils/process.py
+++ b/amlb/utils/process.py
@@ -102,6 +102,8 @@ def live_output_windows(process: subprocess.Popen, **_) -> Tuple[str, str]:
     )
 
     def forward_output(stream, queue_):
+        if isinstance(stream, io.TextIOWrapper):
+            stream.reconfigure(errors="ignore")
         for line in stream:
             queue_.put(line)
 


### PR DESCRIPTION
By default it can use cp1252 decoding which sometimes raises an error and halts the process.