### PR TITLE
For docker to work and work better

### DIFF
--- a/amlb/runners/docker.py
+++ b/amlb/runners/docker.py
@@ -54,6 +54,7 @@ class DockerBenchmark(ContainerBenchmark):
         inst_name = f"{self.sid}.{str_sanitize(str_digest(script_params))}"
         cmd = (
             "docker run --name {name} {options} "
+            '-u "$(id -u $USER):$(id -g $USER)" '
             "-v {input}:/input -v {output}:/output -v {custom}:/custom "
             "--rm {image} {params} -i /input -o /output -u /custom -s skip -Xrun_mode=docker {extra_params}"
         ).format(


### PR DESCRIPTION
This line `**/.setup` in `.dockerignore` denies 

```bash 
python3 runbenchmark.py ... -m docker -s force
```
execution, e.g.: `automlbenchmark/frameworks/TPOT/.setup/Dockerfile`.

And to avoid docker created files to be owned by `root` on host filesystem.