### PR TITLE
Fix Namespace error

### DIFF
--- a/amlb/runners/aws.py
+++ b/amlb/runners/aws.py
@@ -574,8 +574,14 @@ class AWSBenchmark(Benchmark):
             if instance_def.volume_size:
                 ebs['VolumeSize'] = instance_def.volume_size
 
-            instance_tags = ec2_config.instance_tags | ns(Name=f"amlb_{inst_key}")
-            volume_tags = (ec2_config.volume_tags or instance_tags) | ns(Name=f"amlb_{inst_key}")
+            if hasattr(ec2_config, 'instance_tags'):
+                instance_tags = ec2_config.instance_tags | ns(Name=f"amlb_{inst_key}")
+            else:
+                instance_tags = ns(Name=f"amlb_{inst_key}")
+            if hasattr(ec2_config, 'volume_tags'):
+                volume_tags = (ec2_config.volume_tags or instance_tags) | ns(Name=f"amlb_{inst_key}")
+            else:
+                volume_tags = instance_tags | ns(Name=f"amlb_{inst_key}")
             instance_params = dict(
                 BlockDeviceMappings=[dict(
                     DeviceName=ec2_config.root_device_name,


### PR DESCRIPTION
#469 appears to have introduced a bug where running in AWS mode will crash immediately due to a key error if the user doesn't specify `instance_tags` in a custom config. This code fixes the error.

Command:

```
python runbenchmark.py constantpredictor test -f 0 -m aws -p 10
```

Error:

```
---------------------------------------------------
Starting job aws.test.test.kc2.0.constantpredictor.
Starting new EC2 instance with params: constantpredictor test test -t kc2 -f 0 -Xseed=380416698
Job aws.test.test.kc2.0.constantpredictor failed with: 'Namespace' object has no attribute 'instance_tags'
fatal: not a git repository (or any of the parent directories): .git

Metric scores: { 'app_version': 'dev [NA, NA, NA]',
  'constraint': 'test',
  'duration': nan,
  'fold': 0,
  'framework': 'constantpredictor',
  'id': 'openml.org/t/3913',
  'info': "AttributeError: 'Namespace' object has no attribute 'instance_tags'",
  'metric': None,
  'mode': 'aws',
  'models_count': nan,
  'params': '',
  'predict_duration': nan,
  'result': nan,
  'seed': None,
  'task': 'kc2',
  'training_duration': nan,
  'type': None,
  'utc': '2022-08-04T00:46:26',
  'version': None}
Job `aws.test.test.kc2.0.constantpredictor` executed in 0.021 seconds.
Error when handling state change to State.completing for job `aws.test.test.kc2.0.constantpredictor`: cannot unpack non-iterable bool object
Traceback (most recent call last):
  File "/home/ubuntu/benchmark/ag-2022_08_03_hstree/tmp6/automlbenchmark/amlb/job.py", line 158, in set_state
    skip_default = bool(self._on_state(state))
  File "/home/ubuntu/benchmark/ag-2022_08_03_hstree/tmp6/automlbenchmark/amlb/runners/aws.py", line 388, in _on_state
    terminate, failure = self._download_results(_self.ext.instance_id)
TypeError: cannot unpack non-iterable bool object

```