### PR TITLE
Update to use m6i instances by default

### DIFF
--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -150,7 +150,7 @@ aws:                    # configuration namespace for AWS mode.
         ami: ami-0bdf93799014acdc4
         description: Ubuntu Server 18.04 LTS (HVM), EBS General Purpose (SSD) VolumeType
     instance_type:                       #
-      series: m5                         #
+      series: m6i                        # m6i is ~40% faster for similar price as m5
       map:                               # map between num cores required and ec2 instance type sizes
         default: large
         '1': small
@@ -158,8 +158,11 @@ aws:                    # configuration namespace for AWS mode.
         '4': xlarge
         '8': 2xlarge
         '16': 4xlarge
+        '32': 8xlarge
+        '64': 16xlarge
+        '128': 32xlarge
     instance_tags: {}                    # specify custom tags for the EC2 instances here
-    volume_type: standard                # one of gp2, io1, st1, sc1, or standard (default).
+    volume_type: standard                # one of gp3, gp2, io1, st1, sc1, or standard (default).
     volume_tags: {}                      # specify custom tags for the volume tags here (if empty, will apply the same tags as the corresponding instance)
     root_device_name: '/dev/sda1'        #
     availability_zone:                   # the availability zone where the instances will be created (if not set, aws will pick a default one).


### PR DESCRIPTION
I propose that future benchmarks should swap from `m5` to `m6i` AWS instances.

`m6i` instances are the next generation of CPU instances and offer superior performance for very similar price.

`m6i.2xlarge` Geekbench Result: https://browser.geekbench.com/v5/cpu/18064421
`m5.2xlarge` Geekbench Result: https://browser.geekbench.com/v5/cpu/17423989

These results showcase `m6i` single core performance is 43% faster than `m5`.
Overall multi-core performance showcase `m6i` is 36% faster than `m5`.

My experiments show that AutoGluon trains ~40% faster on `m6i` than on `m5`. Notably, this also improves inference speed by a similar amount. I expect that these speedups will be similar for all frameworks, since it is a generic CPU speedup.

To match the compute of `m5` for 1 hour, we only need to train for ~43 minutes on `m6i`.

At time of writing, [on-demand price](https://aws.amazon.com/ec2/pricing/on-demand/) on US East 2 (Ohio) Region for `m6i` and `m5` are identical:

```
Instance name | On-Demand hourly rate | vCPU | Memory | Storage | Network performance
-- | -- | -- | -- | -- | --
m5.2xlarge | $0.384 | 8 | 32 GiB | EBS Only | Up to 10 Gigabit
m6i.2xlarge | $0.384 | 8 | 32 GiB | EBS Only | Up to 12500 Megabit
-- | -- | -- | -- | -- | --
```

At time of writing, [spot pricing](https://aws.amazon.com/ec2/spot/pricing/) on US East 2 (Ohio) are nearly identical:

```
m5.2xlarge | $0.0812 per Hour
m6i.2xlarge | $0.0858 per Hour
```

I think this points to `m6i` as being the cost efficient instance for future benchmarks.
