### PR TITLE
Switch to using Python 3.8 instead of Python 3.7

### DIFF
--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -88,7 +88,7 @@ openml:                # configuration namespace for openML.
 
 versions:              # configuration namespace for versions enforcement (libraries versions are usually enforced in requirements.txt for the app and for each framework).
   pip:
-  python: 3.7          # the Python minor version that will be used by the application in containers and cloud instances, , also used as a based version for virtual environments created for each framework.
+  python: 3.8          # the Python minor version that will be used by the application in containers and cloud instances, , also used as a based version for virtual environments created for each framework.
 
 container: &container          # parent configuration namespace for container modes.
   force_branch: true           # set to true if image can only be built from a clean branch, with same tag as defined in `project_repository`.


### PR DESCRIPTION
Python 3.7 is no longer supported by Python, and some frameworks such as AutoGluon only support Python 3.8+ in their latest releases. Further, many packages such as scikit-learn, pandas, numpy, etc. no longer support Python 3.7.

I'd recommend AMLB use Python 3.8 or Python 3.9 as the new default. (I've tested setting Python 3.9, works out of the box with AutoGluon).