### PR TITLE
Add `flaml_benchmark`

### DIFF
--- a/amlb/frameworks/definitions.py
+++ b/amlb/frameworks/definitions.py
@@ -101,6 +101,9 @@ def _add_default_setup_env(framework):
 
 
 def _add_default_setup_args(framework):
+    if "setup_args" in framework and isinstance(framework.setup_args, list):
+        return
+
     if "setup_args" in framework and isinstance(framework.setup_args, str):
         framework.setup_args = [framework.setup_args]
     else:

--- a/frameworks/flaml/setup.sh
+++ b/frameworks/flaml/setup.sh
@@ -21,7 +21,7 @@ fi
 
 
 if [[ "$VERSION" == "stable" ]]; then
-    PIP install --no-cache-dir -U ${PKG}${OPTIONALS}
+    PIP install --no-cache-dir -U "${PKG}${OPTIONALS}<2"
 elif [[ "$VERSION" =~ ^[0-9] ]]; then
     PIP install --no-cache-dir -U ${PKG}${OPTIONALS}==${VERSION}
 else

--- a/frameworks/flaml/setup.sh
+++ b/frameworks/flaml/setup.sh
@@ -3,22 +3,34 @@ HERE=$(dirname "$0")
 VERSION=${1:-"stable"}
 REPO=${2:-"https://github.com/microsoft/FLAML.git"}
 PKG=${3:-"flaml"}
-if [[ "$VERSION" == "latest" ]]; then
-    VERSION="main"
-fi
+
 
 . ${HERE}/../shared/setup.sh ${HERE} true
 
+if [[ "$VERSION" == "latest" ]]; then
+    VERSION="main"
+    OPTIONALS=""
+fi
+
+if [[ "$VERSION" == "benchmark" ]]; then
+    VERSION="stable"
+    OPTIONALS="[catboost]"
+else
+    PIP uninstall -y catboost
+fi
+
+
 if [[ "$VERSION" == "stable" ]]; then
-    PIP install --no-cache-dir -U ${PKG}
+    PIP install --no-cache-dir -U ${PKG}${OPTIONALS}
 elif [[ "$VERSION" =~ ^[0-9] ]]; then
-    PIP install --no-cache-dir -U ${PKG}==${VERSION}
+    PIP install --no-cache-dir -U ${PKG}${OPTIONALS}==${VERSION}
 else
 #    PIP install --no-cache-dir -e git+${REPO}@${VERSION}#egg=${PKG}
     TARGET_DIR="${HERE}/lib/${PKG}"
     rm -Rf ${TARGET_DIR}
     git clone --depth 1 --single-branch --branch ${VERSION} --recurse-submodules ${REPO} ${TARGET_DIR}
-    PIP install -U -e ${TARGET_DIR}
+    PIP install -U -e ${TARGET_DIR}${OPTIONALS}
 fi
 
 PY -c "from flaml import __version__; print(__version__)" >> "${HERE}/.setup/installed"
+echo ${OPTIONALS} >> "${HERE}/.setup/installed"

--- a/resources/frameworks_stable.yaml
+++ b/resources/frameworks_stable.yaml
@@ -36,6 +36,16 @@ autosklearn2:
 AutoWEKA:
   version: 'stable'
 
+
+flaml:
+  version: 'stable'
+
+
+flaml_benchmark:
+  extends: flaml
+  setup_args: ['stable', 'https://github.com/microsoft/FLAML.git', 'flaml', ' benchmark']
+
+
 GAMA:
   version: 'stable'
 

--- a/resources/frameworks_stable.yaml
+++ b/resources/frameworks_stable.yaml
@@ -43,8 +43,7 @@ flaml:
 
 flaml_benchmark:
   extends: flaml
-  setup_args: ['stable', 'https://github.com/microsoft/FLAML.git', 'flaml', ' benchmark']
-
+  version: "benchmark"
 
 GAMA:
   version: 'stable'


### PR DESCRIPTION
Supersedes #414

todo: add a check that `flaml` can't be invoked if `flaml_benchmark` is already installed (it is currently not possible to switch behavior just based on hyperparameter configuration).