### PR TITLE
Add option to configure for multi objective optimization

### DIFF
--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -435,7 +435,9 @@ class TaskConfig:
         super().__setattr__(name, value)
 
     def __json__(self):
-        return self.__dict__
+        d = self.__dict__
+        d["evaluation_metrics"] = self.evaluation_metrics
+        return d
 
     def __repr__(self):
         return repr_def(self)


### PR DESCRIPTION
Previously tasks could have multiple metrics defined, e.g. `metric: [acc, balacc, logloss]`,  but this was interpreted as "optimize towards the first element, and evaluate results on all metrics". This PR instead moves to a more explicit model:
 each task has now has `optimization_metrics` and `evaluation_metrics`. 

The `optimization_metrics` define which metrics should be forwarded to the AutoML framework to be used during optimization. If an AutoML framework does not support multi-objective optimization, the integration script should issue a warning but proceed with single objective optimization towards the first metric in the list. 

The `evaluation_metrics` define any _additional_ metrics which should be calculated on the produced predictions. The model will always also be evaluated on `optimization_metrics` (there is no need to put a metric in both lists). `evaluation_metrics` are optional.

The score summary will now contain tuples under the `result` and `metric` columns.
```
Summing up scores for current run:
             id task  fold         framework constraint                                    result         metric  duration      seed
openml.org/t/59 iris     0 constantpredictor       test (0.3333333333333333, -1.0986122886681096) (acc, logloss)     0.100 858693182
openml.org/t/59 iris     1 constantpredictor       test (0.3333333333333333, -1.0986122886681096) (acc, logloss)     0.008 858693183
```
 
 TODO:
  - [ ] update the default config
  - [ ] update the docs
  - [ ] update the existing integration scripts
  - [ ] evaluate how much backwards compatability I want to add. currently tasks are automatically converted to the new format, even if the old format is used, but the results are always shown in the new format.