### PR TITLE
Measure inference time

### DIFF
--- a/.github/workflows/run_all_frameworks.yml
+++ b/.github/workflows/run_all_frameworks.yml
@@ -156,6 +156,6 @@ jobs:
     - name: Run ${{ matrix.framework }} on ${{ matrix.task }}
       run: |
         source venv/bin/activate
-        python runbenchmark.py ${{ matrix.framework }} ${{ matrix.benchmark }} test -f 0 -t ${{ matrix.task }} -e -Xinference_time_measurements.enabled=False
+        python runbenchmark.py ${{ matrix.framework }} ${{ matrix.benchmark }} test -f 0 -t ${{ matrix.task }} -e
       env:
         GITHUB_PAT: ${{ secrets.PUBLIC_ACCESS_GITHUB_PAT }}

--- a/.github/workflows/run_all_frameworks.yml
+++ b/.github/workflows/run_all_frameworks.yml
@@ -156,6 +156,6 @@ jobs:
     - name: Run ${{ matrix.framework }} on ${{ matrix.task }}
       run: |
         source venv/bin/activate
-        python runbenchmark.py ${{ matrix.framework }} ${{ matrix.benchmark }} test -f 0 -t ${{ matrix.task }} -e
+        python runbenchmark.py ${{ matrix.framework }} ${{ matrix.benchmark }} test -f 0 -t ${{ matrix.task }} -e --Xinference_time_measurements.enabled=False
       env:
         GITHUB_PAT: ${{ secrets.PUBLIC_ACCESS_GITHUB_PAT }}

--- a/.github/workflows/run_all_frameworks.yml
+++ b/.github/workflows/run_all_frameworks.yml
@@ -156,6 +156,6 @@ jobs:
     - name: Run ${{ matrix.framework }} on ${{ matrix.task }}
       run: |
         source venv/bin/activate
-        python runbenchmark.py ${{ matrix.framework }} ${{ matrix.benchmark }} test -f 0 -t ${{ matrix.task }} -e --Xinference_time_measurements.enabled=False
+        python runbenchmark.py ${{ matrix.framework }} ${{ matrix.benchmark }} test -f 0 -t ${{ matrix.task }} -e -Xinference_time_measurements.enabled=False
       env:
         GITHUB_PAT: ${{ secrets.PUBLIC_ACCESS_GITHUB_PAT }}

--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -404,8 +404,11 @@ class TaskConfig:
         if name == 'metrics':
             self.metric = value[0] if isinstance(value, list) else value
         elif name == 'max_runtime_seconds':
-            self.job_timeout_seconds = min(value * 2,
-                                           value + rconfig().benchmarks.overhead_time_seconds)
+            inference_time_extension = 0
+            if rconfig().inference_time_measurements.enabled:
+                inference_time_extension = rconfig().inference_time_measurements.additional_job_time
+            self.job_timeout_seconds = min(value * 2 + inference_time_extension,
+                                           value + rconfig().benchmarks.overhead_time_seconds + inference_time_extension)
         super().__setattr__(name, value)
 
     def __json__(self):

--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -381,7 +381,7 @@ class TaskConfig:
 
     def __init__(self, name, fold, metrics, seed,
                  max_runtime_seconds, cores, max_mem_size_mb, min_vol_size_mb,
-                 input_dir, output_dir):
+                 input_dir, output_dir, measure_inference_time: bool = False):
         self.framework = None
         self.framework_params = None
         self.framework_version = None
@@ -397,6 +397,7 @@ class TaskConfig:
         self.input_dir = input_dir
         self.output_dir = output_dir
         self.output_predictions_file = os.path.join(output_dir, "predictions.csv")
+        self.measure_inference_time = measure_inference_time
         self.ext = ns()  # used if frameworks require extra config points
 
     def __setattr__(self, name, value):
@@ -477,6 +478,7 @@ class BenchmarkTask:
             min_vol_size_mb=task_def.min_vol_size_mb,
             input_dir=rconfig().input_dir,
             output_dir=benchmark.output_dirs.session,
+            measure_inference_time=rconfig().inference_time_measurements.enabled,
         )
         # allowing to override some task parameters through command line, e.g.: -Xt.max_runtime_seconds=60
         if rconfig()['t'] is not None:

--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -96,7 +96,8 @@ class OpenmlDataset(Dataset):
     def inference_subsample_files(self, fmt: str) -> list[Tuple[int, str]]:
         return [
             (n, str(self._inference_subsample(fmt=fmt, n=n)))
-            for n in [1, 1000, 10_000]
+            for n in rconfig().inference_time_measurements.batch_sizes
+            for _ in range(rconfig().inference_time_measurements.repeats)
         ]
 
     @profile(logger=log)

--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -94,6 +94,14 @@ class OpenmlDataset(Dataset):
         return self._test
 
     def inference_subsample_files(self, fmt: str) -> list[Tuple[int, str]]:
+        """Generates n subsamples of size k from the test dataset in `fmt` data format.
+
+        We measure the inference time of the models for various batch sizes
+        (number of rows). We generate config.inference_time_measurements.repeats
+        subsamples for each of the config.inference_time_measurements.batch_sizes.
+        These subsamples are stored to file in the `fmt` format (parquet, arff, or csv).
+        The function returns a list of tuples of (batch size, file path).
+        """
         seed = rget().seed(self.fold)
         return [
             (n, str(self._inference_subsample(fmt=fmt, n=n, seed=seed + i)))
@@ -106,9 +114,6 @@ class OpenmlDataset(Dataset):
         """ Write subset of `n` samples from the test split to disk in `fmt` format """
         # Just a hack for now, the splitters all work specifically with openml tasks.
         # The important thing is that we split to disk and can load it later.
-        if fmt not in ["csv", "arff", "parquet"]:
-            msg = f"{fmt=}, but must be one of 'csv', 'arff', or 'parquet'."
-            raise ValueError(msg)
 
         # We should consider taking a stratified sample if n is large enough,
         # inference time might differ based on class
@@ -131,6 +136,9 @@ class OpenmlDataset(Dataset):
             )
         elif fmt == "parquet":
             subsample.to_parquet(subsample_path)
+        else:
+            msg = f"{fmt=}, but must be one of 'csv', 'arff', or 'parquet'."
+            raise ValueError(msg)
 
         return subsample_path
 

--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -125,7 +125,7 @@ class OpenmlDataset(Dataset):
 
         _, test_path = self._get_split_paths()
         test_path = pathlib.Path(test_path)
-        subsample_path = test_path.parent / f"{test_path.stem}_{n}.{fmt}"
+        subsample_path = test_path.parent / f"{test_path.stem}_{n}_{seed}.{fmt}"
         if fmt == "csv":
             subsample.to_csv(subsample_path, header=True, index=False)
         elif fmt == "arff":

--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -93,6 +93,12 @@ class OpenmlDataset(Dataset):
         self._ensure_split_created()
         return self._test
 
+    def inference_subsample_files(self, fmt: str) -> list[Tuple[int, str]]:
+        return [
+            (n, str(self._inference_subsample(fmt=fmt, n=n)))
+            for n in [1, 1000, 10_000]
+        ]
+
     @profile(logger=log)
     def _inference_subsample(self, fmt: str, n: int) -> pathlib.Path:
         """ Write subset of `n` samples from the test split to disk in `fmt` format """

--- a/amlb/results.py
+++ b/amlb/results.py
@@ -448,7 +448,7 @@ class TaskResult:
         if inference_times := Namespace.get(meta_result, "inference_times"):
             for data_type, measurements in Namespace.dict(inference_times).items():
                 for n_samples, measured_times in Namespace.dict(measurements).items():
-                    entry[f"infer_batch_size_{data_type}_{n_samples}"] = np.mean(measured_times)
+                    entry[f"infer_batch_size_{data_type}_{n_samples}"] = np.median(measured_times)
         result = self.get_result() if result is None else result
 
         scoring_errors = []

--- a/amlb/results.py
+++ b/amlb/results.py
@@ -447,7 +447,7 @@ class TaskResult:
 
         if inference_times := Namespace.get(meta_result, "inference_times"):
             for n_samples, measured_times in Namespace.dict(inference_times).items():
-                entry[f"inference_{n_samples}_rows"] = np.mean(measured_times)
+                entry[f"infer_batch_size_{n_samples}"] = np.mean(measured_times)
         result = self.get_result() if result is None else result
 
         scoring_errors = []

--- a/amlb/results.py
+++ b/amlb/results.py
@@ -446,8 +446,9 @@ class TaskResult:
             entry[m] = meta_result[m] if m in meta_result else nan
 
         if inference_times := Namespace.get(meta_result, "inference_times"):
-            for n_samples, measured_times in Namespace.dict(inference_times).items():
-                entry[f"infer_batch_size_{n_samples}"] = np.mean(measured_times)
+            for data_type, measurements in Namespace.dict(inference_times).items():
+                for n_samples, measured_times in Namespace.dict(measurements).items():
+                    entry[f"infer_batch_size_{data_type}_{n_samples}"] = np.mean(measured_times)
         result = self.get_result() if result is None else result
 
         scoring_errors = []

--- a/amlb/results.py
+++ b/amlb/results.py
@@ -444,6 +444,10 @@ class TaskResult:
         required_meta_res = ['training_duration', 'predict_duration', 'models_count']
         for m in required_meta_res:
             entry[m] = meta_result[m] if m in meta_result else nan
+
+        if inference_times := Namespace.get(meta_result, "inference_times"):
+            for n_samples, measured_times in Namespace.dict(inference_times).items():
+                entry[f"inference_{n_samples}_rows"] = np.mean(measured_times)
         result = self.get_result() if result is None else result
 
         scoring_errors = []
@@ -473,7 +477,7 @@ class TaskResult:
         entry.info = result.info
         if scoring_errors:
             entry.info = "; ".join(filter(lambda it: it, [entry.info, *scoring_errors]))
-        entry |= Namespace({k: v for k, v in meta_result if k not in required_meta_res})
+        entry |= Namespace({k: v for k, v in meta_result if k not in required_meta_res and k != "inference_times"})
         log.info("Metric scores: %s", entry)
         return entry
 

--- a/amlb/runners/docker.py
+++ b/amlb/runners/docker.py
@@ -116,7 +116,7 @@ class DockerBenchmark(ContainerBenchmark):
         log.info(f"Successfully published docker image {image}.")
 
     def _generate_script(self, custom_commands):
-        docker_content = """FROM ubuntu:18.04
+        docker_content = """FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update

--- a/frameworks/AutoGluon/__init__.py
+++ b/frameworks/AutoGluon/__init__.py
@@ -25,7 +25,8 @@ def run_autogluon_tabular(dataset: Dataset, config: TaskConfig):
             name=dataset.target.name,
             classes=dataset.target.values
         ),
-        problem_type=dataset.type.name  # AutoGluon problem_type is using same names as amlb.data.DatasetType
+        problem_type=dataset.type.name,  # AutoGluon problem_type is using same names as amlb.data.DatasetType
+        inference_subsample_files=dataset.inference_subsample_files(fmt="parquet"),
     )
 
     return run_in_venv(__file__, "exec.py",

--- a/frameworks/AutoGluon/exec.py
+++ b/frameworks/AutoGluon/exec.py
@@ -77,9 +77,14 @@ def run(dataset, config):
         return predictor.predict(data, as_pandas=False), None
 
     infer = inference_time_classification if is_classification else inference_time_regression
-    inference_times = None
+    inference_times = {}
     if config.measure_inference_time:
-        inference_times = measure_inference_times(infer, dataset.inference_subsample_files)
+        inference_times["file"] = measure_inference_times(infer, dataset.inference_subsample_files)
+        test_data = pd.read_parquet(dataset.test.path)
+        inference_times["df"] = measure_inference_times(
+            infer,
+            [(1, test_data.sample(1, random_state=i)) for i in range(100)],
+        )
 
     test_data = TabularDataset(test_path)
     with Timer() as predict:

--- a/frameworks/AutoGluon/exec.py
+++ b/frameworks/AutoGluon/exec.py
@@ -77,7 +77,9 @@ def run(dataset, config):
         return predictor.predict(data, as_pandas=False), None
 
     infer = inference_time_classification if is_classification else inference_time_regression
-    inference_times = measure_inference_times(infer, dataset.inference_subsample_files)
+    inference_times = None
+    if config.measure_inference_time:
+        inference_times = measure_inference_times(infer, dataset.inference_subsample_files)
 
     test_data = TabularDataset(test_path)
     with Timer() as predict:

--- a/frameworks/GAMA/__init__.py
+++ b/frameworks/GAMA/__init__.py
@@ -22,6 +22,7 @@ def run(dataset: Dataset, config: TaskConfig):
             X=dataset.test.X,
             y=dataset.test.y
         ),
+        inference_subsample_files=dataset.inference_subsample_files(fmt="parquet"),
     )
     options = dict(
         serialization=dict(sparse_dataframe_deserialized_format='dense')

--- a/frameworks/GAMA/exec.py
+++ b/frameworks/GAMA/exec.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sys
 import tempfile as tmp
+from typing import Union
 
 import pandas as pd
 
@@ -79,7 +80,7 @@ def run(dataset, config):
         gama_automl.fit(X_train, y_train)
 
     log.info('Predicting on the test set.')
-    def infer(data):
+    def infer(data: Union[str, pd.DataFrame]):
         test_data = pd.read_parquet(data) if isinstance(data, str) else data
         predict_fn = gama_automl.predict_proba if is_classification else gama_automl.predict
         return predict_fn(test_data)

--- a/frameworks/H2OAutoML/__init__.py
+++ b/frameworks/H2OAutoML/__init__.py
@@ -8,25 +8,16 @@ def setup(*args, **kwargs):
     call_script_in_same_dir(__file__, "setup.sh", *args, **kwargs)
 
 
-# def version():
-#     from frameworks.shared.caller import run_cmd_in_venv
-#     out, err = run_cmd_in_venv(__file__, """{py} -c "from h2o import __version__; print(__version__)" | grep "^\d\." """)
-#     if err:
-#         raise ValueError(err)
-#     return out
-
-
 def run(dataset: Dataset, config: TaskConfig):
     from frameworks.shared.caller import run_in_venv
-
     data = dict(
         train=dict(path=dataset.train.path),
         test=dict(path=dataset.test.path),
         target=dict(index=dataset.target.index),
         domains=dict(cardinalities=[0 if f.values is None else len(f.values) for f in dataset.features]),
-        format=dataset.train.format
+        format=dataset.train.format,
+        inference_subsample_files=dataset.inference_subsample_files(fmt=dataset.train.format, with_labels=True),
     )
-
     config.ext.monitoring = rconfig().monitoring
     return run_in_venv(__file__, "exec.py",
                        input_data=data, dataset=dataset, config=config)

--- a/frameworks/H2OAutoML/exec.py
+++ b/frameworks/H2OAutoML/exec.py
@@ -1,6 +1,8 @@
 import contextlib
 import logging
 import os
+import pathlib
+
 import psutil
 import re
 
@@ -10,7 +12,8 @@ import pandas as pd
 import h2o
 from h2o.automl import H2OAutoML
 
-from frameworks.shared.callee import FrameworkError, call_run, output_subdir, result
+from frameworks.shared.callee import FrameworkError, call_run, output_subdir, result, \
+    measure_inference_times
 from frameworks.shared.utils import Monitoring, Namespace as ns, Timer, clean_dir, touch, zip_path
 
 log = logging.getLogger(__name__)
@@ -115,6 +118,16 @@ def run(dataset, config):
         if not aml.leader:
             raise FrameworkError("H2O could not produce any model in the requested time.")
 
+        def infer(path: str):
+            filename = pathlib.Path(path).name
+            batch = h2o.import_file(path, destination_frame=frame_name(filename, config), **import_kwargs)
+            return aml.predict(batch)
+
+        inference_times = None
+        if config.measure_inference_time:
+            inference_times = measure_inference_times(infer,
+                                                      dataset.inference_subsample_files)
+
         with Timer() as predict:
             preds = aml.predict(test)
 
@@ -129,7 +142,8 @@ def run(dataset, config):
             probabilities_labels=preds.probabilities_labels,
             models_count=len(aml.leaderboard),
             training_duration=training.duration,
-            predict_duration=predict.duration
+            predict_duration=predict.duration,
+            inference_times=inference_times,
         )
 
     finally:

--- a/frameworks/RandomForest/__init__.py
+++ b/frameworks/RandomForest/__init__.py
@@ -23,7 +23,8 @@ def run(dataset: Dataset, config: TaskConfig):
         test=dict(
             X=X_test,
             y=y_test
-        )
+        ),
+        inference_subsample_files=dataset.inference_subsample_files(fmt="parquet"),
     )
 
     return run_in_venv(__file__, "exec.py",

--- a/frameworks/TPOT/__init__.py
+++ b/frameworks/TPOT/__init__.py
@@ -21,7 +21,8 @@ def run(dataset: Dataset, config: TaskConfig):
         test=dict(
             X=X_test,
             y=y_test
-        )
+        ),
+        inference_subsample_files=dataset.inference_subsample_files(fmt="parquet"),
     )
 
     def process_results(results):

--- a/frameworks/TPOT/exec.py
+++ b/frameworks/TPOT/exec.py
@@ -80,7 +80,10 @@ def run(dataset, config):
                 return tpot.predict(data)
         return tpot.predict(data)
 
-    inference_times = measure_inference_times(infer, dataset.inference_subsample_files)
+    inference_times = None
+    if config.measure_inference_time:
+        log.info("TPOT inference time measurements exclude preprocessing time of AMLB.")
+        inference_times = measure_inference_times(infer, dataset.inference_subsample_files)
 
     try:
         probabilities = tpot.predict_proba(X_test) if is_classification else None

--- a/frameworks/TunedRandomForest/__init__.py
+++ b/frameworks/TunedRandomForest/__init__.py
@@ -21,7 +21,8 @@ def run(dataset: Dataset, config: TaskConfig):
         test=dict(
             X=X_test,
             y=y_test
-        )
+        ),
+        inference_subsample_files=dataset.inference_subsample_files(fmt="parquet"),
     )
 
     return run_in_venv(__file__, "exec.py",

--- a/frameworks/TunedRandomForest/exec.py
+++ b/frameworks/TunedRandomForest/exec.py
@@ -21,7 +21,7 @@ import pandas as pd
 import sklearn
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 
-from frameworks.shared.callee import call_run, result
+from frameworks.shared.callee import call_run, result, measure_inference_times
 from frameworks.shared.utils import Timer
 from custom_validate import cross_validate
 
@@ -211,6 +211,19 @@ def run(dataset, config):
         predictions = rf.predict(X_test)
     probabilities = rf.predict_proba(X_test) if is_classification else None
 
+    def infer(data):
+        data = pd.read_parquet(data) if isinstance(data, str) else data
+        return rf.predict(data)
+
+    inference_times = {}
+    if config.measure_inference_time:
+        inference_times["file"] = measure_inference_times(infer, dataset.inference_subsample_files)
+        test_data = X_test if isinstance(X_test, pd.DataFrame) else pd.DataFrame(X_test)
+        inference_times["df"] = measure_inference_times(
+            infer,
+            [(1, test_data.sample(1, random_state=i)) for i in range(100)],
+        )
+
     return result(
         output_file=config.output_predictions_file,
         predictions=predictions,
@@ -219,7 +232,8 @@ def run(dataset, config):
         target_is_encoded=is_classification,
         models_count=len(rf),
         training_duration=training.duration,
-        predict_duration=predict.duration
+        predict_duration=predict.duration,
+        inference_times=inference_times,
     )
 
 

--- a/frameworks/autosklearn/__init__.py
+++ b/frameworks/autosklearn/__init__.py
@@ -21,7 +21,8 @@ def run(dataset: Dataset, config: TaskConfig):
             X=X_test,
             y=y_test
         ),
-        predictors_type=['Numerical' if p.is_numerical() else 'Categorical' for p in dataset.predictors]
+        predictors_type=['Numerical' if p.is_numerical() else 'Categorical' for p in dataset.predictors],
+        inference_subsample_files=dataset.inference_subsample_files(fmt="parquet"),
     )
 
     return run_in_venv(__file__, "exec.py",

--- a/frameworks/autosklearn/__init__.py
+++ b/frameworks/autosklearn/__init__.py
@@ -10,16 +10,18 @@ def setup(*args, **kwargs):
 def run(dataset: Dataset, config: TaskConfig):
     from frameworks.shared.caller import run_in_venv
 
-    X_train, X_test = dataset.train.X_enc, dataset.test.X_enc
-    y_train, y_test = unsparsify(dataset.train.y_enc, dataset.test.y_enc)
     data = dict(
         train=dict(
-            X=X_train,
-            y=y_train
+            X=dataset.train.X,
+            y=dataset.train.y,
+            X_enc=dataset.train.X_enc,
+            y_enc=unsparsify(dataset.train.y_enc),
         ),
         test=dict(
-            X=X_test,
-            y=y_test
+            X=dataset.test.X,
+            y=dataset.test.y,
+            X_enc=dataset.test.X_enc,
+            y_enc=unsparsify(dataset.test.y_enc),
         ),
         predictors_type=['Numerical' if p.is_numerical() else 'Categorical' for p in dataset.predictors],
         inference_subsample_files=dataset.inference_subsample_files(fmt="parquet"),

--- a/frameworks/constantpredictor/exec.py
+++ b/frameworks/constantpredictor/exec.py
@@ -31,12 +31,18 @@ def run(dataset: Dataset, config: TaskConfig):
         predictions = predictor.predict(X_test)
     probabilities = predictor.predict_proba(X_test) if is_classification else None
 
-    def infer(path):
-        data = pd.read_parquet(path)
+    def infer(data):
+        data = pd.read_parquet(data) if isinstance(data, str) else data
         return predictor.predict(data)
 
     inference_times = {}
-    inference_times["file"] = measure_inference_times(infer, dataset.inference_subsample_files(fmt="parquet"))
+    if config.measure_inference_time:
+        inference_times["file"] = measure_inference_times(infer, dataset.inference_subsample_files(fmt="parquet"))
+        test_data = X_test if isinstance(X_test, pd.DataFrame) else pd.DataFrame(X_test)
+        inference_times["df"] = measure_inference_times(
+            infer,
+            [(1, test_data.sample(1, random_state=i)) for i in range(100)],
+        )
 
     save_predictions(dataset=dataset,
                      output_file=config.output_predictions_file,

--- a/frameworks/constantpredictor/exec.py
+++ b/frameworks/constantpredictor/exec.py
@@ -35,7 +35,8 @@ def run(dataset: Dataset, config: TaskConfig):
         data = pd.read_parquet(path)
         return predictor.predict(data)
 
-    inference_times = measure_inference_times(infer, dataset.inference_subsample_files(fmt="parquet"))
+    inference_times = {}
+    inference_times["file"] = measure_inference_times(infer, dataset.inference_subsample_files(fmt="parquet"))
 
     save_predictions(dataset=dataset,
                      output_file=config.output_predictions_file,

--- a/frameworks/flaml/__init__.py
+++ b/frameworks/flaml/__init__.py
@@ -17,7 +17,8 @@ def run(dataset, config):
             X=dataset.test.X,
             y=dataset.test.y
         ),
-        problem_type=dataset.type.name
+        problem_type=dataset.type.name,
+        inference_subsample_files=dataset.inference_subsample_files(fmt="parquet"),
     )
     options = dict(
         serialization=dict(sparse_dataframe_deserialized_format='dense')

--- a/frameworks/flaml/exec.py
+++ b/frameworks/flaml/exec.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import Union
 
 import pandas as pd
 from flaml import AutoML, __version__
@@ -15,7 +16,6 @@ def run(dataset, config):
     log.info(f"\n**** FLAML [v{__version__}] ****\n")
 
     X_train, y_train = dataset.train.X, dataset.train.y.squeeze()
-    X_test, y_test = dataset.test.X, dataset.test.y.squeeze()
 
     is_classification = config.type == 'classification'
     time_budget = config.max_runtime_seconds
@@ -52,16 +52,21 @@ def run(dataset, config):
                 log_file_name= flaml_log_file_name,
                 time_budget=time_budget, **training_params)
 
-    def infer(path: str):
-        data = pd.read_parquet(path)
+    def infer(data: Union[str, pd.DataFrame]):
+        data = pd.read_parquet(data) if isinstance(data, str) else data
         predict_fn = aml.predict_proba if is_classification else aml.predict
         return predict_fn(data)
 
-    inference_times = None
+    inference_times = {}
     if config.measure_inference_time:
-        inference_times = measure_inference_times(infer, dataset.inference_subsample_files)
+        inference_times["file"] = measure_inference_times(infer, dataset.inference_subsample_files)
+        inference_times["df"] = measure_inference_times(
+            infer,
+            [(1, dataset.test.X.sample(1, random_state=i)) for i in range(100)],
+        )
 
     with Timer() as predict:
+        X_test, y_test = dataset.test.X, dataset.test.y.squeeze()
         predictions = aml.predict(X_test)
     probabilities = aml.predict_proba(X_test) if is_classification else None
     labels = None

--- a/frameworks/lightautoml/__init__.py
+++ b/frameworks/lightautoml/__init__.py
@@ -21,7 +21,8 @@ def run(dataset: Dataset, config: TaskConfig):
         target=dict(
             name=dataset.target.name,
         ),
-        problem_type=dataset.type.name
+        problem_type=dataset.type.name,
+        inference_subsample_files=dataset.inference_subsample_files(fmt="parquet"),
     )
     options = dict(
         serialization=dict(sparse_dataframe_deserialized_format='dense')

--- a/frameworks/mljarsupervised/__init__.py
+++ b/frameworks/mljarsupervised/__init__.py
@@ -19,7 +19,8 @@ def run(dataset: Dataset, config: TaskConfig):
             X=dataset.test.X,
             y=dataset.test.y
         ),
-        problem_type=dataset.type.name
+        problem_type=dataset.type.name,
+        inference_subsample_files=dataset.inference_subsample_files(fmt="parquet"),
     )
     options = dict(
         serialization=dict(sparse_dataframe_deserialized_format='dense')

--- a/frameworks/mljarsupervised/exec.py
+++ b/frameworks/mljarsupervised/exec.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import logging
+from typing import Union
 
 import numpy as np
 import matplotlib
@@ -45,7 +46,6 @@ def run(dataset, config):
     }
 
     X_train, y_train = dataset.train.X, dataset.train.y.squeeze()
-    X_test, y_test = dataset.test.X, dataset.test.y.squeeze()
 
     automl = AutoML(
         results_path=results_path,
@@ -60,16 +60,20 @@ def run(dataset, config):
         automl.fit(X_train, y_train)
 
 
-    def infer(path: str):
-        batch = pd.read_parquet(path)
+    def infer(data: Union[str, pd.DataFrame]):
+        batch = pd.read_parquet(data) if isinstance(data, str) else data
         return automl.predict_all(batch)
 
-    inference_times = None
+    inference_times = {}
     if config.measure_inference_time:
-        inference_times = measure_inference_times(infer,
-                                                  dataset.inference_subsample_files)
+        inference_times["file"] = measure_inference_times(infer, dataset.inference_subsample_files)
+        inference_times["df"] = measure_inference_times(
+            infer,
+            [(1, dataset.test.X.sample(1, random_state=i)) for i in range(100)],
+        )
 
     with Timer() as predict:
+        X_test, y_test = dataset.test.X, dataset.test.y.squeeze()
         preds = automl.predict_all(X_test)
 
     predictions, probabilities, probabilities_labels = None, None, None

--- a/frameworks/shared/callee.py
+++ b/frameworks/shared/callee.py
@@ -5,7 +5,9 @@ import re
 import signal
 import sys
 from collections import defaultdict
-from typing import Callable, Any, Tuple
+from typing import Callable, Any, Tuple, Union, TypeVar
+
+import pandas as pd
 
 from .utils import InterruptTimeout, Namespace as ns, json_dump, json_loads, kill_proc_tree, touch
 from .utils import deserialize_data, serialize_data, Timer
@@ -95,7 +97,8 @@ def call_run(run_fn):
         res["others"]["inference_times"] = str(inference_file)
     json_dump(res, config.result_file, style='compact')
 
-def measure_inference_times(predict_fn: Callable[[str], Any], files: list[Tuple[int, str]]) -> dict[int, list[float]]:
+DATA_INPUT = TypeVar("DATA_INPUT", bound=Union[str, pd.DataFrame])
+def measure_inference_times(predict_fn: Callable[[DATA_INPUT], Any], files: list[Tuple[int, DATA_INPUT]]) -> dict[int, list[float]]:
     inference_times = defaultdict(list)
     for subsample_size, subsample_path in files:
         with Timer() as predict:

--- a/frameworks/shared/callee.py
+++ b/frameworks/shared/callee.py
@@ -98,8 +98,7 @@ def call_run(run_fn):
 def measure_inference_times(predict_fn: Callable[[str], Any], files: list[Tuple[int, str]]) -> dict[int, list[float]]:
     inference_times = defaultdict(list)
     for subsample_size, subsample_path in files:
-        for _ in range(10):
-            with Timer() as predict:
-                predict_fn(subsample_path)
-            inference_times[subsample_size].append(predict.duration)
+        with Timer() as predict:
+            predict_fn(subsample_path)
+        inference_times[subsample_size].append(predict.duration)
     return inference_times

--- a/frameworks/shared/callee.py
+++ b/frameworks/shared/callee.py
@@ -88,6 +88,11 @@ def call_run(run_fn):
         # ensure there's no subprocess left
         kill_proc_tree(include_parent=False, timeout=5)
 
+    inference_measurements = res.get("others", {}).get("inference_times")
+    if inference_measurements:
+        inference_file = pathlib.Path(config.result_file).parent / "inference_times.json"
+        json_dump(inference_measurements, inference_file, style="compact")
+        res["others"]["inference_times"] = str(inference_file)
     json_dump(res, config.result_file, style='compact')
 
 def measure_inference_times(predict_fn: Callable[[str], Any], files: list[Tuple[int, str]]) -> dict[int, list[float]]:

--- a/frameworks/shared/callee.py
+++ b/frameworks/shared/callee.py
@@ -5,12 +5,11 @@ import re
 import signal
 import sys
 from collections import defaultdict
-from typing import Callable, Any, Tuple, Union, TypeVar
-
-import pandas as pd
+from typing import Callable, Any, Tuple, Union, TypeVar, TYPE_CHECKING
 
 from .utils import InterruptTimeout, Namespace as ns, json_dump, json_loads, kill_proc_tree, touch
 from .utils import deserialize_data, serialize_data, Timer
+
 
 log = logging.getLogger(__name__)
 
@@ -97,7 +96,14 @@ def call_run(run_fn):
         res["others"]["inference_times"] = str(inference_file)
     json_dump(res, config.result_file, style='compact')
 
-DATA_INPUT = TypeVar("DATA_INPUT", bound=Union[str, pd.DataFrame])
+try:
+    import pandas as pd
+    DATA_TYPES = Union[str, pd.DataFrame]
+except ImportError:
+    DATA_TYPES = str
+
+DATA_INPUT = TypeVar("DATA_INPUT", bound=DATA_TYPES)
+
 def measure_inference_times(predict_fn: Callable[[DATA_INPUT], Any], files: list[Tuple[int, DATA_INPUT]]) -> dict[int, list[float]]:
     inference_times = defaultdict(list)
     for subsample_size, subsample_path in files:

--- a/frameworks/shared/caller.py
+++ b/frameworks/shared/caller.py
@@ -1,6 +1,7 @@
 import gc
 import logging
 import os
+import pathlib
 import re
 from tempfile import TemporaryDirectory, mktemp
 from typing import List, Optional, Union
@@ -11,6 +12,7 @@ from amlb.benchmark import TaskConfig
 from amlb.data import Dataset
 from amlb.resources import config as rconfig
 from amlb.results import NoResultError, save_predictions
+from amlb.utils import json_dump, Namespace
 
 from .utils import Namespace as ns, Timer, dir_of, run_cmd, json_dumps, json_load, profile
 from .utils import is_serializable_data, deserialize_data, serialize_data
@@ -151,6 +153,13 @@ def run_in_venv(caller_file, script_file: str, *args,
 
         for name in ['predictions', 'truth', 'probabilities', 'optional_columns']:
             res[name] = deserialize_data(res[name], config=ser_config) if res[name] is not None else None
+
+        inference_filepath = Namespace.dict(res.others).get("inference_times")
+        if inference_filepath:
+            inference_times = json_load(inference_filepath)
+            inference_filepath = pathlib.Path(res.output_file).parent / "inference.json"
+            json_dump(inference_times, inference_filepath)
+            res["others"]["inference_times"] = inference_times
 
         if callable(process_results):
             res = process_results(res)

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -88,6 +88,7 @@ inference_time_measurements:  # configuration namespace for performing additiona
   enabled: true
   batch_sizes: [1, 10, 100, 1000, 10000]  # the batch sizes for which inference speed should be measured
   repeats: 100                            # the number of times to repeat the inference measurement for each batch size
+  additional_job_time: 300  # the time in seconds that will be added to the maximum job time if inference time is measured
 
 openml:                # configuration namespace for openML.
   apikey: c1994bdb7ecb3c6f3c8f3b35f4b47f1f

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -84,6 +84,11 @@ results:                 # configuration namespace for the results.csv file.
   global_lock_timeout: 5 # the timeout used to wait for the lock on the global results file.
   incremental_save: true # if true save results after each job., otherwise save results only when all jobs are completed.
 
+inference_time_measurements:  # configuration namespace for performing additional inference time measurements on various batch sizes
+  enabled: true
+  batch_sizes: [1, 10, 100, 1000, 10000]  # the batch sizes for which inference speed should be measured
+  repeats: 100                            # the number of times to repeat the inference measurement for each batch size
+
 openml:                # configuration namespace for openML.
   apikey: c1994bdb7ecb3c6f3c8f3b35f4b47f1f
   infer_dtypes: False

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -85,7 +85,7 @@ results:                 # configuration namespace for the results.csv file.
   incremental_save: true # if true save results after each job., otherwise save results only when all jobs are completed.
 
 inference_time_measurements:  # configuration namespace for performing additional inference time measurements on various batch sizes
-  enabled: true
+  enabled: false
   batch_sizes: [1, 10, 100, 1000, 10000]  # the batch sizes for which inference speed should be measured
   repeats: 100                            # the number of times to repeat the inference measurement for each batch size
   additional_job_time: 300  # the time in seconds that will be added to the maximum job time if inference time is measured


### PR DESCRIPTION
**help wanted:** I am posting this now since it would be nice to have some feedback. I need merge this very soon in order to run experiments on time.

---

This PR introduces improved measurements for inference time, there are two major changes:
 - inference time is now to be measured the same way across frameworks: everything from reading from disk to producing predictions
 - inference time is measured for different dataset sizes, created by sampling with replacement from the test set

A few notes:
 - [x] I think we should allow also a second measurement which measures the inference time based on a Python object input (e.g., dataframe), for frameworks that support that. It would be nice to also know what the inference time is without the overhead of loading the file (which for small batches probably dominates). (edtit: example for autogluon present)
 - [ ] The implementation is probably not ideal. To be quite honest, this touches parts of the benchmark I hadn’t worked with before so I had to adjust as I go. If this is acceptable, I would rather prefer to refactor it later instead.
 - [x] Currently we only use one subsample per inference batch size, we should generate multiple. We should also make the amount of measurements configurable.
 - [x] I would like to also store each individual measurement, not just the aggregate. 
   - [x] This way we can do things like calculate different aggregates (median/mean) and/or exclude some measurements (some models may have a cold-start, which should be excluded from the aggregate).
 - [x] ~I need to add a way to clean up the generated files.~ They are currently cleaned up by virtue of them being stored in the temporary directory (if the framework uses `run_in_venv`). It might be nicer to generate and delete them right when doing the inference measurements in the subprocess, but in that case we need to be able to generate the splits without the `OpenMLDataset` object. Future work.
 
Current implementation’s result file after running `python runbenchmark.py FRAMEWORK -t iris -f 0` for `constantpredictor`, `tpot`,  and `autogluon`:
```
id,task,framework,constraint,fold,type,result,metric,mode,version,params,app_version,utc,duration,training_duration,predict_duration,models_count,seed,info,acc,balacc,logloss,inference_10000_rows,inference_1000_rows,inference_1_rows,models_ensemble_count
openml.org/t/59,iris,constantpredictor,test,0,multiclass,-1.09861,neg_logloss,local,1.2.2,,"dev [measure_inference_time, 71e7a8b]",2023-06-12T09:58:32,0.2,0.0002,4e-05,1,1757794907,,0.333333,0.333333,1.09861,0.00123646,0.00113094,0.00232852,
openml.org/t/59,iris,TPOT,test,0,multiclass,-0.0131854,neg_logloss,local,0.12.0,,"dev [measure_inference_time, 71e7a8b]",2023-06-12T09:59:55,76.4,65.4,0.0002,368,1156006760,,1.0,1.0,0.0131854,0.0196556,0.00544026,0.0176911,
openml.org/t/59,iris,AutoGluon,test,0,multiclass,-0.746956,neg_logloss,local,0.7.0,,"dev [measure_inference_time, 71e7a8b]",2023-06-12T10:00:30,28.4,18.7,0.002,14,2011490481,,0.933333,0.933333,0.746956,0.0672353,0.0116372,0.00261562,2.0
```

Notes:
 - [Measurements for TPOT are inaccurate](https://github.com/openml/automlbenchmark/pull/532#discussion_r1227194852)
 - [We might run into issues for large datasets (many features)](https://github.com/openml/automlbenchmark/pull/532#discussion_r1227203246), for the experiments we will simply (re)run those datasets a more lenient job timeout (or none at all).