### PR TITLE
Update AutoGluon `max_memory` from 0.1 to 0.4 in persist_models

### DIFF
--- a/frameworks/AutoGluon/exec.py
+++ b/frameworks/AutoGluon/exec.py
@@ -68,7 +68,7 @@ def run(dataset, config):
         )
 
     # Persist model in memory that is going to be predicting to get correct inference latency
-    predictor.persist_models('best')
+    predictor.persist_models('best', max_memory=0.4)
 
     def inference_time_classification(data: Union[str, pd.DataFrame]):
         return None, predictor.predict_proba(data, as_multiclass=True)


### PR DESCRIPTION
Updated max_memory to 0.4 as when tested it resulted in no crashes. The 0.1 default is overly conservative. For batch_size=1 in inference, this gives ~2x faster inference speed on average as more frequently models are able to fit into memory using this raised limit.