### PR TITLE
Add `optimize_for_deployment` for AutoGluon_hq

### DIFF
--- a/resources/frameworks_2023Q2.yaml
+++ b/resources/frameworks_2023Q2.yaml
@@ -21,7 +21,7 @@ AutoGluon_hq:
   description: "AutoGluon with 'high_quality' preset provides generally fast inference speed with high accuracy"
   params:
     _save_artifacts: ['leaderboard', 'info']
-    presets: high_quality
+    presets: ['high_quality', 'optimize_for_deployment']
     _leaderboard_test: True
 
 AutoGluon_hq_il001:
@@ -29,7 +29,7 @@ AutoGluon_hq_il001:
   description: "AutoGluon ~3x faster inference at slight performance loss to 'high quality' (self-reported)."
   params:
     _save_artifacts: ['leaderboard', 'info']
-    presets: high_quality
+    presets: ['high_quality', 'optimize_for_deployment']
     _leaderboard_test: True
     infer_limit: 0.01
 


### PR DESCRIPTION
Add `optimize_for_deployment` for AutoGluon_hq

This disables some of the post-fit logic in favor of a more optimized fit process that reduces disk usage by >10x and reduces overall fit time without any compromise to result quality or inference speed.

Not necessarily critical for the upcoming benchmark run, but it will lead to slightly faster training times due to only the necessary models being refit, rather than all models being refit, making it less likely that AutoGluon goes significantly above the time limit.

