### PR TITLE
Docker/permissions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,13 @@
 .git
 
+# files not required for running the benchmark
+.pytest_cache
+amlb_report
+docs
+examples
+reports
+tests
+
 # generated files/folders
 .ipynb_checkpoints
 logs

--- a/amlb/resources.py
+++ b/amlb/resources.py
@@ -282,6 +282,9 @@ def config():
 
 def output_dirs(root, session=None, subdirs=None, create=False):
     root = root if root is not None else '.'
+    if create and not os.path.exists(root):
+        touch(root, as_dir=True)
+
     dirs = Namespace(
         root=root,
         session=os.path.join(root, session) if session is not None else root

--- a/amlb/runners/aws.py
+++ b/amlb/runners/aws.py
@@ -1125,7 +1125,7 @@ runcmd:
   - pip3 install -U awscli wheel
   - aws s3 cp '{s3_input}' /s3bucket/input --recursive
   - aws s3 cp '{s3_user}' /s3bucket/user --recursive
-  - docker run {docker_options} -v /s3bucket/input:/input -v /s3bucket/output:/output -u "0:0" -v /s3bucket/user:/custom --rm {image} {params} -i /input -o /output -u /custom -s skip -Xrun_mode=aws.docker {extra_params}
+  - docker run {docker_options} -v /s3bucket/input:/input -v /s3bucket/output:/output -v /s3bucket/user:/custom --rm {image} {params} -i /input -o /output -u /custom -s skip -Xrun_mode=aws.docker {extra_params}
   - aws s3 cp /s3bucket/output '{s3_output}' --recursive
   #- rm -f /var/lib/cloud/instance/sem/config_scripts_user
 

--- a/amlb/runners/docker.py
+++ b/amlb/runners/docker.py
@@ -168,9 +168,6 @@ VOLUME /custom
 ADD . /bench/
 
 RUN (grep -v '^\\s*#' | xargs -L 1 $PIP install --no-cache-dir) < requirements.txt
-RUN chown -R {username}:{username} /bench
-RUN chown -R {username}:{username} /home/{username}
-USER {username}
 
 RUN $PY {script} {framework} -s only
 {custom_commands}

--- a/amlb/runners/docker.py
+++ b/amlb/runners/docker.py
@@ -31,12 +31,6 @@ class DockerBenchmark(ContainerBenchmark):
         """
         super().__init__(framework_name, benchmark_name, constraint_name)
         self._custom_image_name = rconfig().docker.image
-        self.user = os.getlogin()
-        # For linux specifically, files created within docker are not
-        # automatically owned by the user starting the docker instance.
-        # For Windows permissions are set fine, so we don't need user information.
-        self.userid = None if os.name == 'nt' else os.getuid()
-        self.usergid =  None if os.name == 'nt' else os.getgid()
         self.minimize_instances = rconfig().docker.minimize_instances
         self.container_name = 'docker'
         self.force_branch = rconfig().docker.force_branch
@@ -56,16 +50,18 @@ class DockerBenchmark(ContainerBenchmark):
         custom_dir = rconfig().user_dir
         for d in [in_dir, out_dir, custom_dir]:
             touch(d, as_dir=True)
+
+        run_as = resolve_docker_run_as_option(rconfig().docker.run_as)
         script_extra_params = "--session="  # in combination with `self.output_dirs.session` usage below to prevent creation of 2 sessions locally
         inst_name = f"{self.sid}.{str_sanitize(str_digest(script_params))}"
         cmd = (
-            "docker run --name {name} {options} {run_as_user}"
+            "docker run --name {name} {options} {run_as} "
             "-v {input}:/input -v {output}:/output -v {custom}:/custom "
             "--rm {image} {params} -i /input -o /output -u /custom -s skip -Xrun_mode=docker {extra_params}"
         ).format(
             name=inst_name,
             options=rconfig().docker.run_extra_options,
-            run_as_user='' if os.name == 'nt' else f'-u "{self.userid}:{self.usergid}" ',
+            run_as=run_as,
             input=in_dir,
             output=self.output_dirs.session,
             custom=custom_dir,
@@ -131,8 +127,6 @@ RUN apt-get -y install python{pyv} python{pyv}-venv python{pyv}-dev python3-pip
 RUN apt-get -y install libhdf5-serial-dev
 #RUN update-alternatives --install /usr/bin/python3 python3 $(which python{pyv}) 1
 
-RUN adduser --disabled-password --gecos '' {userid_option} {username}
-RUN adduser {username} sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # aliases for the python system
@@ -187,10 +181,34 @@ CMD ["{framework}", "test"]
             pyv=rconfig().versions.python,
             pipv=rconfig().versions.pip,
             script=rconfig().script,
-            userid_option=f"-uid {self.userid}" if self.userid else '',
-            username=self.user,
         )
 
         touch(self._script)
         with open(self._script, 'w') as file:
             file.write(docker_content)
+
+
+def resolve_docker_run_as_option(option: str) -> str:
+    """ Resolve `docker.run_as` option into the correct `-u` option for `docker run`.
+
+    option, str: one of 'user' (unix only), 'root', 'default', or a valid `-u` option.
+               * 'user': set as `-u $(id -u):$(id -g)`, only on unix systems.
+               * 'root': set as `-u 0:0`
+               * 'default': does not set `-u`
+               * any string that starts with `-u`, which will be directly forwarded.
+
+    For linux specifically, files created within docker are *not always*
+    automatically owned by the user starting the docker instance.
+    We had reports of different behavior even for people running the same OS and Docker.
+    """
+    if option == "default":
+        return ''
+    if option == "root":
+        return '-u 0:0'
+    if option == "user":
+        if os.name == 'nt':
+            raise ValueError("docker.run_as: 'user' is not supported on Windows.")
+        return f'-u "{os.getuid()}:{os.getgid()}"'
+    if option.startswith("-u"):
+        return rconfig().docker.run_as
+    raise ValueError(f"Invalid setting for `docker.run_as`: '{option}'.")

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -114,6 +114,12 @@ container: &container          # parent configuration namespace for container mo
 docker:                        # configuration namespace for docker: it inherits from `container` namespace.
   <<: *container
   run_extra_options: '--shm-size=2048M'
+  run_as: 'default'    # Sets the user inside the docker container (`docker run -u`), one of:
+                       #  * 'user': set as `-u $(id -u):$(id -g)`, only on unix systems.
+                       #  * 'root': set as `-u 0:0`
+                       #  * 'default': does not set `-u`
+                       #  * any string that starts with `-u`, which will be directly forwarded.
+                       # Try this setting if you have problems with permissions in docker.
   build_extra_options: ''
 
 singularity:                   # configuration namespace for docker: it inherits from `container` namespace.


### PR DESCRIPTION
Removes the logic about users and permissions for docker introduced in #495.
Instead, introduces a `docker.run_as` option which can run the docker container as a specific user (root, current unix user, or a specific other user).

The problem with the previous implementation was that it did not work if the docker images were meant to be shared, as the creators uid/gid were embedded in it. I tried to look for a general solution that would work in both cases, but in doing so I found that docker is inconsistent. I had two users, both on `ubuntu 22.04.02` and `docker cb74dfc`, run:
```
mkdir output
docker run -v $(pwd)/output:/output -u 0:0 --entrypoint=/bin/bash ubuntu:22.04 -c "touch /output/a$(date +%H%M%S)"
docker run -v $(pwd)/output:/output -u $(id -u):$(id -g) --entrypoint=/bin/bash ubuntu:22.04 -c "touch /output/b$(date +%H%M%S)"
```
One had the `root` file listed under her own name on the host machine while the second command gave a permission error.
The other had the `root` file listed under `root` on the host machine while the second command created it under his name.
Help is welcome, but until then we'll leave it configurable.

Additionally:
 - shrink the docker images by leaving out some additional directories.
 - no longer force docker run as root in aws explicitly, but use the 'default'.
