### PR TITLE
Start adding static type checking

### DIFF
--- a/amlb/utils/config.py
+++ b/amlb/utils/config.py
@@ -1,4 +1,4 @@
-from collections import namedtuple
+from __future__ import annotations
 from copy import deepcopy
 from dataclasses import dataclass
 from importlib.util import find_spec
@@ -62,12 +62,12 @@ def config_load(path, verbose=False):
 @dataclass
 class TransformRule:
     from_key: Union[str, List[str]]
-    to_key: str = None
+    to_key: str | None = None  # if not provided, used for transformations on same key
     fn: Callable = identity
     keep_from: bool = False
 
 
-def transform_config(config: Namespace, transform_rules: [TransformRule], inplace=True) -> Namespace:
+def transform_config(config: Namespace, transform_rules: list[TransformRule], inplace=True) -> Namespace:
     """
     Allows to modify a configuration namespace (for example if the configuration format is modified)
     by applying a list of transformation rules.

--- a/amlb/utils/config.py
+++ b/amlb/utils/config.py
@@ -59,10 +59,6 @@ def config_load(path, verbose=False):
         return loader(file, as_namespace=True)
 
 
-# TransformRule = namedtuple('TransformRule',
-#                            ['from_key', 'to_key', 'fn', 'keep_from'],
-#                            defaults=[None, identity, False],
-#                            module=__name__)
 @dataclass
 class TransformRule:
     from_key: Union[str, List[str]]

--- a/amlb/utils/serialization.py
+++ b/amlb/utils/serialization.py
@@ -23,7 +23,7 @@ def _import_data_libraries():
     except ImportError:
         pd = None
     try:
-        import scipy.sparse as sp
+        import scipy.sparse as sp  # type: ignore # https://github.com/scipy/scipy/issues/17158
     except ImportError:
         sp = None
     return np, pd, sp

--- a/amlb/utils/time.py
+++ b/amlb/utils/time.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime as dt
 import logging
 import math
@@ -41,8 +43,8 @@ def datetime_iso(datetime=None, date=True, time=True, micros=False, date_sep='-'
     return datetime.strftime(strf)
 
 
-def countdown(timeout_secs, on_timeout: Callable = None, message: str = None, interval=1, log_level=logging.INFO,
-              interrupt_event: threading.Event = None, interrupt_cond: Callable = None):
+def countdown(timeout_secs, on_timeout: Callable | None = None, message: str = "", interval=1, log_level=logging.INFO,
+              interrupt_event: threading.Event | None = None, interrupt_cond: Callable | None = None):
     timeout_epoch = time.time() + timeout_secs
     remaining = timeout_secs
     interrupt = interrupt_event or threading.Event()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,9 @@ files=[
     "amlb/**/*.py"
 ]
 python_version = "3.9"
+# Required because the normal usage pattern of namespaces raises [attr-defined] errors.
+# I can't a way to disable [attr-defined] errors for `Namespace` only.
+disable_error_code = "attr-defined"
 
 [[tool.mypy.overrides]]
 ignore_errors = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[tool.mypy]
+files=[
+    "amlb/**/*.py"
+]
+
+[[tool.mypy.overrides]]
+ignore_errors = false
+module = "amlb.utils.*"
+
+
+[[tool.mypy.overrides]]
+ignore_errors = true
+module = "amlb.benchmarks.*"
+
+
+[[tool.mypy.overrides]]
+ignore_errors = true
+module = "amlb.datasets.*"
+
+
+[[tool.mypy.overrides]]
+ignore_errors = true
+module = "amlb.frameworks.*"
+
+
+[[tool.mypy.overrides]]
+ignore_errors = true
+module = "amlb.runners.*"
+
+
+[[tool.mypy.overrides]]
+ignore_errors = true
+module = "amlb.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 files=[
     "amlb/**/*.py"
 ]
+python_version = "3.9"
 
 [[tool.mypy.overrides]]
 ignore_errors = false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,7 @@
 pytest
 pytest-mock
 pip-tools
+
+types-psutil
+pandas-stubs
+mypy


### PR DESCRIPTION
As part of a larger effort to improve developer experience (#566), I started adding `mypy` to the dev tool chain.
This PR adds a minimal configuration that checks as I am following the [using mypy with an existing codebase](https://mypy.readthedocs.io/en/stable/existing_code.html) recommendations. 
This PR adds mypy only for `amlb.utils`.

The `mypy` configuration globally ignores the "attr-defined" error, because of the `amlb.utils.core.Namespace` class which uses dynamically created attributes (technically not even that, but it is mimicked with `__getattr__`). I tried to narrow down the filtering of this error by just the `Namespace` class (either through configuration, or by redefining `Namespace` as `Any` for type checking purposes), but unfortunately I could not get that to work - so a global ignore it is. Reducing (or removing) the use of `Namespace` is something I'd like to refactor anyway, hopefully it will be enough so that we can remove the global ignore (possibly by adding specific line-level ignores if need be).