### PR TITLE
Add redirect pages to easier redirect traffic after publication

### DIFF
--- a/docs/website/data.html
+++ b/docs/website/data.html
@@ -1,0 +1,15 @@
+<html>
+  <head>
+    <title>AMLB</title>
+    <meta charset="UTF-8" />
+    <meta http-equiv="refresh" content="0; URL=https://test.openml.org/amlb/"/>
+  </head>
+  <body>
+    <p>
+      This is a redirect page to make sure we can always redirect you to our data,
+      even if we move it after publication! You should be taken to
+      <a href="https://test.openml.org/amlb/">https://test.openml.org/amlb/</a>
+      automatically.
+    </p>
+  </body>
+</html>

--- a/docs/website/visualization.html
+++ b/docs/website/visualization.html
@@ -1,0 +1,19 @@
+<html>
+  <head>
+    <title>AMLB</title>
+    <meta charset="UTF-8" />
+    <meta http-equiv="refresh" content="0; URL=https://compstat-lmu.shinyapps.io/AutoML-Benchmark-Analysis/"/>
+  </head>
+  <body>
+    <p>
+      This is a redirect page to make sure we can always redirect you to our best
+      source for visualizing results from the AutoML benchmark, even if we change
+      where that is after publication!
+      This page will take you to
+      <a href="https://compstat-lmu.shinyapps.io/AutoML-Benchmark-Analysis/">
+        https://compstat-lmu.shinyapps.io/AutoML-Benchmark-Analysis/
+      </a>
+      .
+    </p>
+  </body>
+</html>

--- a/docs/website/welcome.html
+++ b/docs/website/welcome.html
@@ -1,0 +1,21 @@
+<html>
+  <head>
+    <title>AMLB</title>
+    <meta charset="UTF-8" />
+    <!--meta http-equiv="refresh" content="0; URL=https://test.openml.org/amlb/"/-->
+  </head>
+  <body>
+    <p>
+      This is will be a redirect page to make sure we can always redirect you to
+      the best place to get started with contributions to the AutoML benchmark,
+      even if we change its location after publication!
+      For now, if you have questions you can visit our
+      <a href="https://github.com/openml/automlbenchmark/discussions/">
+        Github discussions
+      </a>. If you want to learn more about how to use the software,
+      please visit our <a href="https://openml.github.io/automlbenchmark/">
+      documentation
+      </a>.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
We want to make it easier to redirect traffic coming from our published papers in the future. For example, we might move the visualization tool, or present new results. In those cases, we want readers of the paper to still find the newest (working) data/visualization/documentation.