### PR TITLE
Update Stacking example to work out of the box on Python 3.9

### DIFF
--- a/examples/custom/extensions/Stacking/requirements.txt
+++ b/examples/custom/extensions/Stacking/requirements.txt
@@ -1,1 +1,1 @@
-scikit-learn==0.22.1
+scikit-learn==1.3.1

--- a/examples/custom/extensions/Stacking/setup.sh
+++ b/examples/custom/extensions/Stacking/setup.sh
@@ -2,7 +2,7 @@
 shopt -s expand_aliases
 HERE=$(dirname "$0")
 
-. "$HERE/.setup_env"
+. "$HERE/.setup/setup_env"
 . "$AMLB_ROOT/frameworks/shared/setup.sh" "$HERE" true
 PIP install -r "$HERE/requirements.txt"
 

--- a/examples/custom/frameworks.yaml
+++ b/examples/custom/frameworks.yaml
@@ -9,15 +9,15 @@ GradientBoosting:
 
 Stacking:
   module: extensions.Stacking
-  version: '0.22.1'
+  version: '1.3.1'
   project: https://scikit-learn.org/stable/modules/ensemble.html#stacking
   params:
     _rf_params: {n_estimators: 200}
     _gbm_params: {n_estimators: 200}
-    _linear_params: {penalty: elasticnet, loss: log}
+    _sgdclassifier_params: {penalty: elasticnet, loss: log_loss}
+    _sgdregressor_params: {penalty: elasticnet}
 #    _svc_params: {tol: 1e-3, max_iter: 1e5}
 #    _final_params: {penalty: elasticnet, loss: log} # sgd linear
-    _final_params: {max_iter: 1000}  # logistic/linear
 
 H2OAutoML_nightly:
   module: frameworks.H2OAutoML


### PR DESCRIPTION
Fixes #593.

* Update to match changes of new .setup/setup_env layout
* Update dependency to scikit-learn 1.3, which has a full stack of supported dependencies for Py 3.9