### PR TITLE
Fix minor bugs in time series forecasting

### DIFF
--- a/amlb/datasets/file.py
+++ b/amlb/datasets/file.py
@@ -343,6 +343,8 @@ class TimeSeriesDataset(FileDataset):
         self.id_column = config['id_column']
         self.timestamp_column = config['timestamp_column']
 
+        # Ensure that id_column is parsed as string to avoid incorrect sorting
+        full_data[self.id_column] = full_data[self.id_column].astype(str)
         full_data[self.timestamp_column] = pd.to_datetime(full_data[self.timestamp_column])
         if config['name'] is not None:
             file_name = config['name']
@@ -353,7 +355,7 @@ class TimeSeriesDataset(FileDataset):
 
         self._train = CsvDatasplit(self, train_path, timestamp_column=self.timestamp_column)
         self._test = CsvDatasplit(self, test_path, timestamp_column=self.timestamp_column)
-        self._dtypes = None
+        self._dtypes = full_data.dtypes
 
         # Store repeated item_id & in-sample seasonal error for each time step in the forecast horizon - needed later for metrics like MASE.
         # We need to store this information here because Result object has no access to past time series values.

--- a/frameworks/shared/utils.py
+++ b/frameworks/shared/utils.py
@@ -2,6 +2,7 @@ from importlib import import_module
 import importlib.util
 import logging
 import os
+import pandas as pd
 import sys
 
 
@@ -40,6 +41,13 @@ def load_amlb_module(mod, amlb_path=None):
             mod_path = os.path.join(amlb_path, *tokens)
         return load_module(mod, mod_path)
     return import_module(mod)
+
+
+def load_timeseries_dataset(dataset):
+    # Ensure that id_column is loaded as string to avoid incorrect sorting
+    train_data = pd.read_csv(dataset.train_path, dtype={dataset.id_column: str}, parse_dates=[dataset.timestamp_column])
+    test_data = pd.read_csv(dataset.test_path, dtype={dataset.id_column: str}, parse_dates=[dataset.timestamp_column])
+    return train_data, test_data
 
 
 utils = load_amlb_module("amlb.utils")

--- a/requirements.in
+++ b/requirements.in
@@ -11,3 +11,7 @@ scikit-learn>=1.0,<2.0
 
 pyarrow>=11.0
 # tables>=3.6
+
+# Allow loading datasets from S3
+fsspec
+s3fs

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ boto3==1.26.98
 botocore==1.29.98
     # via
     #   boto3
+    #   s3fs
     #   s3transfer
 certifi==2022.12.7
     # via
@@ -18,6 +19,10 @@ charset-normalizer==3.1.0
     # via requests
 filelock==3.12.0
     # via -r requirements.in
+fsspec==2023.6.0
+    # via
+    #   -r requirements.in
+    #   s3fs
 idna==3.4
     # via requests
 jmespath==1.0.1
@@ -65,6 +70,8 @@ ruamel-yaml==0.17.21
     # via -r requirements.in
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
+s3fs==0.4.2
+    # via -r requirements.in
 s3transfer==0.6.0
     # via boto3
 scikit-learn==1.2.2

--- a/tests/unit/amlb/datasets/file/test_file_dataloader.py
+++ b/tests/unit/amlb/datasets/file/test_file_dataloader.py
@@ -292,7 +292,7 @@ def test_load_timeseries_task_csv(file_loader):
     assert len(ds.repeated_abs_seasonal_error) == len(ds.test.data)
     assert len(ds.repeated_item_id) == len(ds.test.data)
 
-    assert pat.is_categorical_dtype(ds._dtypes[ds.id_column])
+    assert pat.is_string_dtype(ds._dtypes[ds.id_column])
     assert pat.is_datetime64_dtype(ds._dtypes[ds.timestamp_column])
     assert pat.is_float_dtype(ds._dtypes[ds.target.name])
 


### PR DESCRIPTION
Fix several minor bugs in the time series benchmark:
- ensure that `item_id` column is parsed as a string. If the column is parsed as an integer, it may lead to a different sorting order, which in turn introduces mistakes to seasonal error calculation.
- make sure that AutoGluon respects the random seed provided in the config
- add `s3fs` & `fsspec` dependencies that are necessary to enable pandas to load datasets from S3