### PR TITLE
Add 30, 10, and 5 minute constraints

### DIFF
--- a/resources/constraints.yaml
+++ b/resources/constraints.yaml
@@ -28,6 +28,27 @@ test:
   cores: 8
   min_vol_size_mb: 131072
 
+5m8c_gp3:
+  folds: 10
+  max_runtime_seconds: 300
+  cores: 8
+  min_vol_size_mb: 100000
+  ec2_volume_type: gp3
+
+10m8c_gp3:
+  folds: 10
+  max_runtime_seconds: 600
+  cores: 8
+  min_vol_size_mb: 100000
+  ec2_volume_type: gp3
+
+30m8c_gp3:
+  folds: 10
+  max_runtime_seconds: 1800
+  cores: 8
+  min_vol_size_mb: 100000
+  ec2_volume_type: gp3
+
 1h8c_gp3:
   folds: 10
   max_runtime_seconds: 3600


### PR DESCRIPTION
This PR is a proposal to add shorter time constraint options. This is based on my own findings that AutoML systems are capable of achieving meaningful results with less than one hour of runtime on many datasets. For example, AutoGluon is able to succeed on all 104 datasets with 10 folds on `best_quality` using a 10 minute constraint, and almost all datasets with a 5 minute constraint.

These runs would be much cheaper from a compute cost standpoint and could be feasible to run on local compute without clusters in some cases. For example, 5 minute runs with 1 fold could finish 104 datasets in under 10 hours on a single machine.

Some additional ideas on how smaller time budgets could be leveraged:

- As AMLB gets more frameworks added to it, it would be good to have a filtering mechanism to only run expensive benchmarks on frameworks that are competitive. By running most frameworks with low time budget, this could hopefully be a predictive indicator of which systems would also perform well on a large time budget.
- By combining smaller time budgets with a subset of the datasets/folds, we could enable developers to test their systems on a local machine using a "mini-benchmark" for fast iteration and to avoid compute budget concerns.

![train_time_pareto_front_all](https://github.com/openml/automlbenchmark/assets/16392542/f45e0bb2-c5ff-460c-be02-07286752b8e7)
