### PR TITLE
Add overhead_time_multiplier as a configurable option

### DIFF
--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -416,8 +416,8 @@ class TaskConfig:
             inference_time_extension = 0
             if rconfig().inference_time_measurements.enabled:
                 inference_time_extension = rconfig().inference_time_measurements.additional_job_time
-            self.job_timeout_seconds = min(value * 2 + inference_time_extension,
-                                           value + rconfig().benchmarks.overhead_time_seconds + inference_time_extension)
+            overhead_time_multiplier = ns.get(rconfig(), "benchmarks.overhead_time_multiplier", 2)
+            self.job_timeout_seconds = min(value * overhead_time_multiplier, value + rconfig().benchmarks.overhead_time_seconds) + inference_time_extension
         super().__setattr__(name, value)
 
     def __json__(self):

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -47,7 +47,9 @@ benchmarks:                     # configuration namespace for the benchmarks def
                                      #   if 'fail' the benchmark will be immediately interrupted;
   os_mem_size_mb: 2048          # the default amount of memory left to the OS when task assigned memory is computed automatically.
   os_vol_size_mb: 2048          # the default amount of volume left to the OS when task volume memory is verified.
-  overhead_time_seconds: 3600   # amount of additional time allowed for the job to complete before sending an interruption signal
+  overhead_time_multiplier: 2   # multiplier to the time allowed for the job to complete before sending an interruption signal. Default is 2 if unspecified.
+  overhead_time_seconds: 3600   # amount of additional time allowed for the job to complete before sending an interruption signal.
+                                # the total allowed time is min(value * overhead_time_multiplier, value + overhead_time_seconds)
   metrics:                      # default metrics by dataset type (as listed by amlb.data.DatasetType),
                                 # only the first metric is optimized by the frameworks,
                                 # the others are computed only for information purpose.


### PR DESCRIPTION
Added overhead_time_multiplier to configuration options, previously hardcoded to 2.
This will avoid situations where it is impossible to tell AMLB to not kill a job that is running for >2x the specified `max_runtime_seconds`.