### PR TITLE
Issue #356, Default Telemetry (Off)

### DIFF
--- a/frameworks/MLNet/exec.py
+++ b/frameworks/MLNet/exec.py
@@ -35,6 +35,10 @@ def run(dataset: Dataset, config: TaskConfig):
     train_time_in_seconds = config.max_runtime_seconds
     sub_command = config.type
 
+    # Opt-out of Telemetry via framework parameter
+    MLDOTNET_CLI_TELEMETRY_OPTOUT = config.framework_params.get('telemetry_disabled', 'False')
+    os.environ['MLDOTNET_CLI_TELEMETRY_OPTOUT'] = MLDOTNET_CLI_TELEMETRY_OPTOUT
+
     # set up MODELBUILDER_AUTOML
     MODELBUILDER_AUTOML = config.framework_params.get('automl_type', 'NNI')
     os.environ['MODELBUILDER_AUTOML'] = MODELBUILDER_AUTOML

--- a/frameworks/MLNet/exec.py
+++ b/frameworks/MLNet/exec.py
@@ -36,7 +36,7 @@ def run(dataset: Dataset, config: TaskConfig):
     sub_command = config.type
 
     # Opt-out of Telemetry via framework parameter
-    MLDOTNET_CLI_TELEMETRY_OPTOUT = config.framework_params.get('telemetry_disabled', 'False')
+    MLDOTNET_CLI_TELEMETRY_OPTOUT = config.framework_params.get('_telemetry_disabled', 'False')
     os.environ['MLDOTNET_CLI_TELEMETRY_OPTOUT'] = MLDOTNET_CLI_TELEMETRY_OPTOUT
 
     # set up MODELBUILDER_AUTOML

--- a/resources/frameworks.yaml
+++ b/resources/frameworks.yaml
@@ -145,6 +145,8 @@ MLNet:
   version: 'latest'
   description: |
     MLNET.CLI is a automated machine learning tool implemented by ml.net.
+  params:
+    telemetry_disabled: ‘True'
 
 MLPlan:
   version: 'stable'

--- a/resources/frameworks.yaml
+++ b/resources/frameworks.yaml
@@ -146,7 +146,7 @@ MLNet:
   description: |
     MLNET.CLI is a automated machine learning tool implemented by ml.net.
   params:
-    telemetry_disabled: ‘True'
+    _telemetry_disabled: ‘True'
 
 MLPlan:
   version: 'stable'


### PR DESCRIPTION
Added the required framework parameter for MLNet Telemetry, and set the environment variable for MLNet in exec.py to then opt out by default. 

This is the [original issue.](https://github.com/openml/automlbenchmark/issues/356#issue-950480518)

Cheers,
-Noah