### PR TITLE
Update the GAMA repository location

### DIFF
--- a/frameworks/GAMA/setup.sh
+++ b/frameworks/GAMA/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 HERE=$(dirname "$0")
 VERSION=${1:-"stable"}
-REPO=${2:-"https://github.com/PGijsbers/gama"}
+REPO=${2:-"https://github.com/openml-labs/gama"}
 PKG=${3:-"gama"}
 if [[ "$VERSION" == "latest" ]]; then
     VERSION="master"

--- a/frameworks/GAMA/setup.sh
+++ b/frameworks/GAMA/setup.sh
@@ -23,4 +23,10 @@ else
     PIP install -U -e ${TARGET_DIR}
 fi
 
+if [[ "$VERSION" == "23.0.0" ]]; then
+    # We include this only because this is the fixed version for the 2023Q2 definition.
+    echo "GAMA/setup.sh: Downgrading scikit-learn to compatible version."
+    PIP install --no-cache-dir -U "scikit-learn<1.3"
+fi
+
 PY -c "from gama import __version__; print(__version__)" >> "${HERE}/.setup/installed"

--- a/resources/frameworks.yaml
+++ b/resources/frameworks.yaml
@@ -98,7 +98,7 @@ GAMA:
   description: |
     GAMA tries to find a good machine learning pipeline.
     For the machine learning pipeline GAMA considers data preprocessing steps, various machine learning algorithms, and their possible hyperparameters configurations.
-  project: https://github.com/PGijsbers/gama
+  project: https://github.com/openml-labs/gama
   refs: [https://joss.theoj.org/papers/10.21105/joss.01132]
 
 H2OAutoML:


### PR DESCRIPTION
The repository moved from my personal account to the [openml-labs](https://github.com/openml-labs) organisation a while ago. This PR reflects that, and allows for correct installation of `:latest` (as opposed to installing whatever fork I make).