### PR TITLE
Add type annotation for benchmark parser module

### DIFF
--- a/.github/workflows/run_all_frameworks.yml
+++ b/.github/workflows/run_all_frameworks.yml
@@ -86,7 +86,7 @@ jobs:
     if: needs.detect_changes.outputs.skip_baseline == 0
     strategy:
       matrix:
-        framework: [constantpredictor, randomforest]
+        framework: [constantpredictor, randomforest, autogluon]
         task: [iris, kc2, cholesterol]
       fail-fast:  false
     steps:

--- a/amlb/benchmarks/openml.py
+++ b/amlb/benchmarks/openml.py
@@ -26,8 +26,6 @@ def is_openml_benchmark(benchmark: str) -> bool:
 def load_oml_benchmark(benchmark: str) -> tuple[str, str | None, list[Namespace]]:
     """ Loads benchmark defined by openml suite or task, from openml/s/X or openml/t/Y. """
     domain, oml_type, oml_id = benchmark.split('/')
-    path = None  # benchmark file does not exist on disk
-    name = benchmark  # name is later passed as cli input again for containers, it needs to remain parsable
 
     if domain == "test.openml":
         log.debug("Setting openml server to the test server.")
@@ -62,4 +60,6 @@ def load_oml_benchmark(benchmark: str) -> tuple[str, str | None, list[Namespace]
                                    id="{}.org/t/{}".format(domain, tid)))
     else:
         raise ValueError(f"The oml_type is {oml_type} but must be 's' or 't'")
-    return name, path, tasks
+    # The first argument needs to remain parsable further in the pipeline as is
+    # The second argument is path, the benchmark does not exist on disk
+    return benchmark, None, tasks

--- a/amlb/benchmarks/parser.py
+++ b/amlb/benchmarks/parser.py
@@ -1,11 +1,21 @@
-from typing import List
+from __future__ import annotations
+
+from typing import List, Tuple
 
 from .openml import is_openml_benchmark, load_oml_benchmark
 from .file import load_file_benchmark
-from amlb.utils import str_sanitize
+from amlb.utils import str_sanitize, Namespace
 
 
-def benchmark_load(name, benchmark_definition_dirs: List[str]):
+def benchmark_load(
+        name: str,
+        benchmark_definition_dirs: List[str]
+    ) -> Tuple[
+            Namespace | None,
+            List[Namespace],
+            str | None,
+            str
+        ]:
     """ Loads the benchmark definition for the 'benchmark' cli input string.
 
     :param name: the value for 'benchmark'
@@ -17,7 +27,6 @@ def benchmark_load(name, benchmark_definition_dirs: List[str]):
     # which is why it is tried last.
     if is_openml_benchmark(name):
         benchmark_name, benchmark_path, tasks = load_oml_benchmark(name)
-    # elif is_kaggle_benchmark(name):
     else:
         benchmark_name, benchmark_path, tasks = load_file_benchmark(name, benchmark_definition_dirs)
 

--- a/amlb/datautils.py
+++ b/amlb/datautils.py
@@ -59,18 +59,18 @@ def read_csv(path, nrows=None, header=True, index=False, as_data_frame=True, dty
     return df if as_data_frame else df.values
 
 
-def write_csv(
+def write_csv(  # type: ignore[no-untyped-def]
         data: pd.DataFrame | dict | list | np.ndarray,
         path,
         header: bool = True,
         columns: Iterable[str] | None = None,
         index: bool = False,
         append: bool = False
-) -> None:  # type: ignore  # path required pandas internal types
-    if is_data_frame(data):
+) -> None:
+    if isinstance(data, pd.DataFrame):
         data_frame = data
     else:
-        data_frame = to_data_frame(data, columns=columns)
+        data_frame = to_data_frame(data, column_names=columns)
         header = header and columns is not None
     touch(path)
     data_frame.to_csv(
@@ -139,17 +139,17 @@ def is_data_frame(df: object) -> bool:
     return isinstance(df, pd.DataFrame)
 
 
-def to_data_frame(obj: object, columns: Iterable[str]| None=None):
+def to_data_frame(obj: object, column_names: Iterable[str]| None=None) -> pd.DataFrame:
     if obj is None:
         return pd.DataFrame()
-    elif isinstance(obj, dict):
+    columns = list(column_names) if column_names else None
+    if isinstance(obj, dict):
         orient = cast(Literal['columns', 'index'], 'columns' if columns is None else 'index')
         return pd.DataFrame.from_dict(obj, columns=columns, orient=orient)
-    elif isinstance(obj, (list, np.ndarray)):
+    if isinstance(obj, (list, np.ndarray)):
         return pd.DataFrame.from_records(obj, columns=columns)
-    else:
-        raise ValueError("Object should be a dictionary {col1:values, col2:values, ...} "
-                         "or an array of dictionary-like objects [{col1:val, col2:val}, {col1:val, col2:val}, ...].")
+    raise ValueError("Object should be a dictionary {col1:values, col2:values, ...} "
+                     "or an array of dictionary-like objects [{col1:val, col2:val}, {col1:val, col2:val}, ...].")
 
 
 class Encoder(TransformerMixin):

--- a/amlb/datautils.py
+++ b/amlb/datautils.py
@@ -149,7 +149,7 @@ def is_data_frame(df: object) -> bool:
 def to_data_frame(obj: object, column_names: Iterable[str]| None=None) -> pd.DataFrame:
     if obj is None:
         return pd.DataFrame()
-    columns = list(column_names) if column_names else None
+    columns = None if column_names is None else list(column_names)
     if isinstance(obj, dict):
         orient = cast(Literal['columns', 'index'], 'columns' if columns is None else 'index')
         return pd.DataFrame.from_dict(obj, columns=columns, orient=orient)  # type: ignore[arg-type]

--- a/amlb/datautils.py
+++ b/amlb/datautils.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Iterable, Type, Literal, Any, Callable, Tuple, cast, TypeAlias
+from typing import Iterable, Type, Literal, Any, Callable, Tuple, cast, Union
+from typing_extensions import TypeAlias
 
 import arff
 import numpy as np
@@ -29,7 +30,7 @@ from .utils import profile, path_from_split, repr_def, split_path, touch
 
 log = logging.getLogger(__name__)
 
-A: TypeAlias = np.ndarray | scipy.sparse.csr_matrix
+A: TypeAlias = Union[np.ndarray, scipy.sparse.csr_matrix]
 DF = pd.DataFrame
 S = pd.Series
 

--- a/amlb/datautils.py
+++ b/amlb/datautils.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Iterable, Type, Literal, Any, Callable, Self, Tuple, cast, TypeAlias
+from typing import Iterable, Type, Literal, Any, Callable, Tuple, cast, TypeAlias
 
 import arff
 import numpy as np
@@ -221,7 +221,7 @@ class Encoder(TransformerMixin):
     def _reshape(self, vec: np.ndarray) -> np.ndarray:
         return vec if self.for_target else vec.reshape(-1, 1)
 
-    def fit(self, vector: Iterable[str] | None) -> Self:
+    def fit(self, vector: Iterable[str] | None) -> 'Encoder':
         """
         :param vector: must be a line vector (array)
         :return:

--- a/amlb/datautils.py
+++ b/amlb/datautils.py
@@ -12,7 +12,10 @@ from __future__ import annotations
 import logging
 import os
 from typing import Iterable, Type, Literal, Any, Callable, Tuple, cast, Union
-from typing_extensions import TypeAlias
+try:
+    from typing_extensions import TypeAlias
+except ImportError:
+    pass  # Only available when dev dependencies are installed, only needed for type check
 
 import arff
 import numpy as np

--- a/amlb/results.py
+++ b/amlb/results.py
@@ -309,7 +309,7 @@ class TaskResult:
 
         if probabilities is not None:
             prob_cols = probabilities_labels if probabilities_labels else dataset.target.label_encoder.classes
-            df = to_data_frame(probabilities, columns=prob_cols)
+            df = to_data_frame(probabilities, column_names=prob_cols)
             if probabilities_labels is not None:
                 df = df[sort(prob_cols)]  # reorder columns alphabetically: necessary to match label encoding
                 if any(prob_cols != df.columns.values):

--- a/amlb/utils/core.py
+++ b/amlb/utils/core.py
@@ -345,7 +345,7 @@ def str_iter(col, sep=", "):
     return sep.join(map(str, col))
 
 
-def str_sanitize(s):
+def str_sanitize(s: str) ->str:
     return re.sub(r"[^\w-]", "_", s)
 
 


### PR DESCRIPTION
It's not perfect, but it's progress. There are a bunch of different functions with many code paths. Also a number of functions which rely on some pandas internals for typing. I would refactor this for clearer type hints, but I don't want to refactor without test coverage. So I'll merge this as is for now (it's a step in the right direction), and revisit.