### PR TITLE
Add generic callback configuration logic

### DIFF
--- a/frameworks/AutoGluon/README.md
+++ b/frameworks/AutoGluon/README.md
@@ -4,6 +4,17 @@ To run v0.8.2: ```python3 ../automlbenchmark/runbenchmark.py autogluon ...```
 
 To run mainline: ```python3 ../automlbenchmark/runbenchmark.py autogluon:latest ...```
 
+## Callbacks
+Callbacks from the `autogluon.core.callbacks` module can be configured from the configuration file by specifying the classname and any hyperparameters (see AutoGluonES example below).
+This configuration is case-sensitive.
+```yaml
+AutoGluonES:
+  extends: AutoGluon
+  params:
+    callbacks:
+      EarlyStoppingEnsembleCallback:
+        patience: 5
+```
 
 ## Running with Learning Curves Enabled
 
@@ -18,8 +29,9 @@ To summarize these steps:
 5. For example, if running the most basic framework listed below in the example user_dir, the command would look like: \
     `python3 runbenchmark.py AutoGluon_curves_true -u examples/custom ...`
 
+	
 ### Sample Framework Definitions
-```
+```yaml
 # simplest usage
 AutoGluon_curves_true:
   extends: AutoGluon
@@ -27,7 +39,7 @@ AutoGluon_curves_true:
     learning_curves: True
     _save_artifacts: ['learning_curves']
 ```
-```
+```yaml
 # including test data
 AutoGluon_curves_test:
   extends: AutoGluon
@@ -36,7 +48,7 @@ AutoGluon_curves_test:
     _include_test_during_fit: True
     _save_artifacts: ['learning_curves']
 ```
-```
+```yaml
 # parameterizing learning_curves dictionary
 AutoGluon_curves_parameters:
   extends: AutoGluon
@@ -50,7 +62,7 @@ AutoGluon_curves_parameters:
     _include_test_during_fit: True
     _save_artifacts: ['learning_curves']
 ```
-```
+```yaml
 # adding custom hyperparameters
 Defaults: &defaults
   NN_TORCH:

--- a/frameworks/AutoGluon/exec.py
+++ b/frameworks/AutoGluon/exec.py
@@ -176,19 +176,16 @@ def run(dataset, config):
 
 
 def initialize_callbacks(callback_settings):
-    print(callback_settings)
     callbacks = []
     try:
         import autogluon.core.callbacks
     except ImportError:
         raise ValueError("Callbacks are only available for AutoGluon>=1.1.2")
-    print(callbacks)
     for callback, hyperparameters in callback_settings.items():
         callback_cls = getattr(autogluon.core.callbacks, callback, None)
         if not callback_cls:
             raise ValueError(f"Callback {callback} is not a valid callback")
         callbacks.append(callback_cls(**hyperparameters))
-    print(callbacks)
     return callbacks
 
 


### PR DESCRIPTION
You can configure callbacks for AutoGluon through configuration, e.g.: 

```yaml
AutoGluonES:
  extends: AutoGluon
  params:
    callbacks:
      EarlyStoppingEnsembleCallback:
        patience: 5
```

Should probably also be added to the time series script (might be worth at some point trying to see what can be stored in a shared module?)?