### PR TITLE
Update AutoGluon to use uv during setup.sh

### DIFF
--- a/frameworks/AutoGluon/setup.sh
+++ b/frameworks/AutoGluon/setup.sh
@@ -3,6 +3,9 @@
 # exit when any command fails
 set -e
 
+# Uncomment for debugging installation
+# set -x
+
 HERE=$(dirname "$0")
 VERSION=${1:-"stable"}
 REPO=${2:-"https://github.com/autogluon/autogluon.git"}
@@ -14,30 +17,39 @@ fi
 # creating local venv
 . ${HERE}/../shared/setup.sh ${HERE} true
 
-# Below fixes seg fault on MacOS due to bug in libomp: https://github.com/awslabs/autogluon/issues/1442
+# aka "{xyz}/automlbenchmark/frameworks/AutoGluon/venv/bin/python"
+PY_EXEC_NO_ARGS="$(cut -d' ' -f1 <<<"$py_exec")"
+
+# Below fixes seg fault on MacOS due to bug in libomp: https://github.com/autogluon/autogluon/issues/1442
 if [[ -x "$(command -v brew)" ]]; then
     wget https://raw.githubusercontent.com/Homebrew/homebrew-core/fb8323f2b170bd4ae97e1bac9bf3e2983af3fdb0/Formula/libomp.rb -P "${HERE}/lib"
     brew install "${HERE}/lib/libomp.rb"
 fi
 
 PIP install --upgrade pip
-PIP install --upgrade setuptools wheel
+
+PIP install uv
+UV="${PY_EXEC_NO_ARGS} -m uv"
 
 if [[ "$VERSION" == "stable" ]]; then
-    PIP install --no-cache-dir -U "${PKG}"
-    PIP install --no-cache-dir -U "${PKG}.tabular[skex]"
+    $UV pip install --no-cache-dir -U "${PKG}"
+    $UV pip install --no-cache-dir -U "${PKG}.tabular[skex]"
 elif [[ "$VERSION" =~ ^[0-9] ]]; then
-    PIP install --no-cache-dir -U "${PKG}==${VERSION}"
-    PIP install --no-cache-dir -U "${PKG}.tabular[skex]==${VERSION}"
+    $UV pip install --no-cache-dir -U "${PKG}==${VERSION}"
+    $UV pip install --no-cache-dir -U "${PKG}.tabular[skex]==${VERSION}"
 else
     TARGET_DIR="${HERE}/lib/${PKG}"
     rm -Rf ${TARGET_DIR}
     git clone --depth 1 --single-branch --branch ${VERSION} --recurse-submodules ${REPO} ${TARGET_DIR}
     cd ${TARGET_DIR}
-    PY_EXEC_NO_ARGS="$(cut -d' ' -f1 <<<"$py_exec")"
     PY_EXEC_DIR=$(dirname "$PY_EXEC_NO_ARGS")
-    env PATH="$PY_EXEC_DIR:$PATH" bash -c ./full_install.sh
-    PIP install -e tabular/[skex]
+
+    # Install in non-editable mode to avoid interaction with other pre-existing AutoGluon installations
+    env PATH="$PY_EXEC_DIR:$PATH" bash -c "./full_install.sh --non-editable"
+    $UV pip install tabular/[skex]
 fi
+
+# Note: `setuptools` being present in the venv will cause torch==1.4.x to raise an exception for an unknown reason in AMLB.
+echo "Finished setup, testing autogluon install..."
 
 PY -c "from autogluon.tabular.version import __version__; print(__version__)" >> "${HERE}/.setup/installed"


### PR DESCRIPTION
- Update AutoGluon to use [uv](https://github.com/astral-sh/uv) instead of pip for installation in setup.sh This aligns with mainline AutoGluon now switching to `uv` for its install instructions.

- The switch to `uv` reduces AutoGluon installation time from ~10 minutes to ~40 seconds on EC2. This also avoids [a bug in pip where it fails to install AutoGluon](https://github.com/autogluon/autogluon/issues/4515).

- Removed setuptools and wheel installs, as they aren't needed by `uv` and there is a bug in torch 1.4.x that causes an exception if setuptools is installed at the same time.

- Will now install from source in `non-editable` mode. Previously it would install in `editable` mode, which could cause bugs if running AMLB locally alongside a pre-existing local AutoGluon install. This is now avoided by ensuring that the venv directly uses the code pulled in `setup.sh`.
