### PR TITLE
Add jobhistory argument to runbenchmark.py

### DIFF
--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -21,6 +21,8 @@ import signal
 import sys
 from typing import List, Union
 
+import pandas as pd
+
 from .job import Job, JobError, SimpleJobRunner, MultiThreadingJobRunner
 from .datasets import DataLoader, DataSourceType
 from .data import DatasetType
@@ -59,12 +61,17 @@ class Benchmark:
      - openml datasets
      - openml studies (=benchmark suites)
      - user-defined (list of) datasets
+
+     :param job_history: str or pd.DataFrame, default = None
+        If specified, jobs will be skipped if their result is present in job_history.
+        Useful to avoid duplicate work when trying to retry failed jobs.
+
     """
 
     data_loader = None
     framework_install_required = True
 
-    def __init__(self, framework_name: str, benchmark_name: str, constraint_name: str):
+    def __init__(self, framework_name: str, benchmark_name: str, constraint_name: str, job_history: str | pd.DataFrame = None):
         self.job_runner = None
 
         if rconfig().run_mode == 'script':
@@ -79,6 +86,8 @@ class Benchmark:
         self._forward_params = locals()
         if Benchmark.data_loader is None:
             Benchmark.data_loader = DataLoader(rconfig())
+
+        self._job_history = self._load_job_history(job_history=job_history)
 
         fsplits = framework_name.split(':', 1)
         framework_name = fsplits[0]
@@ -109,6 +118,20 @@ class Benchmark:
         if self.parallel_jobs > 1:
             log.warning("Parallelization is not supported in local mode: ignoring `parallel_jobs=%s` parameter.", self.parallel_jobs)
             self.parallel_jobs = 1
+
+    def _load_job_history(self, job_history: str | pd.DataFrame | None) -> pd.DataFrame:
+        """
+        If job_history is None, return None
+        If str, load result csv from str, return pandas DataFrame
+        If pandas DataFrame, return pandas DataFrame
+        """
+        if job_history is None:
+            return None
+        if isinstance(job_history, str):
+            log.info(f'Loading job history from {job_history}')
+            job_history = read_csv(job_history)
+        self._validate_job_history(job_history=job_history)
+        return job_history
 
     def setup(self, mode: SetupMode):
         """
@@ -211,6 +234,7 @@ class Benchmark:
 
             task_defs = self._get_task_defs(tasks)
             jobs = flatten([self._task_jobs(task_def, folds) for task_def in task_defs])
+            log.info(f"Running {len(jobs)} jobs")
             results = self._run_jobs(jobs)
             log.info(f"Processing results for {self.sid}")
             log.debug(results)
@@ -299,14 +323,6 @@ class Benchmark:
         """
         return BenchmarkTask(self, task_def, fold).as_job() if not self._skip_job(task_def, fold) else None
 
-    @lazy_property
-    def _job_history(self):
-        jh = rconfig().job_history
-        if jh and not os.path.exists(jh):
-            log.warning(f"Job history file {jh} does not exist, ignoring it.")
-            return None
-        return read_csv(jh) if jh else None
-
     def _in_job_history(self, task_def, fold):
         jh = self._job_history
         if jh is None:
@@ -316,13 +332,22 @@ class Benchmark:
                       & (jh.id == task_def.id)
                       & (jh.fold == fold)]) > 0
 
+    @staticmethod
+    def _validate_job_history(job_history):
+        required_columns = ['framework', 'constraint', 'id', 'fold']
+        actual_columns = list(job_history.columns)
+        for c in required_columns:
+            if c not in actual_columns:
+                raise AssertionError(f'job_history missing required column "{c}"! '
+                                     f'Columns: {actual_columns}')
+
     def _skip_job(self, task_def, fold):
         if fold < 0 or fold >= task_def.folds:
             log.warning(f"Fold value {fold} is out of range for task {task_def.name}, skipping it.")
             return True
 
         if self._in_job_history(task_def, fold):
-            log.info(f"Task {task_def.name} with fold {fold} is already present in job history {rconfig().job_history}, skipping it.")
+            log.info(f"Task {task_def.name} with fold {fold} is already present in job history, skipping it.")
             return True
 
         return False

--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -334,12 +334,11 @@ class Benchmark:
 
     @staticmethod
     def _validate_job_history(job_history):
-        required_columns = ['framework', 'constraint', 'id', 'fold']
-        actual_columns = list(job_history.columns)
-        for c in required_columns:
-            if c not in actual_columns:
-                raise AssertionError(f'job_history missing required column "{c}"! '
-                                     f'Columns: {actual_columns}')
+        required_columns = {'framework', 'constraint', 'id', 'fold'}
+        actual_columns = set(job_history.columns)
+        if missing_columns := (required_columns - actual_columns):
+            quoted_columns = ', '.join(repr(c) for c in missing_columns)
+            raise AssertionError(f'job_history missing required column(s) {quoted_columns}! ')
 
     def _skip_job(self, task_def, fold):
         if fold < 0 or fold >= task_def.folds:

--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -71,7 +71,7 @@ class Benchmark:
     data_loader = None
     framework_install_required = True
 
-    def __init__(self, framework_name: str, benchmark_name: str, constraint_name: str, job_history: str | pd.DataFrame = None):
+    def __init__(self, framework_name: str, benchmark_name: str, constraint_name: str, job_history: str | pd.DataFrame | None = None):
         self.job_runner = None
 
         if rconfig().run_mode == 'script':

--- a/amlb/runners/aws.py
+++ b/amlb/runners/aws.py
@@ -119,7 +119,7 @@ class AWSBenchmark(Benchmark):
         finally:
             bench.cleanup()
 
-    def __init__(self, framework_name, benchmark_name, constraint_name, region=None):
+    def __init__(self, framework_name, benchmark_name, constraint_name, region=None, job_history: str = None):
         """
 
         :param framework_name:
@@ -127,7 +127,7 @@ class AWSBenchmark(Benchmark):
         :param constraint_name:
         :param region:
         """
-        super().__init__(framework_name, benchmark_name, constraint_name)
+        super().__init__(framework_name, benchmark_name, constraint_name, job_history=job_history)
         self.suid = datetime_iso(micros=True, no_sep=True)  # short sid for AWS entities whose name length is limited
         self.region = (region if region
                        else rconfig().aws.region if rconfig().aws['region']
@@ -1219,12 +1219,12 @@ class AWSRemoteBenchmark(Benchmark):
     # TODO: idea is to handle results progressively on the remote side and push results as soon as they're generated
     #   this would allow to safely run multiple tasks on single AWS instance
 
-    def __init__(self, framework_name, benchmark_name, constraint_name, region=None):
+    def __init__(self, framework_name, benchmark_name, constraint_name, region=None, job_history: str = None):
         self.region = region
         self.s3 = boto3.resource('s3', region_name=self.region)
         self.bucket = self._init_bucket()
         self._download_resources()
-        super().__init__(framework_name, benchmark_name, constraint_name)
+        super().__init__(framework_name, benchmark_name, constraint_name, job_history=job_history)
 
     def run(self, save_scores=False):
         super().run(save_scores)


### PR DESCRIPTION
Add jobhistory argument to runbenchmark.py

This allows the user to specify the specific path to the prior results file when resuming a run, rather than it being tied to the expected output file path on the local machine (which isn't the case when running via AWS mode and not continuing to use the original host instance)

For example, from s3:

```
python runbenchmark.py AutoGluon:stable test test --resume --jobhistory s3://automl-benchmark-ag/aggregated/ec2/2024_10_25/results.csv
```

If the user does not specify `jobhistory`, then the logic remains identical.

I also did some minor code cleanup in `runbenchmarks.py` to reduce code dupe.