### PR TITLE
Docs/fix

### DIFF
--- a/docs/website/scripts/navigation.toml
+++ b/docs/website/scripts/navigation.toml
@@ -22,7 +22,7 @@ url = "papers.html"
 [[pages]]
 name = "user guide"
 icon = "../img/icons/book-open.svg"
-url = "user_guide.html"
+url = "docs/index.html"
 
 [[pages]]
 name = "contributing"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,5 +49,5 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg


### PR DESCRIPTION
Should restore the link to the userguide, and also update to avoid some deprecation warnings.