### PR TITLE
Add hack that allows specifying the user directory as git

### DIFF
--- a/runbenchmark.py
+++ b/runbenchmark.py
@@ -4,6 +4,7 @@ import os
 import re
 import shutil
 import sys
+from pathlib import Path
 
 # prevent asap other modules from defining the root logger using basicConfig
 import amlb.logger
@@ -11,7 +12,7 @@ import amlb.logger
 import openml
 
 import amlb
-from amlb.utils import Namespace as ns, config_load, datetime_iso, str2bool, str_sanitize, zip_path
+from amlb.utils import Namespace as ns, config_load, datetime_iso, str2bool, str_sanitize, zip_path, run_cmd
 from amlb import log, AutoMLError
 from amlb.defaults import default_dirs
 
@@ -99,6 +100,18 @@ parser.add_argument('-X', '--extra', default=[], action='append', help=argparse.
 #                     help="The region on which to run the benchmark when using AWS.")
 
 args = parser.parse_args()
+
+GIT_PATTERN = re.compile(r"https://(?:www.)?\w+.\w+/([a-zA-Z0-9_\-\.]+)/([a-zA-Z0-9_\-\.]+).git")
+if args.userdir and (match := GIT_PATTERN.match(args.userdir)):
+    user, repo = match.groups()
+    DOWNLOAD_DIRECTORY = Path(__file__).parent / "downloads"
+    download_path = DOWNLOAD_DIRECTORY / user / repo
+    if not download_path.exists():
+        download_path.mkdir(parents=True)
+        cmd = f"clone {args.userdir}"
+        run_cmd(f"git {cmd} {download_path}", _log_level_=logging.DEBUG)[0].strip()
+    args.userdir = str(download_path)
+
 script_name = os.path.splitext(os.path.basename(__file__))[0]
 extras = {t[0]: t[1] if len(t) > 1 else True for t in [x.split('=', 1) for x in args.extra]}
 


### PR DESCRIPTION
Minimal hack to easily define frameworks and configurations remotely (e.g., on a GitHub repository). 
The repository must have all the files you would expect for adding a custom framework locally, like [this one](https://github.com/pgijsbers/amlb-template). With the hack we just identify if the custom directory is a git repository, and if so clone it first, then set the local directory as the user directory.

```commandline
python runbenchmark.py ExplainableBoostingMachine -u https://github.com/pgijsbers/amlb-template.git
```

@Innixma @eddiebergman Where do you think we should go from here? I think a few things might be nice to have:

 - specifying where repositories should be cloned to through a configuration option (instead of "downloads").
 - automatically pulling the latest changes from the remote
 - allowing branches/commits to be specified
 - some metadata file to communicate compatibility with different AMLB versions (not quite necessary yet, but I hope to revise some of the requirements in the future as e.g., #642, #279, some of which _require_ changes to the setup scripts). Would be better to error out early.
 - specify multiple user directories (e.g., you might have a framework integration in one, and some definitions in another)
 - add information to the logs and results file on which framework integration was used.
 - externalize most (if not all?) frameworks from this repository (#571)
 - modifying the `frameworks.yaml` to allow us to specify integration scripts of frameworks, so that you can  `python runbenchmark.py FRAMEWORK` and it can then automatically fetch the integration for `FRAMEWORK` if it is one of the "trusted" predefined ones in the shipped `frameworks.yaml`?
 
Are there any additions or concerns that come to mind? Love to hear your thoughts.
 