### PR TITLE
Separate out framework def as dataclass

### DIFF
--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -22,6 +22,7 @@ import sys
 
 import pandas as pd
 
+from .frameworks.definitions import load_framework_definition
 from .job import Job, JobError, SimpleJobRunner, MultiThreadingJobRunner
 from .datasets import DataLoader, DataSourceType
 from .data import DatasetType
@@ -119,13 +120,8 @@ class Benchmark:
             Benchmark.data_loader = DataLoader(rconfig())
 
         self._job_history = self._load_job_history(job_history=job_history)
-
-        fsplits = framework_name.split(":", 1)
-        framework_name = fsplits[0]
-        tag = fsplits[1] if len(fsplits) > 1 else None
-        self.framework_def, self.framework_name = rget().framework_definition(
-            framework_name, tag
-        )
+        framework = load_framework_definition(framework_name, rget())
+        self.framework_def, self.framework_name = framework, framework.name
         log.debug("Using framework definition: %s.", self.framework_def)
 
         self.constraint_def, self.constraint_name = rget().constraint_definition(
@@ -658,6 +654,7 @@ class TaskConfig:
 
 
 class BenchmarkTask:
+
     def __init__(self, benchmark: Benchmark, task_def, fold):
         """
 


### PR DESCRIPTION
This PR defines a Framework dataclass in favor of using a Namespace. The main advantages are type checks, IDE support, and validation. No real functional differences.

Because namespaces were used with "attribute access" (the `.` notation), switching out a namespace for Framework instances doesn't require very invasive changes.
Unfortunately, CI is a bit broken currently (AutoGluon used to be a reliable indicator until v1.2 broke that). But the unit tests pass, Random Forest passes, and AutoGluon-cholesterol passes, so I feel fairly confident about the change.

Part of #658 on a way to a better dev experience (#566).

@mfeurer It's been a long time since you agreed to do occasional PR reviews for AMLB. I understand if things changed and you are no longer available. If so, no hard feelings - just leave a message.