### PR TITLE
Simplify and test container image names

### DIFF
--- a/amlb/runners/container.py
+++ b/amlb/runners/container.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 from abc import abstractmethod
 import logging
 import re
+from typing import cast
 
 from ..benchmark import Benchmark, SetupMode
 from ..errors import InvalidStateError
+from ..frameworks.definitions import Framework
 from ..job import Job
 from ..resources import config as rconfig, get as rget
 from ..__version__ import __version__, _dev_version as dev
@@ -29,7 +31,7 @@ class ContainerBenchmark(Benchmark):
     framework_install_required = False
 
     @classmethod
-    def image_name(cls, framework_def, label=None, **kwargs):
+    def image_name(cls, framework_def: Framework, label: str | None = None) -> str:
         """Determines the image name based on configuration data."""
         if label is None:
             label = rget().project_info.branch
@@ -62,8 +64,10 @@ class ContainerBenchmark(Benchmark):
         self.custom_commands = ""
         self.image = None
 
-    def _container_image_name(self, label=None):
-        return self.image_name(self.framework_def, label)
+    def _container_image_name(self, label: str | None = None) -> str:
+        return self.image_name(
+            cast(Framework, self.framework_def), label
+        )  # framework only None in AWSBenchmark
 
     def _validate(self):
         max_parallel_jobs = rconfig().job_scheduler.max_parallel_jobs

--- a/amlb/runners/container.py
+++ b/amlb/runners/container.py
@@ -30,6 +30,7 @@ class ContainerBenchmark(Benchmark):
 
     @classmethod
     def image_name(cls, framework_def, label=None, **kwargs):
+        """Determines the image name based on configuration data."""
         if label is None:
             label = rget().project_info.branch
 

--- a/amlb/runners/singularity.py
+++ b/amlb/runners/singularity.py
@@ -25,7 +25,7 @@ class SingularityBenchmark(ContainerBenchmark):
     """
 
     @classmethod
-    def image_name(cls, framework_def, label=None, as_docker_image=False, **kwargs):
+    def image_name(cls, framework_def, label=None, as_docker_image=False):
         """
         We prefer to pull from docker, so we have to mind the docker tag
         When downloading from Docker, the colon is changed to underscore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,37 @@
-from pathlib import Path
-from typing import Generator
+import os
 
 import pytest
-from amlb import Resources
-from amlb.utils import Namespace
+from amlb import Resources, resources
+from amlb.defaults import default_dirs
+from amlb.utils import Namespace, config_load
 
 
-@pytest.fixture(autouse=True)
-def tmp_output_directory(tmp_path: Path) -> Generator[Path, None, None]:
-    yield tmp_path
+@pytest.fixture
+def load_default_resources(tmp_path):
+    config_default = config_load(
+        os.path.join(default_dirs.root_dir, "resources", "config.yaml")
+    )
+    config_default_dirs = default_dirs
+    # allowing config override from user_dir: useful to define custom benchmarks and frameworks for example.
+    config_user = Namespace()
+    # config listing properties set by command line
+    config_args = Namespace.parse(
+        {"results.global_save": False},
+        output_dir=str(tmp_path),
+        script=os.path.basename(__file__),
+        run_mode="local",
+        parallel_jobs=1,
+        sid="pytest.session",
+        exit_on_error=True,
+        test_server=False,
+        tag=None,
+        command="pytest invocation",
+    )
+    config_args = Namespace({k: v for k, v in config_args if v is not None})
+    # merging all configuration files and saving to the global variable
+    resources.from_configs(
+        config_default, config_default_dirs, config_user, config_args
+    )
 
 
 @pytest.fixture

--- a/tests/unit/amlb/benchmarks/test_benchmark.py
+++ b/tests/unit/amlb/benchmarks/test_benchmark.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from amlb import Benchmark, SetupMode, resources, DockerBenchmark, SingularityBenchmark
@@ -78,15 +80,16 @@ def test_docker_image_name_uses_label(label, mocker, load_default_resources) -> 
 def test_singularity_image_name(
     framework_name, tag, expected, load_default_resources
 ) -> None:
-    framework_def, _ = resources.get().framework_definition(
-        framework_name,
-        tag=tag,
+    benchmark = SingularityBenchmark(
+        framework_name=f"{framework_name}:{tag}",
+        benchmark_name="test",
+        constraint_name="test",
     )
-    result = SingularityBenchmark.image_name(
-        framework_def,
+    image_path = benchmark._container_image_name(
         as_docker_image=False,
     )
-    assert result == expected
+    image_name = Path(image_path).stem
+    assert image_name == expected
 
 
 @pytest.mark.parametrize(
@@ -100,12 +103,12 @@ def test_singularity_image_name(
 def test_singularity_image_name_as_docker(
     framework_name, tag, expected, load_default_resources
 ) -> None:
-    framework_def, _ = resources.get().framework_definition(
-        framework_name,
-        tag=tag,
+    benchmark = SingularityBenchmark(
+        framework_name=f"{framework_name}:{tag}",
+        benchmark_name="test",
+        constraint_name="test",
     )
-    result = SingularityBenchmark.image_name(
-        framework_def,
+    result = benchmark._container_image_name(
         as_docker_image=True,
     )
     assert result == expected


### PR DESCRIPTION
Originally there was a lot of duplication between the general image name generation and the one that was "re-implemented" in the singularity runner. This refactoring simplifies that and re-uses the common implementation of container in the singularity class. Moreover, this simplification does away with the ugly `kwargs` that were added just to support custom implementations in the inheriting classes (as_docker was only ever used in calls to `_container_image_name` as opposed to `image_name`).