### PR TITLE
Check if stream is already closed

### DIFF
--- a/amlb/logger.py
+++ b/amlb/logger.py
@@ -103,7 +103,7 @@ def setup(
             nonlocal buffer
             buf_type = "err" if file is sys.stderr else "out"
             buf = buffer[buf_type]
-            if buf is None:
+            if buf is None or buf.closed:
                 buf = buffer[buf_type] = io.StringIO()
             line = sep.join(map(str, [*args]))
             buf.write(line)  # "end" newline always added by logger

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -22,7 +22,9 @@ seed: auto              # default global seed (used if not set in task definitio
 token_separator: '.'    # set to '_' for backwards compatibility.
                         # This separator is used to generate directory structure and files,
                         # however the '_' separator makes the parsing of those names more difficult as it's also used in framework names, task names...
-archive: ['logs']       # list of output folders that should be archived by default.
+archive: []       # list of output folders that should be archived by default.
+                  # Note that when used in a parallel setting where the same framework is invoked multiple times in
+                  # the same second, archiving directories may lead to errors due to race conditions (#672).
 
 setup:                   # configuration namespace for the framework setup phase.
   live_output: true      # set to true to stream the output of setup commands, if false they are only printed when setup is complete.


### PR DESCRIPTION
Relates to #664 

Actually - perhaps the use of `io.StringIO` is a bit overkill here? How many print statements without newline are we expecting realistically? We could also eat the overhead and use regular string concatenation (still wouldn't solve root cause).