### PR TITLE
Run CI on master

### DIFF
--- a/.github/workflows/run_all_frameworks.yml
+++ b/.github/workflows/run_all_frameworks.yml
@@ -1,6 +1,10 @@
 name: Run All Frameworks
 
-on: pull_request
+on:
+  push:
+    - branches:
+      - master
+  pull_request:
 
 
 jobs:

--- a/.github/workflows/run_pytest.yaml
+++ b/.github/workflows/run_pytest.yaml
@@ -1,6 +1,10 @@
 name: Light-weight Unit Tests
 
-on: pull_request
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 
 jobs:


### PR DESCRIPTION
Primarily to upload the CodeCov coverage to have a base reference, i.e., should close #671 