### PR TITLE
Enh/error on timeout

### DIFF
--- a/amlb/utils/process.py
+++ b/amlb/utils/process.py
@@ -50,15 +50,7 @@ def file_lock(path, timeout=-1):
 
 
 class StaleProcessError(subprocess.TimeoutExpired):
-    def __init__(self, cmd, timeout, output=None, stderr=None, setting=None):
-        super().__init__(cmd, timeout, output, stderr)
-        self.setting = setting
-
-    def __str__(self):
-        return (
-            f"Process '{self.cmd}' was aborted after producing no output for {self.timeout} seconds. "
-            f"If the process is expected to take more time, please raise the '{self.setting}' limit."
-        )
+    pass
 
 
 def run_subprocess(
@@ -119,14 +111,11 @@ def run_subprocess(
 
         retcode = process.poll()
         if retcode is None:
-            # Process still lives: communication stopped because of activity timeout
+            # Process still lives => communication stopped because of activity timeout
             process.kill()
             process.wait()
             raise StaleProcessError(
-                process.args,
-                float("nan"),
-                output=stdout,
-                stderr=stderr,
+                process.args, float("nan"), output=stdout, stderr=stderr
             )
 
         if check and retcode:

--- a/amlb/utils/process.py
+++ b/amlb/utils/process.py
@@ -109,9 +109,13 @@ def run_subprocess(
             process.kill()
             raise
 
+        # Communication is aborted if either
+        #  - the process has completed, or
+        #  - the process does not produce any output in the specified timeout
+        # `communicate` can't distinguish those cases. If the process has a
+        # return code then it stopped already, otherwise we stop it now.
         retcode = process.poll()
         if retcode is None:
-            # Process still lives => communication stopped because of activity timeout
             process.kill()
             process.wait()
             raise StaleProcessError(

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -27,6 +27,7 @@ archive: ['logs']       # list of output folders that should be archived by defa
 setup:                   # configuration namespace for the framework setup phase.
   live_output: true      # set to true to stream the output of setup commands, if false they are only printed when setup is complete.
   activity_timeout: 600  # when using live output, subprocess will be considered as hanging if nothing was printed during this activity time.
+                         # No effect is live_output is set to 'False'.
 
 frameworks:              # configuration namespace for the frameworks definitions.
   definition_file:       # list of yaml files describing the frameworks base definitions.

--- a/runbenchmark.py
+++ b/runbenchmark.py
@@ -18,6 +18,7 @@ from amlb.utils import (
     str2bool,
     str_sanitize,
     zip_path,
+    StaleProcessError,
 )
 from amlb import log, AutoMLError
 from amlb.defaults import default_dirs
@@ -358,7 +359,12 @@ try:
             args.mode,
         )
 
-    bench.setup(amlb.SetupMode[args.setup])
+    try:
+        bench.setup(amlb.SetupMode[args.setup])
+    except StaleProcessError as e:
+        e.timeout = amlb_res.config.setup.activity_timeout
+        e.setting = "setup.activity_timeout"
+        raise
     if args.setup != "only":
         res = bench.run(args.task, args.fold)
 except (ValueError, AutoMLError) as e:

--- a/tests/unit/amlb/utils/process/test_run.py
+++ b/tests/unit/amlb/utils/process/test_run.py
@@ -1,0 +1,20 @@
+import pytest
+
+from amlb.utils import StaleProcessError, run_cmd
+
+
+@pytest.mark.parametrize("mode", ["line", "block", True])
+def test_subprocess_detects_stale_process(mode):
+    one_ms = 0.001
+    with pytest.raises(StaleProcessError):
+        run_cmd(f"sleep {one_ms}", _activity_timeout_=one_ms / 2, _live_output_=mode)
+
+
+def test_subprocess_does_not_raises_if_process_exits_early():
+    run_cmd("echo hi", _activity_timeout_=1, _live_output_=True)
+
+
+@pytest.mark.xfail(reason="Detection of stale processes currently requires output")
+def test_subprocess_does_not_raises_on_silent_process():
+    one_ms = 0.001
+    run_cmd(f"sleep {one_ms}", _activity_timeout_=one_ms / 2, _live_output_=True)


### PR DESCRIPTION
Closes #681

If a process "completes" due to exceeding the activity timeout, it should raise an error, and not just continue.