### PR TITLE
Error when frameworks installation script fails

### DIFF
--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -197,7 +197,6 @@ class Benchmark:
                 self.framework_module.setup(
                     *self.framework_def.setup_args,
                     _shell_=False,  # prevents #arg from being interpreted as comment
-                    _exit_immediately_=True,
                     _live_output_=rconfig().setup.live_output,
                     _activity_timeout_=rconfig().setup.activity_timeout,
                 )

--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -193,12 +193,18 @@ class Benchmark:
         self._mark_setup_start()
 
         if hasattr(self.framework_module, "setup"):
-            self.framework_module.setup(
-                *self.framework_def.setup_args,
-                _shell_=False,  # prevents #arg from being interpreted as comment
-                _live_output_=rconfig().setup.live_output,
-                _activity_timeout_=rconfig().setup.activity_timeout,
-            )
+            try:
+                self.framework_module.setup(
+                    *self.framework_def.setup_args,
+                    _shell_=False,  # prevents #arg from being interpreted as comment
+                    _exit_immediately_=True,
+                    _live_output_=rconfig().setup.live_output,
+                    _activity_timeout_=rconfig().setup.activity_timeout,
+                )
+            except Exception as e:
+                raise JobError(
+                    f"Setup of framework {self.framework_name} failed."
+                ) from e
 
         if self.framework_def.setup_script is not None:
             run_script(

--- a/amlb/utils/process.py
+++ b/amlb/utils/process.py
@@ -245,7 +245,6 @@ def run_cmd(cmd, *args, **kwargs):
         activity_timeout=None,
         log_level=logging.INFO,
         monitor=None,
-        exit_immediately=False,
     )
     for k, v in params:
         kk = "_" + k + "_"
@@ -254,8 +253,6 @@ def run_cmd(cmd, *args, **kwargs):
             del kwargs[kk]
     cmd_args = as_cmd_args(*args, **kwargs)
     full_cmd = flatten([cmd]) + cmd_args
-    if params.exit_immediately and platform.system() != "Windows":
-        full_cmd = [os.environ["SHELL"], "-e"] + full_cmd
     str_cmd = " ".join(full_cmd)
     log.log(params.log_level, "Running cmd `%s`", str_cmd)
     log.debug("Running cmd `%s` with input: %s", str_cmd, params.input_str)

--- a/amlb/utils/process.py
+++ b/amlb/utils/process.py
@@ -245,6 +245,7 @@ def run_cmd(cmd, *args, **kwargs):
         activity_timeout=None,
         log_level=logging.INFO,
         monitor=None,
+        exit_immediately=False,
     )
     for k, v in params:
         kk = "_" + k + "_"
@@ -253,6 +254,8 @@ def run_cmd(cmd, *args, **kwargs):
             del kwargs[kk]
     cmd_args = as_cmd_args(*args, **kwargs)
     full_cmd = flatten([cmd]) + cmd_args
+    if params.exit_immediately and platform.system() != "Windows":
+        full_cmd = [os.environ["SHELL"], "-e"] + full_cmd
     str_cmd = " ".join(full_cmd)
     log.log(params.log_level, "Running cmd `%s`", str_cmd)
     log.debug("Running cmd `%s` with input: %s", str_cmd, params.input_str)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,12 @@ def load_default_resources(tmp_path):
     )
     config_default_dirs = default_dirs
     config_test = Namespace(
-        frameworks=Namespace(definition_file=["{root}/tests/resources/frameworks.yaml"])
+        frameworks=Namespace(
+            definition_file=[
+                "{root}/resources/frameworks.yaml",
+                "{root}/tests/resources/frameworks.yaml",
+            ]
+        )
     )
     # allowing config override from user_dir: useful to define custom benchmarks and frameworks for example.
     config_user = Namespace()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,9 @@ def load_default_resources(tmp_path):
         os.path.join(default_dirs.root_dir, "resources", "config.yaml")
     )
     config_default_dirs = default_dirs
+    config_test = Namespace(
+        frameworks=Namespace(definition_file=["{root}/tests/resources/frameworks.yaml"])
+    )
     # allowing config override from user_dir: useful to define custom benchmarks and frameworks for example.
     config_user = Namespace()
     # config listing properties set by command line
@@ -30,7 +33,7 @@ def load_default_resources(tmp_path):
     config_args = Namespace({k: v for k, v in config_args if v is not None})
     # merging all configuration files and saving to the global variable
     resources.from_configs(
-        config_default, config_default_dirs, config_user, config_args
+        config_default, config_test, config_default_dirs, config_user, config_args
     )
 
 

--- a/tests/resources/frameworks.yaml
+++ b/tests/resources/frameworks.yaml
@@ -1,0 +1,3 @@
+setup_fail:
+  description: "used for tests"
+  module: tests.resources.frameworks.setup_fail

--- a/tests/resources/frameworks/setup_fail/__init__.py
+++ b/tests/resources/frameworks/setup_fail/__init__.py
@@ -1,0 +1,5 @@
+from amlb.utils import call_script_in_same_dir
+
+
+def setup(*args, **kwargs):
+    call_script_in_same_dir(__file__, "setup.sh", *args, **kwargs)

--- a/tests/resources/frameworks/setup_fail/setup.sh
+++ b/tests/resources/frameworks/setup_fail/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 command_that_fails
 

--- a/tests/resources/frameworks/setup_fail/setup.sh
+++ b/tests/resources/frameworks/setup_fail/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+command_that_fails
+
+echo "Command that succeeds"


### PR DESCRIPTION
If we detect an error during setup, we want to stop the benchmark process immediately, instead of continuing.
Currently, the failed process goes unnoticed and often results in unexpected errors like missing dependencies during the execution of the `exec.py` script.