### PR TITLE
Tiny bug : oml_id must be an int in load_openml_task

### DIFF
--- a/amlb/benchmarks/file.py
+++ b/amlb/benchmarks/file.py
@@ -35,4 +35,9 @@ def load_file_benchmark(
     log.info("Loading benchmark definitions from %s.", benchmark_file)
     tasks = config_load(benchmark_file)
     benchmark_name, _ = os.path.splitext(os.path.basename(benchmark_file))
+    for task in tasks:
+        if task["openml_task_id"] is not None and not isinstance(
+            task["openml_task_id"], int
+        ):
+            raise TypeError("OpenML task id for task {task.name!r} must be integer.")
     return benchmark_name, benchmark_file, tasks

--- a/amlb/benchmarks/openml.py
+++ b/amlb/benchmarks/openml.py
@@ -66,10 +66,15 @@ def load_openml_tasks_from_suite(domain: str, oml_id: str) -> list[Namespace]:
     return tasks
 
 
-def load_openml_task(domain: str, oml_id: str) -> list[Namespace]:
+def load_openml_task(domain: str, oml_id: int) -> list[Namespace]:
+    # check if oml_id is a valid integer before trying to load the task. This sometimes does not happen by default. Only get_suite supports string ids.
+    try:
+        int(oml_id)
+    except ValueError:
+        raise ValueError(f"OpenML task id must be an integer, but got {type(oml_id)}")
     log.info("Loading openml task %s.", oml_id)
     # We first have the retrieve the task because we don't know the dataset id
-    t = openml.tasks.get_task(oml_id, download_data=False, download_qualities=False)
+    t = openml.tasks.get_task(int(oml_id), download_data=False, download_qualities=False)
     data = openml.datasets.get_dataset(
         t.dataset_id, download_data=False, download_qualities=False
     )

--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -21,6 +21,7 @@ import pandas.api.types as pat
 import openml as oml
 import xmltodict
 
+from ..benchmarks.openml import load_openml_task_and_data
 from ..data import AM, DF, Dataset, DatasetType, Datasplit, Feature
 from ..datautils import impute_array
 from ..resources import config as rconfig, get as rget
@@ -71,10 +72,7 @@ class OpenmlLoader:
                         dataset_id, task_id
                     )
                 )
-            task = oml.tasks.get_task(task_id, download_qualities=False)
-            dataset = oml.datasets.get_dataset(
-                task.dataset_id, download_qualities=False
-            )
+            task, dataset = load_openml_task_and_data(task_id)
             _, nfolds, _ = task.get_split_dimensions()
             if fold >= nfolds:
                 raise ValueError(

--- a/tests/unit/amlb/benchmarks/test_openml.py
+++ b/tests/unit/amlb/benchmarks/test_openml.py
@@ -3,7 +3,7 @@ import pytest
 
 from amlb.benchmarks.openml import (
     is_openml_benchmark,
-    load_openml_task,
+    load_openml_task_as_definition,
     load_oml_benchmark,
 )
 from amlb.utils import Namespace
@@ -35,7 +35,7 @@ def test_load_openml_task(mocker, oml_task, oml_dataset):
     mocker.patch(
         "openml.datasets.get_dataset", new=mocker.Mock(return_value=oml_dataset)
     )
-    [task] = load_openml_task("openml", oml_task.id)
+    [task] = load_openml_task_as_definition("openml", oml_task.id)
     assert task.name == oml_dataset.name
     assert task.description == oml_dataset.description
     assert task.openml_task_id == oml_task.id


### PR DESCRIPTION
Check if oml_id is a valid integer before trying to load the task. This sometimes does not happen by default. (Only get_suite supports string ids.)

I am not sure if this behavior is different in the new OpenML API. 