### PR TITLE
FEDOT prediction timer

### DIFF
--- a/frameworks/FEDOT/exec.py
+++ b/frameworks/FEDOT/exec.py
@@ -40,11 +40,11 @@ def run(dataset, config):
     log.info("Predicting on the test set.")
     with Timer() as predict:
         predictions = fedot.predict(features=dataset.test.X)
-        probabilities = None
-        if is_classification:
-            probabilities = fedot.predict_proba(
-                features=dataset.test.X, probs_for_all_classes=True
-            )
+    probabilities = None
+    if is_classification:
+        probabilities = fedot.predict_proba(
+            features=dataset.test.X, probs_for_all_classes=True
+        )
 
     save_artifacts(fedot, config)
 

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -15,7 +15,7 @@ sid:        # session id: set by caller (runbenchmark.py)
 job_history:    # file containing the list of jobs already executed: set by caller (runbenchmark.py)
 
 test_mode: false        # if set to true, some additional checks are executed at runtime.
-seed: auto              # default global seed (used if not set in task definition), can be one of:
+seed: 42              # default global seed (used if not set in task definition), can be one of:
                         #  `auto`: a global seed will be generated and passed to all jobs.
                         #  `none`: no seed will be provided (seed left to framework's responsibility).
                         #   any int32 to pass a fixed seed to the jobs.

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -15,7 +15,7 @@ sid:        # session id: set by caller (runbenchmark.py)
 job_history:    # file containing the list of jobs already executed: set by caller (runbenchmark.py)
 
 test_mode: false        # if set to true, some additional checks are executed at runtime.
-seed: 42              # default global seed (used if not set in task definition), can be one of:
+seed: auto              # default global seed (used if not set in task definition), can be one of:
                         #  `auto`: a global seed will be generated and passed to all jobs.
                         #  `none`: no seed will be provided (seed left to framework's responsibility).
                         #   any int32 to pass a fixed seed to the jobs.


### PR DESCRIPTION
## Summary
Hi!

Fix for FEDOT prediction timer.

## Context

> Minor comment: You should time only one of these predict calls, not both, otherwise your predict time will be twice as long as it > should be.

  Closes #581 