### PR TITLE
Load data should download data to disk

### DIFF
--- a/amlb/benchmarks/openml.py
+++ b/amlb/benchmarks/openml.py
@@ -86,9 +86,9 @@ def load_openml_task_as_definition(domain: str, oml_id: int) -> list[Namespace]:
     ]
 
 
-def load_openml_task_and_data(task_id: int) -> tuple[OpenMLTask, OpenMLDataset]:
+def load_openml_task_and_data(task_id: int, with_data: bool = False) -> tuple[OpenMLTask, OpenMLDataset]:
     task = openml.tasks.get_task(task_id, download_data=False, download_qualities=False)
     data = openml.datasets.get_dataset(
-        task.dataset_id, download_data=False, download_qualities=False
+        task.dataset_id, download_data=with_data, download_qualities=False
     )
     return task, data

--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -72,7 +72,7 @@ class OpenmlLoader:
                         dataset_id, task_id
                     )
                 )
-            task, dataset = load_openml_task_and_data(task_id)
+            task, dataset = load_openml_task_and_data(task_id, with_data=True)
             _, nfolds, _ = task.get_split_dimensions()
             if fold >= nfolds:
                 raise ValueError(


### PR DESCRIPTION
This should fix the issue with arff files not being downloaded in time to generate data splits.