### PR TITLE
Switch to functools for caching

### DIFF
--- a/amlb/benchmark.py
+++ b/amlb/benchmark.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from copy import copy
 from enum import Enum
+from functools import cached_property
 from importlib import import_module, invalidate_caches
 import logging
 import math
@@ -37,7 +38,6 @@ from .utils import (
     file_lock,
     flatten,
     json_dump,
-    lazy_property,
     profile,
     repr_def,
     run_cmd,
@@ -503,7 +503,7 @@ class Benchmark:
         )
         return board.as_data_frame()
 
-    @lazy_property
+    @cached_property
     def output_dirs(self):
         return routput_dirs(
             rconfig().output_dir,

--- a/amlb/data.py
+++ b/amlb/data.py
@@ -127,7 +127,7 @@ class Datasplit(ABC):
         """
         pass
 
-    @property
+    @lazy_property
     @abstractmethod
     def data(self) -> DF:
         """

--- a/amlb/data.py
+++ b/amlb/data.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from enum import Enum
+from functools import cached_property
 import logging
 from typing import List, Union, Iterable
 
@@ -24,7 +25,7 @@ import scipy.sparse as sp
 from typing_extensions import TypeAlias
 
 from .datautils import Encoder
-from .utils import clear_cache, lazy_property, profile, repr_def
+from .utils import clear_cache, profile, repr_def
 
 log = logging.getLogger(__name__)
 
@@ -66,7 +67,7 @@ class Feature:
     def is_numerical(self) -> bool:
         return self.data_type in ["int", "float", "number"]
 
-    @lazy_property
+    @cached_property
     def label_encoder(self) -> Encoder:
         return Encoder(
             "label" if self.values is not None else "no-op",
@@ -77,7 +78,7 @@ class Feature:
             normalize_fn=Feature.normalize,
         ).fit(self.values)
 
-    @lazy_property
+    @cached_property
     def one_hot_encoder(self) -> Encoder:
         return Encoder(
             "one-hot" if self.values is not None else "no-op",
@@ -127,7 +128,7 @@ class Datasplit(ABC):
         """
         pass
 
-    @lazy_property
+    @cached_property
     @abstractmethod
     def data(self) -> DF:
         """
@@ -135,7 +136,7 @@ class Datasplit(ABC):
         """
         pass
 
-    @lazy_property
+    @cached_property
     @profile(logger=log)
     def X(self) -> DF:
         """
@@ -144,7 +145,7 @@ class Datasplit(ABC):
         predictors_ind = [p.index for p in self.dataset.predictors]
         return self.data.iloc[:, predictors_ind]
 
-    @lazy_property
+    @cached_property
     @profile(logger=log)
     def y(self) -> DF:
         """
@@ -152,7 +153,7 @@ class Datasplit(ABC):
         """
         return self.data.iloc[:, [self.dataset.target.index]]  # type: ignore
 
-    @lazy_property
+    @cached_property
     @profile(logger=log)
     def data_enc(self) -> AM:
         encoded_cols = [
@@ -162,15 +163,15 @@ class Datasplit(ABC):
         # optimize mem usage : frameworks use either raw data or encoded ones,
         # so we can clear the cached raw data once they've been encoded
         self.release(["data", "X", "y"])
-        return np.hstack(tuple(col.reshape(-1, 1) for col in encoded_cols))
+        return np.hstack(tuple(col.reshape(-1, 1) for col in encoded_cols))  # type: ignore[union-attr]
 
-    @lazy_property
+    @cached_property
     @profile(logger=log)
     def X_enc(self) -> AM:
         predictors_ind = [p.index for p in self.dataset.predictors]
         return self.data_enc[:, predictors_ind]
 
-    @lazy_property
+    @cached_property
     @profile(logger=log)
     def y_enc(self) -> AM:
         # return self.dataset.target.label_encoder.transform(self.y)

--- a/amlb/datasets/file.py
+++ b/amlb/datasets/file.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import tempfile
+from functools import cache, cached_property
 from typing import List
 
 import arff
@@ -18,9 +19,7 @@ from ..resources import config as rconfig
 from ..utils import (
     Namespace as ns,
     as_list,
-    lazy_property,
     list_all_files,
-    memoize,
     path_from_split,
     profile,
     repr_def,
@@ -257,7 +256,7 @@ class FileDataset(Dataset):
     def target(self) -> Feature:
         return self._get_metadata("target")
 
-    @memoize
+    @cache
     def _get_metadata(self, prop):
         meta = self._train.load_metadata()
         return meta[prop]
@@ -281,7 +280,7 @@ class FileDatasplit(Datasplit):
             )
         return self._get_data(format)
 
-    @lazy_property
+    @cached_property
     def data(self):
         # use codecs for unicode support: path = codecs.load(self._path, 'rb', 'utf-8')
         log.debug("Loading datasplit %s.", self.path)

--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -9,6 +9,7 @@ import pathlib
 from abc import abstractmethod
 import copy
 import functools
+from functools import cached_property
 import logging
 import os
 import re
@@ -27,7 +28,6 @@ from ..datautils import impute_array
 from ..resources import config as rconfig, get as rget
 from ..utils import (
     as_list,
-    lazy_property,
     path_from_split,
     profile,
     split_path,
@@ -107,7 +107,7 @@ class OpenmlDataset(Dataset):
             self._nrows = len(self._load_full_data(fmt="dataframe"))
         return self._nrows
 
-    @lazy_property
+    @cached_property
     def type(self):
         def get_type(card):
             if card > 2:
@@ -262,7 +262,7 @@ class OpenmlDataset(Dataset):
 
         return subsample_path
 
-    @lazy_property
+    @cached_property
     @profile(logger=log)
     def features(self):
         def has_missing_values(f) -> bool:
@@ -298,7 +298,7 @@ class OpenmlDataset(Dataset):
             )
         ]
 
-    @lazy_property
+    @cached_property
     def target(self):
         return next(f for f in self.features if f.is_target)
 
@@ -347,12 +347,12 @@ class OpenmlDatasplit(Datasplit):
             )
         return self._get_data(format)
 
-    @lazy_property
+    @cached_property
     @profile(logger=log)
     def data(self) -> DF:
         return self._get_data("dataframe")
 
-    @lazy_property
+    @cached_property
     @profile(logger=log)
     def data_enc(self) -> AM:
         return self._get_data("array")

--- a/amlb/resources.py
+++ b/amlb/resources.py
@@ -12,14 +12,13 @@ import os
 import random
 import re
 import sys
+from functools import cache, cached_property
 
 from amlb.benchmarks.parser import benchmark_load
 from amlb.frameworks import default_tag, load_framework_definitions
 from .frameworks.definitions import TaskConstraint
 from .utils import (
     Namespace,
-    lazy_property,
-    memoize,
     normalize_path,
     run_cmd,
     str_sanitize,
@@ -66,7 +65,7 @@ class Resources:
         sys.path.append(common_dirs["user"])
         log.debug("Extended Python sys.path to user directory: %s.", sys.path)
 
-    @lazy_property
+    @cached_property
     def project_info(self):
         split_url = self.config.project_repository.split("#", 1)
         repo = split_url[0]
@@ -74,7 +73,7 @@ class Resources:
         branch = tag or "master"
         return Namespace(repo=repo, tag=tag, branch=branch)
 
-    @lazy_property
+    @cached_property
     def git_info(self):
         def git(cmd, defval=None):
             try:
@@ -99,7 +98,7 @@ class Resources:
             repo=repo, branch=branch, commit=commit, tags=tags, status=status
         )
 
-    @lazy_property
+    @cached_property
     def app_version(self):
         v = __version__
         if v != dev:
@@ -118,7 +117,7 @@ class Resources:
         else:
             return self._seed
 
-    @lazy_property
+    @cached_property
     def _seed(self):
         if str(self.config.seed).lower() in ["none", ""]:
             return None
@@ -167,12 +166,12 @@ class Resources:
             )
         return framework, framework.name
 
-    @lazy_property
+    @cached_property
     def _frameworks(self):
         frameworks_file = self.config.frameworks.definition_file
         return load_framework_definitions(frameworks_file, self.config)
 
-    @memoize
+    @cache
     def constraint_definition(self, name: str) -> TaskConstraint:
         """
         :param name: name of the benchmark constraint definition as defined in the constraints file
@@ -187,7 +186,7 @@ class Resources:
             )
         return TaskConstraint(**Namespace.dict(constraint))
 
-    @lazy_property
+    @cached_property
     def _constraints(self):
         constraints_file = self.config.benchmarks.constraints_file
         log.info("Loading benchmark constraint definitions from %s.", constraints_file)

--- a/amlb/results.py
+++ b/amlb/results.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import collections
 import io
 import logging
+from functools import cache
+
 import math
 import os
 import re
@@ -43,11 +45,9 @@ from .resources import get as rget, config as rconfig, output_dirs
 from .utils import (
     Namespace,
     backup_file,
-    cached,
     datetime_iso,
     get_metadata,
     json_load,
-    memoize,
     profile,
     set_metadata,
 )
@@ -185,7 +185,7 @@ class Scoreboard:
             else None
         )
 
-    @cached
+    @cache
     def as_data_frame(self):
         # index = ['task', 'framework', 'fold']
         index = []
@@ -236,7 +236,7 @@ class Scoreboard:
         log.debug("Scores columns: %s.", df.columns)
         return df
 
-    @memoize
+    @cache
     def as_printable_data_frame(self, verbosity=3):
         def none_like_as_empty(val: Any) -> str:
             return (
@@ -450,7 +450,7 @@ class TaskResult:
                 ]  # reorder columns alphabetically: necessary to match label encoding
                 if any(prob_cols != df.columns.values):
                     encoding_map = {
-                        prob_cols.index(col): i
+                        prob_cols.index(col): i  # type: ignore[union-attr]
                         for i, col in enumerate(df.columns.values)
                     }
                     remap = np.vectorize(lambda v: encoding_map[v])
@@ -606,11 +606,11 @@ class TaskResult:
         )
         self._metadata = metadata
 
-    @cached
+    @cache
     def get_result(self):
         return self.load_predictions(self._predictions_file)
 
-    @cached
+    @cache
     def get_result_metadata(self):
         return self._metadata or self.load_metadata(self._metadata_file)
 

--- a/amlb/utils/cache.py
+++ b/amlb/utils/cache.py
@@ -1,6 +1,6 @@
 import logging
+import functools
 
-from .core import flatten
 
 log = logging.getLogger(__name__)
 
@@ -13,78 +13,38 @@ def _cached_property_name(fn):
     return _CACHE_PROP_PREFIX_ + (fn.__name__ if hasattr(fn, "__name__") else str(fn))
 
 
-def clear_cache(self, functions=None):
-    cached_properties = [
-        prop for prop in dir(self) if prop.startswith(_CACHE_PROP_PREFIX_)
-    ]
-    properties_to_clear = (
-        cached_properties
-        if functions is None
-        else [
-            prop
-            for prop in [_cached_property_name(fn) for fn in functions]
-            if prop in cached_properties
-        ]
-    )
-    for prop in properties_to_clear:
-        delattr(self, prop)
-    log.debug("Cleared cached properties: %s.", properties_to_clear)
-
-
-def cache(self, key, fn):
-    """
-
-    :param self: the object that will hold the cached value
-    :param key: the key/attribute for the cached value
-    :param fn: the function returning the value to be cached
-    :return: the value returned by fn on first call
-    """
-    if not hasattr(self, key):
-        value = fn(self)
-        setattr(self, key, value)
-    return getattr(self, key)
+def clear_cache(obj, functions=None):
+    attributes = {att: getattr(obj, att) for att in (functions or dir(obj.__class__))}
+    functions = {
+        name: fn for name, fn in attributes.items() if callable(getattr(obj, name))
+    }
+    properties = {
+        name: getattr(obj.__class__, name).fget
+        for name, prop in attributes.items()
+        if isinstance(getattr(obj.__class__, name), property)
+    }
+    # Note that it is not possible to evict specific entries from the lru cache,
+    # this means that the property and methods will be cleared for *all* objects
+    # obj's class. In practice, doesn't really come into play since clear_cached
+    # is only called on Dataset and Datasplit objects.
+    cleared_properties = []
+    for name, fn in (functions | properties).items():
+        if hasattr(fn, "cache_clear"):
+            fn.cache_clear()
+            cleared_properties.append(name)
+    log.debug("Cleared cached properties: %s.", cleared_properties)
 
 
 def cached(fn):
-    """
-
-    :param fn:
-    :return:
-    """
-    result = _cached_property_name(fn)
-
-    def decorator(self):
-        return cache(self, result, fn)
-
-    return decorator
+    return functools.cache(fn)
 
 
 def memoize(fn):
-    prop_name = _cached_property_name(fn)
-
-    def decorator(self, *args, **kwargs):
-        memo = cache(self, prop_name, lambda _: {})
-        key = tuple(flatten((args, kwargs), flatten_dict=True))
-        if key not in memo:
-            memo[key] = fn(self, *args, **kwargs)
-        return memo[key]
-
-    return decorator
+    return functools.cache(fn)
 
 
 def lazy_property(prop_fn):
-    """
-
-    :param prop_fn:
-    :return:
-    """
-    prop_name = _cached_property_name(prop_fn)
-
-    @property
-    def decorator(self):
-        return cache(self, prop_name, prop_fn)
-
-    return decorator
+    return property(functools.cache(prop_fn))
 
 
 __all__ = [s for s in dir() if not s.startswith("_") and s not in __no_export]

--- a/amlb/utils/cache.py
+++ b/amlb/utils/cache.py
@@ -11,15 +11,31 @@ __no_export = set(dir())  # all variables defined above this are not exported
 
 def clear_cache(obj: Any, functions: Sequence[str] | None = None) -> None:
     attributes_to_check = functions or dir(type(obj))
+    # Must be careful to check the definitions on the class, checking on the instance
+    # will trigger invocations of the cached properties through `getattr`.
     cached_properties = [
         name
         for name in attributes_to_check
         if isinstance(getattr(type(obj), name), cached_property)
     ]
-    for property_ in cached_properties:
-        delattr(obj, property_)
+    _functions = [fn for fn in attributes_to_check if callable(getattr(type(obj), fn))]
 
-    log.debug("Cleared cached properties: %s.", cached_properties)
+    cleared_properties = []
+    for property_ in cached_properties:
+        # You need to delete the attribute to evict the cache of a cached property,
+        # but you cannot check for it with hasattr as that would invoke it.
+        try:
+            delattr(obj, property_)
+            cleared_properties.append(property_)
+        except AttributeError:
+            pass
+
+    for cached_function in [getattr(obj, fn) for fn in _functions]:
+        if hasattr(cached_function, "cache_clear"):
+            cached_function.cache_clear()
+            cleared_properties.append(cached_function.__name__)
+
+    log.debug("Cleared cached properties: %s.", cleared_properties)
 
 
 def cached(fn):

--- a/amlb/utils/cache.py
+++ b/amlb/utils/cache.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import logging
-import functools
 from functools import cached_property
 from typing import Any, Sequence
 
@@ -36,18 +35,6 @@ def clear_cache(obj: Any, functions: Sequence[str] | None = None) -> None:
             cleared_properties.append(cached_function.__name__)
 
     log.debug("Cleared cached properties: %s.", cleared_properties)
-
-
-def cached(fn):
-    return functools.cache(fn)
-
-
-def memoize(fn):
-    return functools.cache(fn)
-
-
-def lazy_property(prop_fn):
-    return cached_property(functools.cache(prop_fn))
 
 
 __all__ = [s for s in dir() if not s.startswith("_") and s not in __no_export]


### PR DESCRIPTION
Switch to functools for caching to reduce the number of custom solutions (I imagine part of the reason this was custom written was the lack of `cached_property` in Py3.6). 

There is one "major" distinction. The old mechanism created a per-instance cache. This is preserves for properties through `cached_property` but is _not_ reserved for methods with `cache`. As far as I can tell, this isn't really a problem: 

 * Few methods use caching.
 * Of those that do, most are inexpensive, so if they do now incidentally do the work one extra time, it's not a big deal.
 * But most importantly, most of these are on objects, e.g. FileDataset, of which there not normally more than one instance at the same time or which are often cleared together (splits). Since the benchmark is run sequentially (in the same process, anyway), this means that it's not normally clearing cache that shouldn't be cleared due to the introduction of this difference.
 
 @shchur if you're up for it, I would appreciate a sanity check :)
