### PR TITLE
[wip] reworking serialization

### DIFF
--- a/.github/workflows/run_all_frameworks.yml
+++ b/.github/workflows/run_all_frameworks.yml
@@ -173,6 +173,9 @@ jobs:
     - name: Run ${{ matrix.framework }} on ${{ matrix.task }}
       run: |
         source venv/bin/activate
+        ls /home/runner/work/automlbenchmark/automlbenchmark/venv/bin/coverage
+        /home/runner/work/automlbenchmark/automlbenchmark/venv/bin/coverage --help
+        coverage --help
         coverage run -m runbenchmark ${{ matrix.framework }} ${{ matrix.benchmark }} test -f 0 -t ${{ matrix.task }} -e
         coverage xml
       env:

--- a/.github/workflows/run_all_frameworks.yml
+++ b/.github/workflows/run_all_frameworks.yml
@@ -174,6 +174,11 @@ jobs:
       run: |
         source venv/bin/activate
         ls /home/runner/work/automlbenchmark/automlbenchmark/venv/bin/coverage
+        python -m pip list
+        python -m pip install "coverage[toml]"
+        echo $(pwd)
+        which coverage
+        coverage --help
         /home/runner/work/automlbenchmark/automlbenchmark/venv/bin/coverage --help
         coverage --help
         coverage run -m runbenchmark ${{ matrix.framework }} ${{ matrix.benchmark }} test -f 0 -t ${{ matrix.task }} -e

--- a/.github/workflows/run_all_frameworks.yml
+++ b/.github/workflows/run_all_frameworks.yml
@@ -102,6 +102,7 @@ jobs:
       - name: Create venv
         run: python -m venv venv
       - uses: actions/cache@v3
+        if: failure()
         id: cache
         with:
           path: /home/runner/work/automlbenchmark/automlbenchmark/venv
@@ -151,6 +152,7 @@ jobs:
     - name: Create venv
       run: python -m venv venv
     - uses: actions/cache@v3
+      if: failure()
       id: cache
       with:
         path: /home/runner/work/automlbenchmark/automlbenchmark/venv
@@ -173,14 +175,6 @@ jobs:
     - name: Run ${{ matrix.framework }} on ${{ matrix.task }}
       run: |
         source venv/bin/activate
-        ls /home/runner/work/automlbenchmark/automlbenchmark/venv/bin/coverage
-        python -m pip list
-        python -m pip install "coverage[toml]"
-        echo $(pwd)
-        which coverage
-        coverage --help
-        /home/runner/work/automlbenchmark/automlbenchmark/venv/bin/coverage --help
-        coverage --help
         coverage run -m runbenchmark ${{ matrix.framework }} ${{ matrix.benchmark }} test -f 0 -t ${{ matrix.task }} -e
         coverage xml
       env:

--- a/.github/workflows/run_all_frameworks.yml
+++ b/.github/workflows/run_all_frameworks.yml
@@ -164,6 +164,12 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
         python -m pip install "coverage[toml]"
+    - name: Check Things
+      run: |
+        ls -lah venv
+        ls -lah venv/bin
+        ls -lah /home/runner/work/automlbenchmark/automlbenchmark/venv/bin
+        echo $(pwd)
     - name: Run ${{ matrix.framework }} on ${{ matrix.task }}
       run: |
         source venv/bin/activate

--- a/amlb/utils/serialization.py
+++ b/amlb/utils/serialization.py
@@ -6,6 +6,7 @@ import pickle
 import re
 from typing import Optional
 
+
 from .core import Namespace as ns, json_dump, json_load
 from .process import profile
 
@@ -34,9 +35,10 @@ ser_config = ns(
     # the serializer to use when there's no specific serializer available.
     # mainly intended to serialize simple data structures like lists.
     # allowed=['pickle', 'json']
-    fallback_serializer="json",
+    # OPTION REMOVED: Only JSON is allowed. Pickle is evil.
+    # fallback_serializer="json",
     # format used to serialize pandas dataframes/series between processes.
-    # allowed=['pickle', 'parquet', 'hdf', 'json']
+    # allowed=['parquet', 'json']
     pandas_serializer="parquet",
     # the compression format used when serializing pandas dataframes/series.
     # allowed=[None, 'infer', 'bz2', 'gzip']
@@ -182,9 +184,7 @@ def serialize_data(data, path, config: Optional[ns] = None):
             # for example, 'true' and 'false' are converted automatically to booleans, even for column names…
             data.rename(str, axis="columns", inplace=True)
         ser = config.pandas_serializer
-        if ser == "pickle":
-            data.to_pickle(path, compression=config.pandas_compression)
-        elif ser == "parquet":
+        if ser == "parquet":
             if isinstance(data, pd.Series):
                 data = pd.DataFrame({__series__: data})
             # parquet serialization doesn't support sparse dataframes
@@ -194,18 +194,15 @@ def serialize_data(data, path, config: Optional[ns] = None):
                 json_dump(dtypes, f"{path}.dtypes", style="compact")
                 data = unsparsify(data)
             data.to_parquet(path, compression=config.pandas_parquet_compression)
-        elif ser == "hdf":
-            data.to_hdf(path, os.path.basename(path), mode="w", format="table")
         elif ser == "json":
             data.to_json(path, compression=config.pandas_compression)
-    else:  # fallback serializer
-        if config.fallback_serializer == "json":
-            path = f"{root}.json"
-            json_dump(data, path, style="compact")
         else:
-            path = f"{root}.pkl"
-            with open(path, "wb") as f:
-                pickle.dump(data, f)
+            raise ValueError(
+                f"Invalid pandas serialization {ser} must be 'parquet' or 'json'"
+            )
+    else:  # fallback serializer
+        path = f"{root}.json"
+        json_dump(data, path, style="compact")
     return path
 
 

--- a/amlb/utils/serialization.py
+++ b/amlb/utils/serialization.py
@@ -1,4 +1,5 @@
 import logging
+
 import math
 import os
 import pickle
@@ -34,8 +35,6 @@ ser_config = ns(
     # mainly intended to serialize simple data structures like lists.
     # allowed=['pickle', 'json']
     fallback_serializer="json",
-    # if numpy can use pickle to serialize ndarrays,
-    numpy_allow_pickle=True,
     # format used to serialize pandas dataframes/series between processes.
     # allowed=['pickle', 'parquet', 'hdf', 'json']
     pandas_serializer="parquet",
@@ -163,8 +162,14 @@ def serialize_data(data, path, config: Optional[ns] = None):
     root, ext = os.path.splitext(path)
     np, pd, sp = _import_data_libraries()
     if np and isinstance(data, np.ndarray):
-        path = f"{root}.npy"
-        np.save(path, data, allow_pickle=config.numpy_allow_pickle)
+        if data.dtype == "object":
+            # Numpy cannot save object arrays without pickle
+            path = f"{root}.json"
+            data = data.squeeze().tolist()
+            json_dump(data, path, style="compact")
+        else:
+            path = f"{root}.npy"
+            np.save(path, data, allow_pickle=False)
     elif sp and isinstance(data, sp.spmatrix):
         # use custom extension to recognize sparsed matrices from file name.
         # .npz is automatically appended if missing, and can also potentially be used for numpy arrays.
@@ -212,7 +217,7 @@ def deserialize_data(path, config: Optional[ns] = None):
     if ext == ".npy":
         if np is None:
             raise SerializationError(f"Numpy is required to deserialize {path}.")
-        return np.load(path, allow_pickle=config.numpy_allow_pickle)
+        return np.load(path)
     elif ext == ".npz":
         _, ext2 = os.path.splitext(base)
         if ext2 == ".spy":

--- a/examples/custom/extensions/GradientBoosting/exec.py
+++ b/examples/custom/extensions/GradientBoosting/exec.py
@@ -32,7 +32,6 @@ def run(dataset: Dataset, config: TaskConfig):
 
     save_predictions(
         dataset=dataset,
-        output_file=config.output_predictions_file,
         probabilities=probabilities,
         predictions=predictions,
         truth=y_test,

--- a/examples/custom/extensions/Stacking/exec.py
+++ b/examples/custom/extensions/Stacking/exec.py
@@ -133,7 +133,6 @@ def run(dataset, config):
     probabilities = estimator.predict_proba(X_test) if is_classification else None
 
     return result(
-        output_file=config.output_predictions_file,
         predictions=predictions,
         truth=y_test,
         probabilities=probabilities,

--- a/frameworks/AutoGluon/exec.py
+++ b/frameworks/AutoGluon/exec.py
@@ -100,6 +100,7 @@ def run(dataset, config):
             eval_metric=perf_metric.name,
             path=models_dir,
             problem_type=problem_type,
+            verbosity=4,
         ).fit(train_data=train_path, time_limit=time_limit, **training_params)
 
     log.info(f"Finished fit in {training.duration}s.")

--- a/frameworks/AutoGluon/exec.py
+++ b/frameworks/AutoGluon/exec.py
@@ -183,7 +183,6 @@ def run(dataset, config):
     shutil.rmtree(predictor.path, ignore_errors=True)
 
     return result(
-        output_file=config.output_predictions_file,
         predictions=predictions,
         probabilities=probabilities,
         probabilities_labels=prob_labels,

--- a/frameworks/AutoGluon/exec_ts.py
+++ b/frameworks/AutoGluon/exec_ts.py
@@ -95,7 +95,6 @@ def run(dataset, config):
     get_reusable_executor().shutdown(wait=True)
 
     return result(
-        output_file=config.output_predictions_file,
         predictions=predictions_only,
         truth=truth_only,
         target_is_encoded=False,

--- a/frameworks/AutoGluon/setup.sh
+++ b/frameworks/AutoGluon/setup.sh
@@ -61,3 +61,18 @@ fi
 echo "Finished setup, testing autogluon install..."
 
 PY -c "from autogluon.tabular.version import __version__; print(__version__)" >> "${HERE}/.setup/installed"
+
+echo "Installing AMLB dependencies into AutoGluon venv"
+REQ_FILE="${HERE}/../shared/requirements.txt"
+
+for line in $(grep -vE '^\s*#' "$REQ_FILE" | grep -vE '^\s*$'); do
+    pkg=$(echo "$line" | sed -E 's/[=><~!].*$//')
+    # In a line like "numpy==1.12.0" then pkg=numpy and line is the whole line
+
+    if ! PY -c "import $pkg" &> /dev/null; then
+        echo "$pkg not found. Installing from requirements.txt..."
+        PIP install --no-cache-dir "$line"
+    else
+        echo "$pkg is already installed by the framework, using that instead."
+    fi
+done

--- a/frameworks/FEDOT/exec.py
+++ b/frameworks/FEDOT/exec.py
@@ -53,7 +53,6 @@ def run(dataset, config):
     save_artifacts(fedot, config)
 
     return result(
-        output_file=config.output_predictions_file,
         predictions=predictions,
         truth=dataset.test.y,
         probabilities=probabilities,

--- a/frameworks/FEDOT/exec_ts.py
+++ b/frameworks/FEDOT/exec_ts.py
@@ -104,7 +104,6 @@ def run(dataset, config):
 
     save_artifacts(fedot, config)
     return result(
-        output_file=config.output_predictions_file,
         predictions=all_series_predictions,
         truth=truth_only,
         target_is_encoded=False,

--- a/frameworks/GAMA/exec.py
+++ b/frameworks/GAMA/exec.py
@@ -123,7 +123,6 @@ def run(dataset, config):
         probabilities = gama_automl.predict_proba(X_test)
 
     return result(
-        output_file=config.output_predictions_file,
         predictions=predictions,
         probabilities=probabilities,
         truth=y_test,

--- a/frameworks/H2OAutoML/exec.py
+++ b/frameworks/H2OAutoML/exec.py
@@ -203,7 +203,6 @@ def run(dataset, config):
         save_artifacts(aml, dataset=dataset, config=config)
 
         return result(
-            output_file=config.output_predictions_file,
             predictions=preds.predictions,
             truth=preds.truth,
             probabilities=preds.probabilities,

--- a/frameworks/MLPlan/exec.py
+++ b/frameworks/MLPlan/exec.py
@@ -125,7 +125,6 @@ def run(dataset, config):
         target_encoded = False
 
     return result(
-        output_file=config.output_predictions_file,
         predictions=predictions,
         truth=truth,
         probabilities=probabilities,

--- a/frameworks/NaiveAutoML/exec.py
+++ b/frameworks/NaiveAutoML/exec.py
@@ -105,7 +105,6 @@ def run(dataset, config):
     save_artifacts(automl, config)
 
     return result(
-        output_file=config.output_predictions_file,
         predictions=predictions,
         probabilities=probabilities,
         truth=dataset.test.y,

--- a/frameworks/RandomForest/exec.py
+++ b/frameworks/RandomForest/exec.py
@@ -132,7 +132,6 @@ def run(dataset, config):
         log.info("Finished inference time measurements.")
 
     return result(
-        output_file=config.output_predictions_file,
         predictions=predictions,
         truth=y_test,
         probabilities=probabilities,

--- a/frameworks/SapientML/exec.py
+++ b/frameworks/SapientML/exec.py
@@ -79,7 +79,6 @@ def run(dataset, config):
         )
 
         return result(
-            output_file=config.output_predictions_file,
             predictions=predictions,
             truth=y_test,
             probabilities=probabilities,
@@ -88,7 +87,6 @@ def run(dataset, config):
         )
     else:
         return result(
-            output_file=config.output_predictions_file,
             predictions=predictions,
             truth=y_test,
             training_duration=training.duration,

--- a/frameworks/TPOT/exec.py
+++ b/frameworks/TPOT/exec.py
@@ -131,7 +131,6 @@ def run(dataset, config):
     save_artifacts(tpot, config)
 
     return result(
-        output_file=config.output_predictions_file,
         predictions=predictions,
         truth=y_test,
         probabilities=probabilities,

--- a/frameworks/TunedRandomForest/exec.py
+++ b/frameworks/TunedRandomForest/exec.py
@@ -286,7 +286,6 @@ def run(dataset, config):
         log.info("Finished inference time measurements.")
 
     return result(
-        output_file=config.output_predictions_file,
         predictions=predictions,
         truth=y_test,
         probabilities=probabilities,

--- a/frameworks/autosklearn/exec.py
+++ b/frameworks/autosklearn/exec.py
@@ -207,7 +207,6 @@ def run(dataset, config):
     save_artifacts(auto_sklearn, config)
 
     return result(
-        output_file=config.output_predictions_file,
         predictions=predictions,
         truth=dataset.test.y if use_pandas else dataset.test.y_enc,
         probabilities=probabilities,

--- a/frameworks/flaml/exec.py
+++ b/frameworks/flaml/exec.py
@@ -91,7 +91,6 @@ def run(dataset, config):
     log.info(f"Finished predict in {predict.duration}s.")
 
     return result(
-        output_file=config.output_predictions_file,
         probabilities=probabilities,
         predictions=predictions,
         truth=y_test,

--- a/frameworks/hyperoptsklearn/exec.py
+++ b/frameworks/hyperoptsklearn/exec.py
@@ -117,7 +117,6 @@ def run(dataset, config):
         probabilities = None
 
     return result(
-        output_file=config.output_predictions_file,
         predictions=predictions,
         truth=y_test,
         probabilities=probabilities,

--- a/frameworks/lightautoml/exec.py
+++ b/frameworks/lightautoml/exec.py
@@ -99,7 +99,6 @@ def run(dataset, config):
     save_artifacts(automl, config)
 
     return result(
-        output_file=config.output_predictions_file,
         probabilities_labels=probabilities_labels,
         probabilities=probabilities,
         predictions=predictions,

--- a/frameworks/mljarsupervised/exec.py
+++ b/frameworks/mljarsupervised/exec.py
@@ -105,7 +105,6 @@ def run(dataset, config):
         shutil.rmtree(results_path, ignore_errors=True)
 
     return result(
-        output_file=config.output_predictions_file,
         predictions=predictions,
         truth=y_test,
         probabilities=probabilities,

--- a/frameworks/oboe/exec.py
+++ b/frameworks/oboe/exec.py
@@ -123,7 +123,6 @@ def run(dataset, config):
         probabilities = None
 
     return result(
-        output_file=config.output_predictions_file,
         predictions=predictions,
         truth=y_test,
         probabilities=probabilities,

--- a/frameworks/shared/callee.py
+++ b/frameworks/shared/callee.py
@@ -107,7 +107,7 @@ def call_run(run_fn):
         json_dump(inference_measurements, inference_file, style="compact")
         res["others"]["inference_times"] = str(inference_file)
 
-    res["output_file"] = config.output_predictions_file
+    res.setdefault("output_file", config.output_predictions_file)
     json_dump(res, config.result_file, style="compact")
 
 

--- a/frameworks/shared/callee.py
+++ b/frameworks/shared/callee.py
@@ -27,7 +27,6 @@ class FrameworkError(Exception):
 
 
 def result(
-    output_file=None,
     predictions=None,
     truth=None,
     probabilities=None,
@@ -107,6 +106,8 @@ def call_run(run_fn):
         )
         json_dump(inference_measurements, inference_file, style="compact")
         res["others"]["inference_times"] = str(inference_file)
+
+    res["output_file"] = config.output_predictions_file
     json_dump(res, config.result_file, style="compact")
 
 

--- a/frameworks/shared/callee.py
+++ b/frameworks/shared/callee.py
@@ -93,6 +93,7 @@ def call_run(run_fn):
                     path = os.path.join(config.result_dir, ".".join([name, "data"]))
                     res[name] = serialize_data(arr, path, config=ser_config)
     except BaseException as e:
+        log.error("Integration script failed with uncaught exception:")
         log.exception(e)
         res = dict(error_message=str(e), models_count=0)
     finally:

--- a/frameworks/shared/setup.sh
+++ b/frameworks/shared/setup.sh
@@ -46,17 +46,3 @@ PIP() {
 
 echo "PY=$py_exec"
 echo "PIP=$pip_exec"
-
-REQ_FILE="$SHARED_DIR/requirements.txt"
-
-for line in $(grep -vE '^\s*#' "$REQ_FILE" | grep -vE '^\s*$'); do
-    pkg=$(echo "$line" | sed -E 's/[=><~!].*$//')
-    # In a line like "numpy==1.12.0" then pkg=numpy and line is the whole line
-
-    if ! PY -c "import $pkg" &> /dev/null; then
-        echo "$pkg not found. Installing from requirements.txt..."
-        PIP install --no-cache-dir "$line"
-    else
-        echo "$pkg is already installed by the framework, using that instead."
-    fi
-done

--- a/frameworks/shared/setup.sh
+++ b/frameworks/shared/setup.sh
@@ -44,13 +44,19 @@ PIP() {
   $pip_exec "$@"
 }
 
-#if [[ -x "$(command -v $PY_VENV/bin/activate)" ]]; then
-#    $PY_ROOT/activate
-#fi
-
-#echo "PY=$(command -v PY)"
-#echo "PIP=$(command -v PIP)"
 echo "PY=$py_exec"
 echo "PIP=$pip_exec"
 
-PIP install --no-cache-dir -r $SHARED_DIR/requirements.txt
+REQ_FILE="$SHARED_DIR/requirements.txt"
+
+for line in $(grep -vE '^\s*#' "$REQ_FILE" | grep -vE '^\s*$'); do
+    pkg=$(echo "$line" | sed -E 's/[=><~!].*$//')
+    # In a line like "numpy==1.12.0" then pkg=numpy and line is the whole line
+
+    if ! PY -c "import $pkg" &> /dev/null; then
+        echo "$pkg not found. Installing from requirements.txt..."
+        PIP install --no-cache-dir "$line"
+    else
+        echo "$pkg is already installed by the framework, using that instead."
+    fi
+done

--- a/tests/unit/amlb/utils/serialization/test_serializers.py
+++ b/tests/unit/amlb/utils/serialization/test_serializers.py
@@ -19,35 +19,11 @@ def test_serialize_list_json(tmpdir):
 
 
 @pytest.mark.use_disk
-def test_serialize_list_pickle(tmpdir):
-    li = [[1, 2.2, None, 3, 4.4, "foo", True], ["bar", False, 2 / 3]]
-    dest = os.path.join(tmpdir, "my_list")
-    path = serialize_data(li, dest, config=ns(fallback_serializer="pickle"))
-    assert path == f"{dest}.pkl"
-
-    reloaded = deserialize_data(path)
-    assert isinstance(reloaded, list)
-    assert li == reloaded
-
-
-@pytest.mark.use_disk
 def test_serialize_dict_json(tmpdir):
     di = dict(first=[1, 2.2, None, 3, 4.4, "foo", True], second=["bar", False, 2 / 3])
     dest = os.path.join(tmpdir, "my_dict")
     path = serialize_data(di, dest, config=ns(fallback_serializer="json"))
     assert path == f"{dest}.json"
-
-    reloaded = deserialize_data(path)
-    assert isinstance(reloaded, dict)
-    assert di == reloaded
-
-
-@pytest.mark.use_disk
-def test_serialize_dict_pickle(tmpdir):
-    di = dict(first=[1, 2.2, None, 3, 4.4, "foo", True], second=["bar", False, 2 / 3])
-    dest = os.path.join(tmpdir, "my_dict")
-    path = serialize_data(di, dest, config=ns(fallback_serializer="pickle"))
-    assert path == f"{dest}.pkl"
 
     reloaded = deserialize_data(path)
     assert isinstance(reloaded, dict)
@@ -154,83 +130,6 @@ def test_serialize_sparse_matrix_reload_as_array(tmpdir):
     )
     assert isinstance(reloaded, np.ndarray)
     assert np.array_equal(mat.toarray(), reloaded, equal_nan=True)
-
-
-@pytest.mark.use_disk
-def test_serialize_sparse_dataframe(tmpdir):
-    import pandas as pd
-
-    ser_config = ns(
-        pandas_serializer="pickle", sparse_dataframe_deserialized_format=None
-    )
-    dfs = pd.DataFrame(
-        dict(
-            first=[0, 0, 0, 3.3],
-            second=[4.4, 0, 0, 0],
-            third=[0, pd.NA, 0, 0],
-        )
-    ).astype("Sparse")
-    assert is_sparse(dfs)
-    dest = os.path.join(tmpdir, "my_sparse_df")
-    path = serialize_data(dfs, dest, config=ser_config)
-    assert path == f"{dest}.pd"
-
-    reloaded = deserialize_data(path, config=ser_config)
-    assert isinstance(reloaded, pd.DataFrame)
-    assert is_sparse(reloaded)
-    assert dfs.compare(reloaded).empty
-
-
-@pytest.mark.use_disk
-def test_serialize_pandas_dataframe_reload_as_dense(tmpdir):
-    import pandas as pd
-
-    ser_config = ns(
-        pandas_serializer="pickle", sparse_dataframe_deserialized_format="dense"
-    )
-    dfs = pd.DataFrame(
-        dict(
-            first=[0, 0, 0, 3.3],
-            second=[4.4, 0, 0, 0],
-            third=[0, pd.NA, 0, 0],
-            # fourth=[None, None, 'a', None]
-        )
-    ).astype("Sparse")
-    assert is_sparse(dfs)
-    dest = os.path.join(tmpdir, "my_sparse_df")
-    path = serialize_data(dfs, dest, config=ser_config)
-    assert path == f"{dest}.pd"
-
-    reloaded = deserialize_data(path, config=ser_config)
-    assert isinstance(reloaded, pd.DataFrame)
-    assert not is_sparse(reloaded)
-    assert dfs.compare(reloaded).empty
-
-
-@pytest.mark.use_disk
-def test_serialize_pandas_dataframe_reload_as_array(tmpdir):
-    import numpy as np
-    import pandas as pd
-
-    ser_config = ns(
-        pandas_serializer="pickle", sparse_dataframe_deserialized_format="array"
-    )
-    dfs = pd.DataFrame(
-        dict(
-            first=[0, 0, 0, 3.3],
-            second=[4.4, 0, 0, 0],
-            third=[0, pd.NA, 0, 0],
-            # fourth=[None, None, 'a', None]
-        )
-    ).astype("Sparse")
-    assert is_sparse(dfs)
-    dest = os.path.join(tmpdir, "my_sparse_df")
-    path = serialize_data(dfs, dest, config=ser_config)
-    assert path == f"{dest}.pd"
-
-    reloaded = deserialize_data(path, config=ser_config)
-    assert isinstance(reloaded, np.ndarray)
-    assert np.array_equal(dfs.to_numpy(), np.asarray(reloaded), equal_nan=True)
 
 
 @pytest.mark.use_disk


### PR DESCRIPTION
Ideal scenario there are only two formats left in the end: 
 - parquet for tabular data
 - json for everything else

but might need to support sparse data through scipy.
In any case I hope to avoid situations where pickle is used which leaks dependencies between libraries used by the benchmark software and the integration scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- The output file path is no longer passed as an argument to result functions across multiple frameworks; instead, it is conditionally included in the result data.
	- Serialization of NumPy arrays now avoids using pickle, improving security by serializing object arrays as JSON lists and restricting pandas serializers to "parquet" and "json" formats only.

- **Chores**
	- Removed the configuration option for NumPy pickle allowance, streamlining serialization settings.
	- Updated package installation script to conditionally install requirements based on import checks, reducing unnecessary installs.

- **Tests**
	- Removed multiple tests for pickle serialization and sparse DataFrame deserialization to reflect updated serialization methods.

- **CI**
	- Added diagnostic steps in the GitHub Actions workflow to verify virtual environment contents and coverage tool availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->