### PR TITLE
Make parquet the default data format (#637)

### DIFF
--- a/amlb/datasets/openml.py
+++ b/amlb/datasets/openml.py
@@ -337,7 +337,16 @@ class OpenmlDataset(Dataset):
 
 class OpenmlDatasplit(Datasplit):
     def __init__(self, dataset: OpenmlDataset):
-        super().__init__(dataset, "arff")
+        default_format = getattr(rconfig().openml, "default_data_format", "parquet")
+        if default_format not in __supported_file_formats__:
+            log.warning(
+                "Invalid default_data_format '%s', falling back to 'parquet'. "
+                "Supported formats: %s",
+                default_format,
+                __supported_file_formats__,
+            )
+            default_format = "parquet"
+        super().__init__(dataset, default_format)
         self._data: dict[str, AM | DF | str] = {}
 
     def data_path(self, format):

--- a/amlb/datautils.py
+++ b/amlb/datautils.py
@@ -162,9 +162,7 @@ def reorder_dataset(
         )
 
 
-def _reorder_columns(
-    columns: list, target_src: int, target_dest: int
-) -> list | None:
+def _reorder_columns(columns: list, target_src: int, target_dest: int) -> list | None:
     """Calculate the new column order. Returns None if no reordering needed."""
     n_cols = len(columns)
     src = n_cols + 1 + target_src if target_src < 0 else target_src

--- a/amlb/datautils.py
+++ b/amlb/datautils.py
@@ -122,13 +122,18 @@ def write_csv(  # type: ignore[no-untyped-def]
 def reorder_dataset(
     path: str, target_src: int = 0, target_dest: int = -1, save: bool = True
 ) -> str | np.ndarray:
-    """Put the `target_src`th column as the `target_dest`th column"""
+    """Put the `target_src`th column as the `target_dest`th column.
+
+    Supports multiple file formats: arff, csv, and parquet.
+    The output format matches the input format.
+    """
     if (
         target_src == target_dest and save
     ):  # no reordering needed, not data to load, returning original path
         return path
 
     p = split_path(path)
+    file_ext = p.extension.lower()
     p.basename += "_target_" + (
         "first"
         if target_dest == 0
@@ -143,29 +148,54 @@ def reorder_dataset(
             return reordered_path
         path = reordered_path
 
+    # Load data based on file format
+    if file_ext == ".arff":
+        return _reorder_arff(path, reordered_path, target_src, target_dest, save)
+    elif file_ext == ".parquet":
+        return _reorder_parquet(path, reordered_path, target_src, target_dest, save)
+    elif file_ext == ".csv":
+        return _reorder_csv(path, reordered_path, target_src, target_dest, save)
+    else:
+        raise ValueError(
+            f"Unsupported file format '{file_ext}' for reorder_dataset. "
+            "Supported formats: .arff, .parquet, .csv"
+        )
+
+
+def _reorder_columns(
+    columns: list, target_src: int, target_dest: int
+) -> list | None:
+    """Calculate the new column order. Returns None if no reordering needed."""
+    n_cols = len(columns)
+    src = n_cols + 1 + target_src if target_src < 0 else target_src
+    dest = n_cols + 1 + target_dest if target_dest < 0 else target_dest
+
+    if src == dest:
+        return None
+
+    ori = list(range(n_cols))
+    if src < dest:
+        return ori[:src] + ori[src + 1 : dest] + [src] + ori[dest:]
+    else:
+        return ori[:dest] + [src] + ori[dest:src] + ori[src + 1 :]
+
+
+def _reorder_arff(
+    path: str, reordered_path: str, target_src: int, target_dest: int, save: bool
+) -> str | np.ndarray:
+    """Reorder columns in an ARFF file."""
     with open(path) as file:
         df = arff.load(file)
 
     columns = np.asarray(df["attributes"], dtype=object)
     data = np.asarray(df["data"], dtype=object)
 
-    if (
-        target_src == target_dest or path == reordered_path
-    ):  # no reordering needed, returning loaded data
-        return data
-
-    ori = list(range(len(columns)))
-    src = len(columns) + 1 + target_src if target_src < 0 else target_src
-    dest = len(columns) + 1 + target_dest if target_dest < 0 else target_dest
-    if src < dest:
-        new = ori[:src] + ori[src + 1 : dest] + [src] + ori[dest:]
-    elif src > dest:
-        new = ori[:dest] + [src] + ori[dest:src] + ori[src + 1 :]
-    else:  # no reordering needed, returning loaded data or original path
+    new_order = _reorder_columns(list(columns), target_src, target_dest)
+    if new_order is None or path == reordered_path:
         return data if not save else path
 
-    reordered_attr = columns[new]
-    reordered_data = data[:, new]
+    reordered_attr = columns[new_order]
+    reordered_data = data[:, new_order]
 
     if not save:
         return reordered_data
@@ -180,6 +210,48 @@ def reorder_dataset(
             },
             file,
         )
+    return reordered_path
+
+
+def _reorder_parquet(
+    path: str, reordered_path: str, target_src: int, target_dest: int, save: bool
+) -> str | np.ndarray:
+    """Reorder columns in a Parquet file."""
+    df = pd.read_parquet(path)
+    columns = list(df.columns)
+
+    new_order = _reorder_columns(columns, target_src, target_dest)
+    if new_order is None or path == reordered_path:
+        return df.values if not save else path
+
+    reordered_columns = [columns[i] for i in new_order]
+    reordered_df = df[reordered_columns]
+
+    if not save:
+        return reordered_df.values
+
+    reordered_df.to_parquet(reordered_path)
+    return reordered_path
+
+
+def _reorder_csv(
+    path: str, reordered_path: str, target_src: int, target_dest: int, save: bool
+) -> str | np.ndarray:
+    """Reorder columns in a CSV file."""
+    df = pd.read_csv(path)
+    columns = list(df.columns)
+
+    new_order = _reorder_columns(columns, target_src, target_dest)
+    if new_order is None or path == reordered_path:
+        return df.values if not save else path
+
+    reordered_columns = [columns[i] for i in new_order]
+    reordered_df = df[reordered_columns]
+
+    if not save:
+        return reordered_df.values
+
+    reordered_df.to_csv(reordered_path, index=False)
     return reordered_path
 
 

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -102,6 +102,9 @@ inference_time_measurements:  # configuration namespace for performing additiona
 openml:                # configuration namespace for openML.
   apikey: c1994bdb7ecb3c6f3c8f3b35f4b47f1f
   infer_dtypes: False
+  default_data_format: parquet   # default file format for data splits: one of 'parquet', 'arff', 'csv'.
+                                 # 'parquet' is recommended for better performance and smaller file sizes.
+                                 # 'arff' is kept for backward compatibility with legacy frameworks.
 
 versions:              # configuration namespace for versions enforcement (libraries versions are usually enforced in requirements.txt for the app and for each framework).
   pip:

--- a/tests/unit/amlb/datasets/openml/test_openml_dataloader.py
+++ b/tests/unit/amlb/datasets/openml/test_openml_dataloader.py
@@ -136,10 +136,20 @@ def _assert_target(target, name, values=None):
 
 
 def _assert_data_paths(dataset, ds_id, fold):
+    # Default format is determined by config (default: parquet)
+    # The .path property returns data_path(self.format)
+    default_format = dataset.train.format
     assert dataset.train.path.endswith(
-        os.path.join("datasets", str(ds_id), f"dataset_train_{fold}.arff")
+        os.path.join("datasets", str(ds_id), f"dataset_train_{fold}.{default_format}")
     )
     assert dataset.test.path.endswith(
+        os.path.join("datasets", str(ds_id), f"dataset_test_{fold}.{default_format}")
+    )
+    # Verify all supported formats can be requested explicitly
+    assert dataset.train.data_path("arff").endswith(
+        os.path.join("datasets", str(ds_id), f"dataset_train_{fold}.arff")
+    )
+    assert dataset.test.data_path("arff").endswith(
         os.path.join("datasets", str(ds_id), f"dataset_test_{fold}.arff")
     )
     assert dataset.train.data_path("csv").endswith(


### PR DESCRIPTION
  Summary

  - Add configurable default_data_format option under openml namespace in config
  - Change default format from ARFF to Parquet for OpenML datasets
  - Extend reorder_dataset() to support parquet and csv formats

  Changes

  - resources/config.yaml: Add openml.default_data_format: parquet
  - amlb/datasets/openml.py: Read format from config with parquet fallback
  - amlb/datautils.py: Refactor to handle parquet, csv, and arff files
  - tests/: Update path assertions to use configurable format

  Backward Compatibility

  Users can restore previous behavior by setting:
  openml:
    default_data_format: arff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OpenML datasets now use a configurable default data format (Parquet by default) instead of fixed ARFF, improving performance
  * Dataset reordering functionality now supports multiple formats: ARFF, Parquet, and CSV

* **Chores**
  * Added openml.default_data_format configuration option with fallback handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->